### PR TITLE
feat(cli): implement output contract (GREEN phase)

### DIFF
--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -4,7 +4,229 @@
  * @packageDocumentation
  */
 
-import type { OutputOptions } from "./types.js";
+import type { OutputMode, OutputOptions } from "./types.js";
+
+// =============================================================================
+// Exit Code Mapping
+// =============================================================================
+
+/**
+ * Maps error categories to CLI exit codes.
+ * Based on SPEC.md error taxonomy.
+ */
+const EXIT_CODE_MAP: Record<string, number> = {
+	validation: 1,
+	not_found: 2,
+	conflict: 3,
+	permission: 4,
+	timeout: 5,
+	rate_limit: 6,
+	network: 7,
+	internal: 8,
+	auth: 9,
+	cancelled: 130,
+};
+
+/**
+ * Default exit code for unknown error categories.
+ */
+const DEFAULT_EXIT_CODE = 1;
+
+/**
+ * Writes to a stream with proper backpressure handling.
+ * Returns a promise that resolves when the write is complete.
+ */
+async function writeWithBackpressure(stream: NodeJS.WritableStream, data: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const canContinue = stream.write(data, (error) => {
+			if (error) reject(error);
+		});
+
+		if (canContinue) {
+			resolve();
+		} else {
+			// Backpressure: wait for drain before resolving
+			stream.once("drain", () => resolve());
+			stream.once("error", reject);
+		}
+	});
+}
+
+// =============================================================================
+// Internal Utilities
+// =============================================================================
+
+/**
+ * Detects output mode based on environment and options.
+ *
+ * Priority: explicit option > env var > TTY detection
+ */
+function detectMode(options?: OutputOptions): OutputMode {
+	// Explicit mode takes highest priority
+	if (options?.mode) {
+		return options.mode;
+	}
+
+	// Check environment variables (JSONL takes priority over JSON)
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
+	const envJsonl = process.env["OUTFITTER_JSONL"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
+	const envJson = process.env["OUTFITTER_JSON"];
+	if (envJsonl === "1") return "jsonl";
+	if (envJson === "1") return "json";
+	if (envJsonl === "0" || envJson === "0") return "human";
+
+	// Default: JSON for non-TTY, human for TTY
+	return process.stdout.isTTY ? "human" : "json";
+}
+
+/**
+ * Safe JSON stringify that handles circular references.
+ */
+function safeStringify(value: unknown, pretty?: boolean): string {
+	const seen = new WeakSet();
+
+	const replacer = (_key: string, val: unknown): unknown => {
+		// Handle undefined
+		if (val === undefined) {
+			return null;
+		}
+
+		// Handle circular references
+		if (typeof val === "object" && val !== null) {
+			if (seen.has(val)) {
+				return "[Circular]";
+			}
+			seen.add(val);
+		}
+
+		return val;
+	};
+
+	return JSON.stringify(value, replacer, pretty ? 2 : undefined);
+}
+
+/**
+ * Formats data for human-readable output.
+ */
+function formatHuman(data: unknown): string {
+	if (data === null || data === undefined) {
+		return "";
+	}
+
+	if (typeof data === "string") {
+		return data;
+	}
+
+	if (typeof data === "number" || typeof data === "boolean") {
+		return String(data);
+	}
+
+	if (Array.isArray(data)) {
+		return data.map((item) => formatHuman(item)).join("\n");
+	}
+
+	if (typeof data === "object") {
+		// Simple key: value formatting for objects
+		const lines: string[] = [];
+		for (const [key, value] of Object.entries(data)) {
+			lines.push(`${key}: ${formatHuman(value)}`);
+		}
+		return lines.join("\n");
+	}
+
+	return String(data);
+}
+
+/**
+ * Extracts KitError-compatible properties from an error.
+ */
+interface KitErrorLike {
+	_tag: string | undefined;
+	category: string | undefined;
+	context: Record<string, unknown> | undefined;
+}
+
+function getErrorProperties(error: Error): KitErrorLike {
+	const errorObj = error as Error & {
+		_tag?: string;
+		category?: string;
+		context?: Record<string, unknown>;
+	};
+	return {
+		_tag: errorObj._tag,
+		category: errorObj.category,
+		context: errorObj.context,
+	};
+}
+
+/**
+ * Gets the exit code for an error based on its category.
+ */
+function getExitCode(error: Error): number {
+	const { category } = getErrorProperties(error);
+
+	if (category !== undefined) {
+		const code = EXIT_CODE_MAP[category];
+		if (code !== undefined) {
+			return code;
+		}
+	}
+
+	return DEFAULT_EXIT_CODE;
+}
+
+/**
+ * Serializable error structure for JSON output.
+ */
+interface SerializedError {
+	message: string;
+	_tag?: string;
+	category?: string;
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Serializes an error to JSON format.
+ */
+function serializeErrorToJson(error: Error): string {
+	const { _tag, category, context } = getErrorProperties(error);
+
+	const result: SerializedError = {
+		message: error.message,
+	};
+
+	if (_tag !== undefined) {
+		result._tag = _tag;
+	}
+
+	if (category !== undefined) {
+		result.category = category;
+	}
+
+	if (context !== undefined) {
+		result.context = context;
+	}
+
+	return JSON.stringify(result);
+}
+
+/**
+ * Formats an error for human-readable output.
+ */
+function formatErrorHuman(error: Error): string {
+	const { _tag } = getErrorProperties(error);
+
+	if (_tag) {
+		return `${_tag}: ${error.message}`;
+	}
+
+	return error.message;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
 
 /**
  * Output data to the console with automatic mode selection.
@@ -30,10 +252,50 @@ import type { OutputOptions } from "./types.js";
  *
  * // Output to stderr
  * output(errors, { stream: process.stderr });
+ *
+ * // Await for large outputs (recommended)
+ * await output(largeDataset, { mode: "jsonl" });
  * ```
  */
-export function output(_data: unknown, _options?: OutputOptions): void {
-	throw new Error("output not implemented");
+export async function output(data: unknown, options?: OutputOptions): Promise<void> {
+	const mode = detectMode(options);
+	const stream = options?.stream ?? process.stdout;
+
+	let outputText: string;
+
+	switch (mode) {
+		case "json": {
+			// Handle undefined/null explicitly
+			const jsonData = data === undefined ? null : data;
+			outputText = safeStringify(jsonData, options?.pretty);
+			break;
+		}
+
+		case "jsonl": {
+			// Arrays get one JSON object per line
+			if (Array.isArray(data)) {
+				if (data.length === 0) {
+					outputText = "";
+				} else {
+					outputText = data.map((item) => safeStringify(item)).join("\n");
+				}
+			} else {
+				// Single objects get single JSON line
+				outputText = safeStringify(data);
+			}
+			break;
+		}
+
+		default: {
+			outputText = formatHuman(data);
+			break;
+		}
+	}
+
+	// Only write if there's content (with backpressure handling)
+	if (outputText) {
+		await writeWithBackpressure(stream, `${outputText}\n`);
+	}
 }
 
 /**
@@ -56,6 +318,18 @@ export function output(_data: unknown, _options?: OutputOptions): void {
  * }
  * ```
  */
-export function exitWithError(_error: Error): never {
-	throw new Error("exitWithError not implemented");
+export function exitWithError(error: Error, options?: OutputOptions): never {
+	const exitCode = getExitCode(error);
+	const mode = detectMode(options);
+	const isJsonMode = mode === "json" || mode === "jsonl";
+
+	if (isJsonMode) {
+		// JSON mode: serialize to stderr
+		process.stderr.write(`${serializeErrorToJson(error)}\n`);
+	} else {
+		// Human mode: formatted output to stderr
+		process.stderr.write(`${formatErrorHuman(error)}\n`);
+	}
+
+	process.exit(exitCode);
 }


### PR DESCRIPTION
Implements output() and exitWithError() to pass all 38 tests:

output():
- Mode detection with priority: explicit > env var > TTY
- JSON mode with safe stringify (handles circular refs)
- JSONL mode with one object per line
- Human mode with formatted key-value output
- Configurable output stream

exitWithError():
- Exit code mapping from error categories (SPEC.md taxonomy)
- JSON serialization with _tag, category, message, context
- Human-readable format for TTY output

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>