### PR TITLE
feat(cli): implement pagination cursor persistence (GREEN phase)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,10 +21,11 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.6",
+        "@types/node": "^25.0.10",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "zod": "^4.0.0",
+        "zod": "^4.3.5",
       },
     },
   },
@@ -106,7 +107,7 @@
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
-    "@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+    "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -294,17 +295,23 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "bun-types/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.6",
+		"@types/node": "^25.0.10",
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -4,10 +4,78 @@
  * Handles cursor-based pagination state that persists per-command
  * for --next and --reset functionality.
  *
+ * XDG State Directory Pattern:
+ * Path: $XDG_STATE_HOME/{toolName}/cursors/{command}[/{context}]/cursor.json
+ *
  * @packageDocumentation
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { CursorOptions, PaginationState } from "./types.js";
+
+/**
+ * Pattern matching unsafe path components:
+ * - ".." path traversal (standalone or within path)
+ * - Absolute paths starting with /
+ * - Windows-style paths with drive letters
+ */
+const UNSAFE_PATH_PATTERN = /(?:^|[\\/])\.\.(?:[\\/]|$)|^[\\/]|^[a-zA-Z]:/;
+
+/**
+ * Validates a path component is safe to use in filesystem operations.
+ * @throws Error if path contains traversal or absolute path indicators
+ */
+function validatePathComponent(component: string, name: string): void {
+	if (UNSAFE_PATH_PATTERN.test(component)) {
+		throw new Error(`Security: path traversal detected in ${name}`);
+	}
+}
+
+/**
+ * Get the default state directory based on platform.
+ * - macOS: ~/Library/Application Support
+ * - Windows: %LOCALAPPDATA%
+ * - Linux/other: ~/.local/state
+ */
+function getDefaultStateHome(): string {
+	const home = os.homedir();
+	switch (process.platform) {
+		case "darwin":
+			return path.join(home, "Library", "Application Support");
+		case "win32":
+			// biome-ignore lint/complexity/useLiteralKeys: TypeScript noPropertyAccessFromIndexSignature requires bracket notation
+			return process.env["LOCALAPPDATA"] ?? path.join(home, "AppData", "Local");
+		default:
+			return path.join(home, ".local", "state");
+	}
+}
+
+/**
+ * Resolve the XDG state path for a cursor file.
+ *
+ * @param options - Cursor options specifying command, context, and tool name
+ * @returns Absolute path to the cursor.json file
+ * @throws Error if path components contain traversal attempts
+ */
+function getStatePath(options: CursorOptions): string {
+	// Validate all path components for security
+	validatePathComponent(options.command, "command");
+	validatePathComponent(options.toolName, "toolName");
+	if (options.context) {
+		validatePathComponent(options.context, "context");
+	}
+
+	const xdgState =
+		// biome-ignore lint/complexity/useLiteralKeys: TypeScript noPropertyAccessFromIndexSignature requires bracket notation
+		process.env["XDG_STATE_HOME"] ?? getDefaultStateHome();
+	const parts = [xdgState, options.toolName, "cursors", options.command];
+	if (options.context) {
+		parts.push(options.context);
+	}
+	return path.join(...parts, "cursor.json");
+}
 
 /**
  * Load persisted pagination state for a command.
@@ -28,8 +96,32 @@ import type { CursorOptions, PaginationState } from "./types.js";
  * }
  * ```
  */
-export function loadCursor(_options: CursorOptions): PaginationState | undefined {
-	throw new Error("loadCursor not implemented");
+export function loadCursor(options: CursorOptions): PaginationState | undefined {
+	const statePath = getStatePath(options);
+
+	if (!fs.existsSync(statePath)) {
+		return undefined;
+	}
+
+	try {
+		const content = fs.readFileSync(statePath, "utf-8");
+		const parsed = JSON.parse(content) as unknown;
+
+		// Validate required structure - cursor must be a string
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
+			typeof (parsed as Record<string, unknown>)["cursor"] !== "string"
+		) {
+			return undefined;
+		}
+
+		return parsed as PaginationState;
+	} catch {
+		// Return undefined for corrupted/invalid JSON
+		return undefined;
+	}
 }
 
 /**
@@ -53,8 +145,25 @@ export function loadCursor(_options: CursorOptions): PaginationState | undefined
  * }
  * ```
  */
-export function saveCursor(_cursor: string, _options: CursorOptions): void {
-	throw new Error("saveCursor not implemented");
+export function saveCursor(cursor: string, options: CursorOptions): void {
+	const statePath = getStatePath(options);
+	const stateDir = path.dirname(statePath);
+
+	// Create parent directories if needed
+	fs.mkdirSync(stateDir, { recursive: true });
+
+	// Build the pagination state
+	const state: PaginationState = {
+		cursor,
+		command: options.command,
+		timestamp: Date.now(),
+		hasMore: options.hasMore ?? true,
+		...(options.context && { context: options.context }),
+		...(options.total !== undefined && { total: options.total }),
+	};
+
+	// Write state to file
+	fs.writeFileSync(statePath, JSON.stringify(state), "utf-8");
 }
 
 /**
@@ -75,6 +184,14 @@ export function saveCursor(_cursor: string, _options: CursorOptions): void {
  * }
  * ```
  */
-export function clearCursor(_options: CursorOptions): void {
-	throw new Error("clearCursor not implemented");
+export function clearCursor(options: CursorOptions): void {
+	const statePath = getStatePath(options);
+
+	try {
+		if (fs.existsSync(statePath)) {
+			fs.unlinkSync(statePath);
+		}
+	} catch {
+		// Don't throw for missing files or directories
+	}
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -326,6 +326,12 @@ export interface CursorOptions {
 
 	/** Tool name for XDG path resolution */
 	readonly toolName: string;
+
+	/** Whether there are more results (defaults to true) */
+	readonly hasMore?: boolean;
+
+	/** Total count of results (if known) */
+	readonly total?: number;
 }
 
 // =============================================================================


### PR DESCRIPTION
Implements 3 pagination utility functions:
- loadCursor: loads pagination state from XDG state directory
- saveCursor: persists pagination state with automatic timestamp
- clearCursor: removes pagination state for command/context

Uses XDG Base Directory Specification for state storage.
All 134 tests passing (38 output + 74 input + 22 pagination).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>