### PR TITLE
docs(spec): add hybrid error pattern with numeric codes

### DIFF
--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -1,0 +1,3 @@
+# Keep .agents directory local - not committed to repo
+*
+!.gitignore


### PR DESCRIPTION
- Add optional code and correlationId to KitError interface
- Document ~30 curated error codes by domain
- Add recovery heuristics (isRecoverable, isRetryable, getBackoffDelay)
- Add Result utilities (unwrapOrElse, orElse, combine2/3)
- Add assertion utilities (assertDefined, assertNonEmpty, assertMatches)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>