### PR TITLE
feat(contracts): add Result utilities (unwrapOrElse, orElse, combine2/3)

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,9 @@
 // Re-export Result from better-result for convenience
 export { Result, TaggedError } from "better-result";
 
+// Result utilities (extensions to better-result)
+export { combine2, combine3, orElse, unwrapOrElse } from "./result/index.js";
+
 // Errors
 export {
 	// Types

--- a/packages/contracts/src/result/index.ts
+++ b/packages/contracts/src/result/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Result utilities
+ *
+ * Extends better-result with additional combinators.
+ *
+ * @module result
+ */
+
+export { combine2, combine3, orElse, unwrapOrElse } from "./utilities.js";

--- a/packages/contracts/src/result/utilities.test.ts
+++ b/packages/contracts/src/result/utilities.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for Result utilities
+ */
+import { describe, expect, it, vi } from "bun:test";
+import { Result } from "better-result";
+import { combine2, combine3, orElse, unwrapOrElse } from "./utilities.js";
+
+describe("unwrapOrElse", () => {
+	it("returns value on Ok", () => {
+		const result = Result.ok(42);
+		const value = unwrapOrElse(result, () => 0);
+
+		expect(value).toBe(42);
+	});
+
+	it("calls defaultFn on Err and returns computed value", () => {
+		const result = Result.err("error");
+		const defaultFn = vi.fn((error: string) => error.length);
+		const value = unwrapOrElse(result, defaultFn);
+
+		expect(value).toBe(5); // "error".length = 5
+		expect(defaultFn).toHaveBeenCalledTimes(1);
+		expect(defaultFn).toHaveBeenCalledWith("error");
+	});
+
+	it("does NOT call defaultFn on Ok (lazy evaluation)", () => {
+		const result = Result.ok(42);
+		const defaultFn = vi.fn(() => 0);
+		unwrapOrElse(result, defaultFn);
+
+		expect(defaultFn).not.toHaveBeenCalled();
+	});
+});
+
+describe("orElse", () => {
+	it("returns first Result on Ok", () => {
+		const first = Result.ok<number, string>(42);
+		const fallback = Result.ok<number, string>(0);
+		const result = orElse(first, fallback);
+
+		expect(result.isOk()).toBe(true);
+		expect(result.isOk() && result.value).toBe(42);
+	});
+
+	it("returns fallback on Err", () => {
+		const first = Result.err<number, string>("first error");
+		const fallback = Result.ok<number, string>(99);
+		const result = orElse(first, fallback);
+
+		expect(result.isOk()).toBe(true);
+		expect(result.isOk() && result.value).toBe(99);
+	});
+
+	it("returns fallback error when both are Err", () => {
+		const first = Result.err<number, string>("first error");
+		const fallback = Result.err<number, string>("fallback error");
+		const result = orElse(first, fallback);
+
+		expect(result.isErr()).toBe(true);
+		expect(result.isErr() && result.error).toBe("fallback error");
+	});
+});
+
+describe("combine2", () => {
+	it("returns tuple on both Ok", () => {
+		const r1 = Result.ok<number, string>(1);
+		const r2 = Result.ok<string, string>("hello");
+		const result = combine2(r1, r2);
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) {
+			expect(result.value).toEqual([1, "hello"]);
+		}
+	});
+
+	it("returns first error when first is Err", () => {
+		const r1 = Result.err<number, string>("first error");
+		const r2 = Result.ok<string, string>("hello");
+		const result = combine2(r1, r2);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("first error");
+		}
+	});
+
+	it("returns second error when first is Ok and second is Err", () => {
+		const r1 = Result.ok<number, string>(1);
+		const r2 = Result.err<string, string>("second error");
+		const result = combine2(r1, r2);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("second error");
+		}
+	});
+
+	it("returns first error when both are Err", () => {
+		const r1 = Result.err<number, string>("first error");
+		const r2 = Result.err<string, string>("second error");
+		const result = combine2(r1, r2);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("first error");
+		}
+	});
+});
+
+describe("combine3", () => {
+	it("returns tuple on all Ok", () => {
+		const r1 = Result.ok<number, string>(1);
+		const r2 = Result.ok<string, string>("hello");
+		const r3 = Result.ok<boolean, string>(true);
+		const result = combine3(r1, r2, r3);
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) {
+			expect(result.value).toEqual([1, "hello", true]);
+		}
+	});
+
+	it("returns first error when first is Err", () => {
+		const r1 = Result.err<number, string>("first error");
+		const r2 = Result.ok<string, string>("hello");
+		const r3 = Result.ok<boolean, string>(true);
+		const result = combine3(r1, r2, r3);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("first error");
+		}
+	});
+
+	it("returns second error when first is Ok and second is Err", () => {
+		const r1 = Result.ok<number, string>(1);
+		const r2 = Result.err<string, string>("second error");
+		const r3 = Result.ok<boolean, string>(true);
+		const result = combine3(r1, r2, r3);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("second error");
+		}
+	});
+
+	it("returns third error when first two are Ok and third is Err", () => {
+		const r1 = Result.ok<number, string>(1);
+		const r2 = Result.ok<string, string>("hello");
+		const r3 = Result.err<boolean, string>("third error");
+		const result = combine3(r1, r2, r3);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("third error");
+		}
+	});
+
+	it("returns first error when all are Err", () => {
+		const r1 = Result.err<number, string>("first error");
+		const r2 = Result.err<string, string>("second error");
+		const r3 = Result.err<string, string>("third error");
+		const result = combine3(r1, r2, r3);
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error).toBe("first error");
+		}
+	});
+});

--- a/packages/contracts/src/result/utilities.ts
+++ b/packages/contracts/src/result/utilities.ts
@@ -1,0 +1,117 @@
+/**
+ * Result utilities
+ *
+ * Extends better-result with additional combinators not provided by the library.
+ * These utilities provide lazy evaluation and tuple combinators.
+ *
+ * @module result/utilities
+ */
+import { Result } from "better-result";
+
+/**
+ * Extract value from Ok, or compute default from error.
+ *
+ * Unlike `unwrapOr`, the default is computed lazily only on Err.
+ * This is useful when the default value is expensive to compute
+ * and should only be evaluated when needed.
+ *
+ * @param result - The Result to unwrap
+ * @param defaultFn - Function to compute default value from error
+ * @returns The success value or computed default
+ *
+ * @example
+ * ```typescript
+ * const result = Result.err("not found");
+ * const value = unwrapOrElse(result, (error) => {
+ *   console.log("Computing expensive default due to:", error);
+ *   return expensiveComputation();
+ * });
+ * ```
+ */
+export const unwrapOrElse = <T, E>(result: Result<T, E>, defaultFn: (error: E) => T): T => {
+	return result.isOk() ? result.value : defaultFn(result.error);
+};
+
+/**
+ * Return first Ok, or fallback if first is Err.
+ *
+ * Useful for trying alternative operations - if the first fails,
+ * fall back to an alternative Result.
+ *
+ * @param result - The primary Result to try
+ * @param fallback - The fallback Result if primary is Err
+ * @returns First Ok result, or fallback
+ *
+ * @example
+ * ```typescript
+ * const primary = parseFromCache(key);
+ * const fallback = parseFromNetwork(key);
+ * const result = orElse(primary, fallback);
+ * ```
+ */
+export const orElse = <T, E, F>(result: Result<T, E>, fallback: Result<T, F>): Result<T, F> => {
+	// If Ok, return as-is (cast needed to change phantom error type)
+	// If Err, return the fallback
+	return result.isOk() ? (result as unknown as Result<T, F>) : fallback;
+};
+
+/**
+ * Combine two Results into a tuple Result.
+ *
+ * Returns first error if either fails, evaluated left-to-right.
+ * Useful for combining independent operations that must all succeed.
+ *
+ * @param r1 - First Result
+ * @param r2 - Second Result
+ * @returns Result containing tuple of both values, or first error
+ *
+ * @example
+ * ```typescript
+ * const user = fetchUser(id);
+ * const settings = fetchSettings(id);
+ * const combined = combine2(user, settings);
+ *
+ * if (combined.isOk()) {
+ *   const [userData, userSettings] = combined.value;
+ * }
+ * ```
+ */
+export const combine2 = <T1, T2, E>(r1: Result<T1, E>, r2: Result<T2, E>): Result<[T1, T2], E> => {
+	if (r1.isErr()) return r1 as unknown as Result<[T1, T2], E>;
+	if (r2.isErr()) return r2 as unknown as Result<[T1, T2], E>;
+	return Result.ok([r1.value, r2.value]);
+};
+
+/**
+ * Combine three Results into a tuple Result.
+ *
+ * Returns first error if any fails, evaluated left-to-right.
+ * Useful for combining independent operations that must all succeed.
+ *
+ * @param r1 - First Result
+ * @param r2 - Second Result
+ * @param r3 - Third Result
+ * @returns Result containing tuple of all values, or first error
+ *
+ * @example
+ * ```typescript
+ * const user = fetchUser(id);
+ * const settings = fetchSettings(id);
+ * const permissions = fetchPermissions(id);
+ * const combined = combine3(user, settings, permissions);
+ *
+ * if (combined.isOk()) {
+ *   const [userData, userSettings, userPermissions] = combined.value;
+ * }
+ * ```
+ */
+export const combine3 = <T1, T2, T3, E>(
+	r1: Result<T1, E>,
+	r2: Result<T2, E>,
+	r3: Result<T3, E>,
+): Result<[T1, T2, T3], E> => {
+	if (r1.isErr()) return r1 as unknown as Result<[T1, T2, T3], E>;
+	if (r2.isErr()) return r2 as unknown as Result<[T1, T2, T3], E>;
+	if (r3.isErr()) return r3 as unknown as Result<[T1, T2, T3], E>;
+	return Result.ok([r1.value, r2.value, r3.value]);
+};


### PR DESCRIPTION
- unwrapOrElse: lazy default extraction (unlike unwrapOr)
- orElse: OR logic combinator for fallback Results
- combine2/3: tuple combinators for combining Results

Extends better-result with utilities from monorepo that are not
provided by the library.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>