### PR TITLE
docs(logging): add README, CHANGELOG, and TSDoc comments

### DIFF
--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-01-22
+
+### Added
+
+- `createLogger()` - Create configured logger instances with level filtering, sinks, and redaction
+- `createChildLogger()` - Create child loggers with inherited configuration and merged context
+- `configureRedaction()` - Configure global redaction patterns and keys
+- `flush()` - Flush all pending log writes before process exit
+- `createJsonFormatter()` - JSON output formatter for log aggregation
+- `createPrettyFormatter()` - Human-readable formatter with optional ANSI colors
+- `createConsoleSink()` - Console output with stdout/stderr routing by level
+- `createFileSink()` - File output with buffered writes
+- Automatic redaction of sensitive data (password, token, secret, apikey)
+- Support for custom redaction patterns (regex) and keys
+- Recursive redaction for nested objects
+- Error object serialization with name, message, and stack trace
+- Runtime level changes via `setLevel()`
+- Dynamic sink addition via `addSink()`

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -1,0 +1,338 @@
+# @outfitter/logging
+
+Structured logging via logtape with automatic sensitive data redaction. Provides consistent log formatting across CLI, MCP, and server contexts.
+
+## Installation
+
+```bash
+bun add @outfitter/logging
+```
+
+## Quick Start
+
+```typescript
+import {
+  createLogger,
+  createConsoleSink,
+  configureRedaction,
+} from "@outfitter/logging";
+
+// Configure global redaction (optional - defaults already cover common sensitive keys)
+configureRedaction({
+  keys: ["apiKey", "accessToken"],
+  patterns: [/sk-[a-zA-Z0-9]+/g],
+});
+
+// Create a logger
+const logger = createLogger({
+  name: "my-service",
+  level: "debug",
+  sinks: [createConsoleSink()],
+  redaction: { enabled: true },
+});
+
+// Log with metadata
+logger.info("Request received", {
+  path: "/api/users",
+  apiKey: "secret-key-123", // Will be redacted to "[REDACTED]"
+});
+```
+
+## Log Levels
+
+| Level    | Priority | Use For                                    |
+| -------- | -------- | ------------------------------------------ |
+| `trace`  | 0        | Very detailed debugging (loops, internals) |
+| `debug`  | 1        | Development debugging                      |
+| `info`   | 2        | Normal operations                          |
+| `warn`   | 3        | Unexpected but handled situations          |
+| `error`  | 4        | Failures requiring attention               |
+| `fatal`  | 5        | Unrecoverable failures                     |
+| `silent` | 6        | Disable all logging                        |
+
+Messages are filtered by minimum level. Setting `level: "warn"` filters out `trace`, `debug`, and `info`.
+
+```typescript
+const logger = createLogger({
+  name: "app",
+  level: "warn", // Only warn, error, fatal will be logged
+  sinks: [createConsoleSink()],
+});
+
+logger.debug("Filtered out");
+logger.warn("This appears");
+```
+
+### Changing Level at Runtime
+
+```typescript
+logger.setLevel("debug"); // Enable debug logging
+logger.setLevel("silent"); // Disable all logging
+```
+
+## Redaction
+
+Automatic redaction protects sensitive data from appearing in logs.
+
+### Default Sensitive Keys
+
+These keys are redacted by default (case-insensitive matching):
+
+- `password`
+- `secret`
+- `token`
+- `apikey`
+
+### Custom Redaction Patterns
+
+```typescript
+configureRedaction({
+  patterns: [
+    /Bearer [a-zA-Z0-9._-]+/g, // Bearer tokens
+    /sk-[a-zA-Z0-9]{20,}/g, // OpenAI keys
+    /ghp_[a-zA-Z0-9]{36}/g, // GitHub PATs
+  ],
+  keys: ["credentials", "privateKey"],
+});
+```
+
+### Per-Logger Redaction
+
+```typescript
+const logger = createLogger({
+  name: "auth",
+  redaction: {
+    enabled: true,
+    patterns: [/custom-secret-\d+/g],
+    keys: ["myCustomKey"],
+    replacement: "***", // Custom replacement (default: "[REDACTED]")
+  },
+});
+```
+
+### Nested Object Redaction
+
+Redaction is recursive and applies to nested objects:
+
+```typescript
+logger.info("Config loaded", {
+  database: {
+    host: "localhost",
+    password: "super-secret", // Redacted
+  },
+  api: {
+    url: "https://api.example.com",
+    token: "jwt-token", // Redacted
+  },
+});
+// Output: { database: { host: "localhost", password: "[REDACTED]" }, ... }
+```
+
+## Child Loggers
+
+Create scoped loggers that inherit parent configuration and merge context:
+
+```typescript
+const parent = createLogger({
+  name: "app",
+  context: { service: "api" },
+  sinks: [createConsoleSink()],
+  redaction: { enabled: true },
+});
+
+const child = createChildLogger(parent, { handler: "getUser" });
+
+child.info("Processing request");
+// Output includes merged context: { service: "api", handler: "getUser" }
+```
+
+Child loggers:
+
+- Inherit parent's sinks, level, and redaction config
+- Merge context (child overrides parent for conflicting keys)
+- Share the same `setLevel()` and `addSink()` behavior
+
+## Formatters
+
+### JSON Formatter
+
+Machine-readable output for log aggregation:
+
+```typescript
+import { createJsonFormatter } from "@outfitter/logging";
+
+const formatter = createJsonFormatter();
+// Output: {"timestamp":1705936800000,"level":"info","category":"app","message":"Hello","userId":"123"}
+```
+
+### Pretty Formatter
+
+Human-readable output with optional ANSI colors:
+
+```typescript
+import { createPrettyFormatter } from "@outfitter/logging";
+
+const formatter = createPrettyFormatter({ colors: true, timestamp: true });
+// Output: 2024-01-22T12:00:00.000Z [INFO] app: Hello {"userId":"123"}
+```
+
+## Sinks
+
+### Console Sink
+
+Routes logs to stdout/stderr based on level:
+
+- `trace`, `debug`, `info` -> stdout
+- `warn`, `error`, `fatal` -> stderr
+
+```typescript
+import { createConsoleSink } from "@outfitter/logging";
+
+const logger = createLogger({
+  name: "app",
+  sinks: [createConsoleSink()],
+});
+```
+
+### File Sink
+
+Buffered writes to a file path:
+
+```typescript
+import { createFileSink, flush } from "@outfitter/logging";
+
+const logger = createLogger({
+  name: "app",
+  sinks: [createFileSink({ path: "/var/log/app.log" })],
+});
+
+logger.info("Application started");
+
+// Call flush() before exit to ensure all logs are written
+await flush();
+```
+
+### Custom Sinks
+
+Implement the `Sink` interface for custom destinations:
+
+```typescript
+import type { Sink, LogRecord, Formatter } from "@outfitter/logging";
+
+const customSink: Sink = {
+  formatter: createJsonFormatter(), // Optional
+  write(record: LogRecord, formatted?: string): void {
+    // Send to your destination
+    sendToRemote(formatted ?? JSON.stringify(record));
+  },
+  async flush(): Promise<void> {
+    // Optional: ensure pending writes complete
+    await flushPendingWrites();
+  },
+};
+```
+
+### Multiple Sinks
+
+Logs can be sent to multiple destinations:
+
+```typescript
+const logger = createLogger({
+  name: "app",
+  sinks: [
+    createConsoleSink(),
+    createFileSink({ path: "/var/log/app.log" }),
+    customRemoteSink,
+  ],
+});
+```
+
+## Structured Metadata
+
+### Basic Metadata
+
+```typescript
+logger.info("User logged in", {
+  userId: "u123",
+  email: "user@example.com",
+});
+```
+
+### Error Serialization
+
+Error objects are automatically serialized with name, message, and stack:
+
+```typescript
+try {
+  await riskyOperation();
+} catch (error) {
+  logger.error("Operation failed", { error });
+  // error is serialized as: { name: "Error", message: "...", stack: "..." }
+}
+```
+
+### Context Inheritance
+
+Logger context is merged with per-call metadata:
+
+```typescript
+const logger = createLogger({
+  name: "api",
+  context: { requestId: "abc123" },
+  sinks: [createConsoleSink()],
+});
+
+logger.info("Processing", { step: 1 });
+// Metadata: { requestId: "abc123", step: 1 }
+```
+
+## Flushing
+
+Call `flush()` before process exit to ensure buffered logs are written:
+
+```typescript
+import { flush } from "@outfitter/logging";
+
+process.on("beforeExit", async () => {
+  await flush();
+});
+
+// Or before explicit exit
+logger.info("Shutting down");
+await flush();
+process.exit(0);
+```
+
+## API Reference
+
+### Functions
+
+| Function                | Description                                         |
+| ----------------------- | --------------------------------------------------- |
+| `createLogger`          | Create a configured logger instance                 |
+| `createChildLogger`     | Create a child logger with merged context           |
+| `configureRedaction`    | Configure global redaction patterns and keys        |
+| `flush`                 | Flush all pending log writes across all sinks       |
+| `createJsonFormatter`   | Create a JSON formatter for structured output       |
+| `createPrettyFormatter` | Create a human-readable formatter with colors       |
+| `createConsoleSink`     | Create a console sink (stdout/stderr routing)       |
+| `createFileSink`        | Create a file sink with buffered writes             |
+
+### Types
+
+| Type                     | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `LogLevel`               | Union of log level strings                      |
+| `LogRecord`              | Structured log record with timestamp/metadata   |
+| `LoggerConfig`           | Configuration options for `createLogger`        |
+| `LoggerInstance`         | Logger interface with level methods             |
+| `RedactionConfig`        | Per-logger redaction configuration              |
+| `GlobalRedactionConfig`  | Global redaction patterns and keys              |
+| `Formatter`              | Interface for log record formatting             |
+| `Sink`                   | Interface for log output destinations           |
+| `PrettyFormatterOptions` | Options for human-readable formatter            |
+| `FileSinkOptions`        | Options for file sink configuration             |
+
+## License
+
+MIT

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -15,151 +15,372 @@ import { writeFileSync } from "node:fs";
 
 /**
  * Log levels supported by the logger, ordered from lowest to highest severity.
- * "silent" is a special level that disables all logging.
+ *
+ * Level priority (lowest to highest): trace (0) < debug (1) < info (2) < warn (3) < error (4) < fatal (5)
+ *
+ * The special level "silent" (6) disables all logging when set as the minimum level.
+ *
+ * @example
+ * ```typescript
+ * const level: LogLevel = "info";
+ *
+ * // Set minimum level to filter logs
+ * const logger = createLogger({ name: "app", level: "warn" });
+ * logger.debug("Filtered out"); // Not logged
+ * logger.warn("Logged");        // Logged
+ * ```
  */
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "silent";
 
 /**
  * A structured log record containing all information about a log event.
+ *
+ * Log records are passed to formatters and sinks for processing. They contain
+ * the timestamp, level, category (logger name), message, and optional metadata.
+ *
+ * @example
+ * ```typescript
+ * const record: LogRecord = {
+ *   timestamp: Date.now(),
+ *   level: "info",
+ *   category: "my-service",
+ *   message: "Request processed",
+ *   metadata: { duration: 150, status: 200 },
+ * };
+ * ```
  */
 export interface LogRecord {
 	/** Unix timestamp in milliseconds when the log was created */
 	timestamp: number;
 
-	/** Severity level of the log */
+	/** Severity level of the log (excludes "silent" which is only for filtering) */
 	level: Exclude<LogLevel, "silent">;
 
-	/** Logger category/name (e.g., "my-service", "api") */
+	/** Logger category/name identifying the source (e.g., "my-service", "api") */
 	category: string;
 
-	/** Human-readable log message */
+	/** Human-readable log message describing the event */
 	message: string;
 
-	/** Structured metadata attached to the log */
+	/** Optional structured metadata attached to the log for additional context */
 	metadata?: Record<string, unknown>;
 }
 
 /**
  * Formatter interface for converting log records to strings.
+ *
+ * Formatters are responsible for serializing log records into output strings.
+ * Built-in formatters include JSON (for machine parsing) and pretty (for humans).
+ *
+ * @example
+ * ```typescript
+ * const customFormatter: Formatter = {
+ *   format(record: LogRecord): string {
+ *     return `[${record.level.toUpperCase()}] ${record.category}: ${record.message}`;
+ *   },
+ * };
+ *
+ * const sink: Sink = {
+ *   formatter: customFormatter,
+ *   write(record, formatted) {
+ *     console.log(formatted); // "[INFO] app: Hello world"
+ *   },
+ * };
+ * ```
  */
 export interface Formatter {
-	/** Format a log record into a string representation */
+	/**
+	 * Format a log record into a string representation.
+	 *
+	 * @param record - The log record to format
+	 * @returns Formatted string representation of the log record
+	 */
 	format(record: LogRecord): string;
 }
 
 /**
  * Sink interface for outputting log records to various destinations.
+ *
+ * Sinks receive log records and write them to their destination (console, file,
+ * remote service, etc.). They can optionally have a formatter to convert records
+ * to strings, and a flush method for buffered writes.
+ *
+ * @example
+ * ```typescript
+ * const customSink: Sink = {
+ *   formatter: createJsonFormatter(),
+ *   write(record: LogRecord, formatted?: string): void {
+ *     const output = formatted ?? JSON.stringify(record);
+ *     sendToRemoteService(output);
+ *   },
+ *   async flush(): Promise<void> {
+ *     await flushPendingRequests();
+ *   },
+ * };
+ * ```
  */
 export interface Sink {
-	/** Write a log record (optionally with pre-formatted string) */
+	/**
+	 * Write a log record to the sink's destination.
+	 *
+	 * @param record - The log record to write
+	 * @param formatted - Optional pre-formatted string from the sink's formatter
+	 */
 	write(record: LogRecord, formatted?: string): void;
 
-	/** Optional formatter specific to this sink */
+	/** Optional formatter specific to this sink for converting records to strings */
 	formatter?: Formatter;
 
-	/** Optional async flush to ensure all pending writes complete */
+	/**
+	 * Optional async flush to ensure all pending/buffered writes complete.
+	 * Called by the global `flush()` function before process exit.
+	 *
+	 * @returns Promise that resolves when all pending writes are complete
+	 */
 	flush?(): Promise<void>;
 }
 
 /**
  * Redaction configuration for sensitive data scrubbing.
+ *
+ * Redaction automatically replaces sensitive values in log metadata to prevent
+ * accidental exposure of secrets, tokens, and credentials. Default sensitive keys
+ * (password, secret, token, apikey) are always redacted when enabled.
+ *
+ * @example
+ * ```typescript
+ * const logger = createLogger({
+ *   name: "auth",
+ *   redaction: {
+ *     enabled: true,
+ *     patterns: [/Bearer [a-zA-Z0-9._-]+/g], // Redact Bearer tokens in strings
+ *     keys: ["privateKey", "credentials"],   // Additional keys to redact
+ *     replacement: "***",                    // Custom replacement text
+ *   },
+ * });
+ * ```
  */
 export interface RedactionConfig {
-	/** Enable or disable redaction (default: true) */
+	/**
+	 * Enable or disable redaction for this logger.
+	 * @defaultValue true (when RedactionConfig is provided)
+	 */
 	enabled?: boolean;
 
-	/** Additional regex patterns to match and redact */
+	/** Additional regex patterns to match and redact within string values */
 	patterns?: RegExp[];
 
-	/** Additional key names whose values should be redacted */
+	/** Additional key names whose values should be fully redacted (case-insensitive) */
 	keys?: string[];
 
-	/** Replacement string (default: "[REDACTED]") */
+	/**
+	 * Replacement string for redacted values.
+	 * @defaultValue "[REDACTED]"
+	 */
 	replacement?: string;
 }
 
 /**
  * Configuration options for creating a logger.
+ *
+ * Defines the logger's name, minimum level, context, sinks, and redaction settings.
+ *
+ * @example
+ * ```typescript
+ * const config: LoggerConfig = {
+ *   name: "my-service",
+ *   level: "debug",
+ *   context: { service: "api", version: "1.0.0" },
+ *   sinks: [createConsoleSink(), createFileSink({ path: "/var/log/app.log" })],
+ *   redaction: { enabled: true },
+ * };
+ *
+ * const logger = createLogger(config);
+ * ```
  */
 export interface LoggerConfig {
-	/** Logger name/category */
+	/** Logger name used as the category in log records */
 	name: string;
 
-	/** Minimum log level to output (default: "info") */
+	/**
+	 * Minimum log level to output. Messages below this level are filtered.
+	 * @defaultValue "info"
+	 */
 	level?: LogLevel;
 
-	/** Initial context metadata to attach to all logs */
+	/** Initial context metadata attached to all log records from this logger */
 	context?: Record<string, unknown>;
 
-	/** Sinks to output logs to */
+	/** Array of sinks to output log records to */
 	sinks?: Sink[];
 
-	/** Redaction configuration */
+	/** Redaction configuration for sensitive data scrubbing */
 	redaction?: RedactionConfig;
 }
 
 /**
  * Logger instance with methods for each log level.
+ *
+ * Provides methods for logging at each severity level, plus utilities for
+ * runtime configuration changes and context inspection.
+ *
+ * @example
+ * ```typescript
+ * const logger = createLogger({ name: "app", sinks: [createConsoleSink()] });
+ *
+ * logger.info("Server started", { port: 3000 });
+ * logger.error("Failed to connect", { error: new Error("timeout") });
+ *
+ * logger.setLevel("debug"); // Enable debug logging at runtime
+ * logger.debug("Debug info", { details: "..." });
+ * ```
  */
 export interface LoggerInstance {
-	/** Log at trace level */
+	/**
+	 * Log at trace level (most verbose, for detailed debugging).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	trace(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Log at debug level */
+	/**
+	 * Log at debug level (development debugging).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	debug(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Log at info level */
+	/**
+	 * Log at info level (normal operations).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	info(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Log at warn level */
+	/**
+	 * Log at warn level (unexpected but handled situations).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	warn(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Log at error level */
+	/**
+	 * Log at error level (failures requiring attention).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	error(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Log at fatal level */
+	/**
+	 * Log at fatal level (unrecoverable failures).
+	 * @param message - Human-readable log message
+	 * @param metadata - Optional structured metadata
+	 */
 	fatal(message: string, metadata?: Record<string, unknown>): void;
 
-	/** Get the current context metadata */
+	/**
+	 * Get the current context metadata attached to this logger.
+	 * @returns Copy of the logger's context object
+	 */
 	getContext(): Record<string, unknown>;
 
-	/** Set the minimum log level at runtime */
+	/**
+	 * Set the minimum log level at runtime.
+	 * @param level - New minimum level (messages below this are filtered)
+	 */
 	setLevel(level: LogLevel): void;
 
-	/** Add a sink at runtime */
+	/**
+	 * Add a sink at runtime.
+	 * @param sink - Sink to add to this logger's output destinations
+	 */
 	addSink(sink: Sink): void;
 }
 
 /**
- * Options for pretty (human-readable) formatter.
+ * Options for the pretty (human-readable) formatter.
+ *
+ * Controls ANSI color output and timestamp inclusion for terminal display.
+ *
+ * @example
+ * ```typescript
+ * // Colorized with timestamps (default)
+ * const formatter = createPrettyFormatter({ colors: true, timestamp: true });
+ *
+ * // Plain text without timestamps (for piping)
+ * const plainFormatter = createPrettyFormatter({ colors: false, timestamp: false });
+ * ```
  */
 export interface PrettyFormatterOptions {
-	/** Enable ANSI colors in output (default: true) */
+	/**
+	 * Enable ANSI colors in output. Colors are applied per log level:
+	 * trace (dim), debug (cyan), info (green), warn (yellow), error (red), fatal (magenta).
+	 * @defaultValue false
+	 */
 	colors?: boolean;
 
-	/** Include timestamp in output (default: true) */
+	/**
+	 * Include ISO 8601 timestamp in output.
+	 * @defaultValue true
+	 */
 	timestamp?: boolean;
 }
 
 /**
- * Options for file sink.
+ * Options for the file sink.
+ *
+ * Configures the file path and append behavior for file-based logging.
+ * File sink uses buffered writes - call `flush()` before exit to ensure
+ * all logs are written.
+ *
+ * @example
+ * ```typescript
+ * const sink = createFileSink({
+ *   path: "/var/log/app.log",
+ *   append: true, // Append to existing file (default)
+ * });
+ *
+ * // For fresh logs on each run:
+ * const freshSink = createFileSink({
+ *   path: "/tmp/session.log",
+ *   append: false, // Truncate file on start
+ * });
+ * ```
  */
 export interface FileSinkOptions {
-	/** Path to the log file */
+	/** Absolute path to the log file */
 	path: string;
 
-	/** Append to existing file (default: true) */
+	/**
+	 * Append to existing file or truncate on start.
+	 * @defaultValue true
+	 */
 	append?: boolean;
 }
 
 /**
  * Global redaction configuration options.
+ *
+ * Patterns and keys configured globally apply to all loggers that have
+ * redaction enabled. Use `configureRedaction()` to add global patterns.
+ *
+ * @example
+ * ```typescript
+ * // Configure global patterns that apply to all loggers
+ * configureRedaction({
+ *   patterns: [
+ *     /ghp_[a-zA-Z0-9]{36}/g,  // GitHub PATs
+ *     /sk-[a-zA-Z0-9]{20,}/g,   // OpenAI keys
+ *   ],
+ *   keys: ["privateKey", "credentials"],
+ * });
+ * ```
  */
 export interface GlobalRedactionConfig {
-	/** Additional regex patterns to match and redact globally */
+	/** Regex patterns to match and redact within string values (applied globally) */
 	patterns?: RegExp[];
 
-	/** Additional key names whose values should be redacted globally */
+	/** Key names whose values should be fully redacted (case-insensitive, applied globally) */
 	keys?: string[];
 }
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation to `@outfitter/logging` package:

- **README.md** — Installation, quick start, log levels, redaction patterns, child loggers, formatters, sinks
- **CHANGELOG.md** — Initial 0.1.0 release notes
- **TSDoc comments** — All exported functions, types, and interfaces documented with `@param`, `@returns`, and `@example`

## Highlights

- Documents log level hierarchy (trace → fatal → silent)
- Shows automatic redaction of sensitive keys (password, token, secret, apikey)
- Covers custom redaction patterns for API keys (OpenAI, GitHub PATs, Bearer tokens)
- Explains child logger context inheritance

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)