### PR TITLE
docs(ui): add README, CHANGELOG, and TSDoc comments

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-01-22
+
+### Added
+
+- **Color Tokens**
+  - `createTheme()` - Create semantic color theme with success, warning, error, info, primary, secondary, and muted colors
+  - `applyColor()` - Apply named color to text (green, yellow, red, blue, cyan, magenta, white, gray)
+  - `supportsColor()` - Detect color support respecting NO_COLOR, FORCE_COLOR, and TTY
+
+- **Terminal Detection**
+  - `getTerminalWidth()` - Get terminal width with fallback to 80 for non-TTY
+  - `isInteractive()` - Check if terminal is interactive (TTY and not CI)
+
+- **Text Formatting**
+  - `stripAnsi()` - Remove ANSI escape codes from text
+  - `getStringWidth()` - Calculate visible width ignoring ANSI codes (via Bun.stringWidth)
+  - `wrapText()` - Word wrap with ANSI code preservation across line breaks
+  - `truncateText()` - Truncate with ellipsis and ANSI code awareness
+  - `padText()` - Pad text to width with ANSI code awareness
+
+- **Output Shapes**
+  - `renderTable()` - ASCII table rendering with automatic column width calculation, custom headers, and column width options
+  - `renderList()` - Nested bullet list rendering with indentation
+  - `renderTree()` - Unicode tree rendering with box-drawing characters
+  - `renderProgress()` - Progress bar rendering with optional percentage display
+
+- **Content Renderers**
+  - `renderMarkdown()` - Basic markdown to terminal with heading, bold, italic, and code styling
+  - `renderJson()` - JSON pretty printing with indentation
+  - `renderText()` - Plain text passthrough
+
+- **Types**
+  - `Theme` - Theme interface with semantic and text color functions
+  - `ColorName` - Union type of available color names
+  - `TableOptions` - Table rendering configuration
+  - `ListItem` - List item type supporting strings and nested items
+  - `NestedListItem` - Nested list item with text and children
+  - `ProgressOptions` - Progress bar configuration
+  - `TerminalOptions` - Terminal detection options

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,399 @@
+# @outfitter/ui
+
+Color tokens, output shapes, and terminal renderers for consistent CLI output.
+
+## Installation
+
+```bash
+bun add @outfitter/ui
+```
+
+## Quick Start
+
+```typescript
+import {
+  createTheme,
+  renderTable,
+  renderTree,
+  renderProgress,
+  supportsColor,
+} from "@outfitter/ui";
+
+// Create theme with semantic colors
+const theme = createTheme();
+console.log(theme.success("Operation completed!"));
+console.log(theme.error("Something went wrong"));
+
+// Render a table
+const data = [
+  { name: "Alice", role: "Admin", status: "Active" },
+  { name: "Bob", role: "User", status: "Pending" },
+];
+console.log(renderTable(data));
+
+// Render progress
+console.log(renderProgress({ current: 75, total: 100, showPercent: true }));
+```
+
+## Color Token System
+
+The theme provides semantic and text color functions that wrap text in ANSI escape codes when colors are supported.
+
+### Semantic Colors
+
+| Token     | Color  | Use For            |
+| --------- | ------ | ------------------ |
+| `success` | Green  | Success messages   |
+| `warning` | Yellow | Warnings           |
+| `error`   | Red    | Errors             |
+| `info`    | Blue   | Informational text |
+
+### Text Colors
+
+| Token       | Style   | Use For            |
+| ----------- | ------- | ------------------ |
+| `primary`   | Default | Primary text       |
+| `secondary` | Gray    | Secondary text     |
+| `muted`     | Dim     | De-emphasized text |
+
+### Usage
+
+```typescript
+import { createTheme } from "@outfitter/ui";
+
+const theme = createTheme();
+
+console.log(theme.success("Done!"));       // Green
+console.log(theme.error("Failed!"));       // Red
+console.log(theme.warning("Caution"));     // Yellow
+console.log(theme.info("Note"));           // Blue
+console.log(theme.muted("(optional)"));    // Dim
+```
+
+### Direct Color Application
+
+```typescript
+import { applyColor } from "@outfitter/ui";
+
+// Apply named colors directly
+console.log(applyColor("Hello", "green"));
+console.log(applyColor("Warning", "yellow"));
+console.log(applyColor("Error", "red"));
+```
+
+Available color names: `green`, `yellow`, `red`, `blue`, `cyan`, `magenta`, `white`, `gray`.
+
+## Environment Respect
+
+The color system respects standard environment variables and terminal capabilities:
+
+| Variable      | Behavior                                  |
+| ------------- | ----------------------------------------- |
+| `NO_COLOR`    | Disables all colors (per no-color.org)    |
+| `FORCE_COLOR` | Enables colors even without TTY           |
+| (neither)     | Falls back to TTY detection               |
+
+```typescript
+import { supportsColor, createTheme } from "@outfitter/ui";
+
+if (supportsColor()) {
+  const theme = createTheme();
+  console.log(theme.success("Colored output"));
+} else {
+  console.log("Plain output");
+}
+```
+
+### Priority Order
+
+1. `NO_COLOR` takes highest priority - if set and non-empty, colors are disabled
+2. `FORCE_COLOR` enables colors if `NO_COLOR` is not set
+3. Falls back to checking `process.stdout.isTTY`
+
+## Output Shapes
+
+### Table
+
+Renders data as an ASCII table with borders. Automatically calculates column widths based on content.
+
+```typescript
+import { renderTable } from "@outfitter/ui";
+
+const data = [
+  { id: 1, name: "Alice", status: "Active" },
+  { id: 2, name: "Bob", status: "Inactive" },
+];
+
+console.log(renderTable(data));
+// +----+-------+----------+
+// | id | name  | status   |
+// +----+-------+----------+
+// | 1  | Alice | Active   |
+// | 2  | Bob   | Inactive |
+// +----+-------+----------+
+
+// With custom headers and column widths
+console.log(
+  renderTable(data, {
+    headers: { id: "ID", name: "Name" },
+    columnWidths: { status: 10 },
+  })
+);
+```
+
+### List
+
+Renders items as a bullet list with optional nesting.
+
+```typescript
+import { renderList } from "@outfitter/ui";
+
+// Simple list
+console.log(renderList(["First item", "Second item", "Third item"]));
+// - First item
+// - Second item
+// - Third item
+
+// Nested list
+console.log(
+  renderList([
+    "Parent item",
+    { text: "Item with children", children: ["Child 1", "Child 2"] },
+  ])
+);
+// - Parent item
+// - Item with children
+//   - Child 1
+//   - Child 2
+```
+
+### Tree
+
+Renders hierarchical data as a tree with unicode box characters.
+
+```typescript
+import { renderTree } from "@outfitter/ui";
+
+const tree = {
+  src: {
+    components: {
+      Button: null,
+      Input: null,
+    },
+    utils: {
+      helpers: null,
+    },
+  },
+  tests: null,
+};
+
+console.log(renderTree(tree));
+// ├── src
+// │   ├── components
+// │   │   ├── Button
+// │   │   └── Input
+// │   └── utils
+// │       └── helpers
+// └── tests
+```
+
+### Progress
+
+Renders a progress bar with optional percentage display.
+
+```typescript
+import { renderProgress } from "@outfitter/ui";
+
+console.log(renderProgress({ current: 50, total: 100 }));
+// [██████████░░░░░░░░░░]
+
+console.log(renderProgress({ current: 75, total: 100, showPercent: true }));
+// [███████████████░░░░░] 75%
+
+console.log(renderProgress({ current: 30, total: 100, width: 10 }));
+// [███░░░░░░░]
+```
+
+## Text Formatting
+
+### Wrap Text
+
+Word wraps text at a specified width, preserving ANSI codes across line breaks.
+
+```typescript
+import { wrapText } from "@outfitter/ui";
+
+const long = "This is a long sentence that should be wrapped";
+console.log(wrapText(long, 20));
+// This is a long
+// sentence that
+// should be wrapped
+```
+
+### Truncate Text
+
+Truncates text with ellipsis, respecting ANSI codes in width calculation.
+
+```typescript
+import { truncateText } from "@outfitter/ui";
+
+console.log(truncateText("Hello World", 8));  // "Hello..."
+console.log(truncateText("Short", 10));       // "Short" (no change)
+```
+
+### Pad Text
+
+Pads text to a specified width, handling ANSI codes correctly.
+
+```typescript
+import { padText } from "@outfitter/ui";
+
+console.log(padText("Hi", 10));  // "Hi        "
+```
+
+### Strip ANSI
+
+Removes ANSI escape codes from text.
+
+```typescript
+import { stripAnsi } from "@outfitter/ui";
+
+console.log(stripAnsi("\x1b[32mGreen\x1b[0m"));  // "Green"
+```
+
+### Get String Width
+
+Calculates visible width of text, ignoring ANSI codes. Uses `Bun.stringWidth()` internally.
+
+```typescript
+import { getStringWidth } from "@outfitter/ui";
+
+console.log(getStringWidth("Hello"));           // 5
+console.log(getStringWidth("\x1b[31mHello\x1b[0m"));  // 5
+```
+
+## Content Renderers
+
+### Markdown
+
+Renders markdown to terminal with ANSI styling for headings, bold, italic, and code.
+
+```typescript
+import { renderMarkdown } from "@outfitter/ui";
+
+const md = `# Heading
+
+Some **bold** and *italic* text.
+
+\`inline code\` and:
+
+\`\`\`javascript
+const x = 1;
+\`\`\`
+`;
+
+console.log(renderMarkdown(md));
+```
+
+### JSON
+
+Pretty-prints JSON data with indentation.
+
+```typescript
+import { renderJson } from "@outfitter/ui";
+
+console.log(renderJson({ name: "test", value: 42 }));
+// {
+//   "name": "test",
+//   "value": 42
+// }
+```
+
+## Terminal Detection
+
+### Get Terminal Width
+
+Returns the terminal width, with a fallback of 80 for non-TTY environments.
+
+```typescript
+import { getTerminalWidth } from "@outfitter/ui";
+
+const width = getTerminalWidth();  // e.g., 120 in a terminal, 80 if not TTY
+```
+
+### Is Interactive
+
+Checks if the terminal is interactive (TTY and not CI).
+
+```typescript
+import { isInteractive } from "@outfitter/ui";
+
+if (isInteractive()) {
+  // Safe to use interactive prompts
+} else {
+  // Use non-interactive fallback
+}
+```
+
+### Supports Color
+
+Checks if the environment supports colors.
+
+```typescript
+import { supportsColor } from "@outfitter/ui";
+
+// Uses automatic detection
+if (supportsColor()) {
+  // Colors are supported
+}
+
+// With explicit options
+supportsColor({ isTTY: true });   // true
+supportsColor({ isTTY: false });  // false (unless FORCE_COLOR is set)
+```
+
+## API Reference
+
+### Types
+
+```typescript
+interface Theme {
+  success: (text: string) => string;
+  warning: (text: string) => string;
+  error: (text: string) => string;
+  info: (text: string) => string;
+  primary: (text: string) => string;
+  secondary: (text: string) => string;
+  muted: (text: string) => string;
+}
+
+type ColorName = "green" | "yellow" | "red" | "blue" | "cyan" | "magenta" | "white" | "gray";
+
+interface TableOptions {
+  columnWidths?: Record<string, number>;
+  headers?: Record<string, string>;
+}
+
+interface NestedListItem {
+  text: string;
+  children?: Array<string | NestedListItem>;
+}
+
+type ListItem = string | NestedListItem;
+
+interface ProgressOptions {
+  current: number;
+  total: number;
+  width?: number;      // Default: 20
+  showPercent?: boolean;  // Default: false
+}
+
+interface TerminalOptions {
+  isTTY?: boolean;
+  isCI?: boolean;
+}
+```
+
+## License
+
+MIT

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,48 +12,149 @@
 // Types
 // ============================================================================
 
-/** Theme type with semantic and text color functions */
+/**
+ * Theme interface with semantic and text color functions.
+ *
+ * Each function wraps text in ANSI escape codes when colors are supported.
+ * When colors are not supported (NO_COLOR set, non-TTY), functions return the text unchanged.
+ *
+ * @example
+ * ```typescript
+ * const theme = createTheme();
+ * console.log(theme.success("Done!"));       // Green text
+ * console.log(theme.error("Failed!"));       // Red text
+ * console.log(theme.muted("(optional)"));    // Dim text
+ * ```
+ */
 export interface Theme {
-	// Semantic colors
+	/** Applies green color for success messages */
 	success: (text: string) => string;
+	/** Applies yellow color for warning messages */
 	warning: (text: string) => string;
+	/** Applies red color for error messages */
 	error: (text: string) => string;
+	/** Applies blue color for informational messages */
 	info: (text: string) => string;
-	// Text colors
+	/** Returns text unchanged (primary/default text) */
 	primary: (text: string) => string;
+	/** Applies gray color for secondary text */
 	secondary: (text: string) => string;
+	/** Applies dim styling for de-emphasized text */
 	muted: (text: string) => string;
 }
 
-/** Color names for applyColor */
+/**
+ * Available color names for the {@link applyColor} function.
+ *
+ * @example
+ * ```typescript
+ * import { applyColor, ColorName } from "@outfitter/ui";
+ *
+ * const color: ColorName = "green";
+ * console.log(applyColor("Success", color));
+ * ```
+ */
 export type ColorName = "green" | "yellow" | "red" | "blue" | "cyan" | "magenta" | "white" | "gray";
 
-/** Table rendering options */
+/**
+ * Configuration options for {@link renderTable}.
+ *
+ * @example
+ * ```typescript
+ * const options: TableOptions = {
+ *   headers: { id: "ID", name: "Name" },
+ *   columnWidths: { description: 20 },
+ * };
+ * ```
+ */
 export interface TableOptions {
+	/**
+	 * Fixed column widths by key.
+	 * If not specified, column width is calculated from content.
+	 */
 	columnWidths?: Record<string, number>;
+	/**
+	 * Custom header labels by key.
+	 * If not specified, the object key is used as the header.
+	 */
 	headers?: Record<string, string>;
 }
 
-/** List item with optional nesting */
+/**
+ * A list item with optional nested children for {@link renderList}.
+ *
+ * @example
+ * ```typescript
+ * const item: NestedListItem = {
+ *   text: "Parent item",
+ *   children: ["Child 1", "Child 2"],
+ * };
+ * ```
+ */
 export interface NestedListItem {
+	/** The text content of this list item */
 	text: string;
+	/** Optional nested child items (strings or nested items) */
 	children?: Array<string | NestedListItem>;
 }
 
-/** List item type */
+/**
+ * A list item that can be either a simple string or a nested item with children.
+ *
+ * @example
+ * ```typescript
+ * const items: ListItem[] = [
+ *   "Simple item",
+ *   { text: "Parent", children: ["Child 1", "Child 2"] },
+ * ];
+ * ```
+ */
 export type ListItem = string | NestedListItem;
 
-/** Progress bar options */
+/**
+ * Configuration options for {@link renderProgress}.
+ *
+ * @example
+ * ```typescript
+ * const options: ProgressOptions = {
+ *   current: 75,
+ *   total: 100,
+ *   width: 20,
+ *   showPercent: true,
+ * };
+ * // Renders: [███████████████░░░░░] 75%
+ * ```
+ */
 export interface ProgressOptions {
+	/** Current progress value */
 	current: number;
+	/** Total value (100% when current equals total) */
 	total: number;
+	/** Width of the progress bar in characters (default: 20) */
 	width?: number;
+	/** Whether to show percentage after the bar (default: false) */
 	showPercent?: boolean;
 }
 
-/** Terminal detection options */
+/**
+ * Options for terminal detection functions.
+ *
+ * These options allow overriding automatic detection for testing
+ * or specific environments.
+ *
+ * @example
+ * ```typescript
+ * // Force TTY mode for testing
+ * supportsColor({ isTTY: true });
+ *
+ * // Simulate CI environment
+ * isInteractive({ isTTY: true, isCI: true }); // returns false
+ * ```
+ */
 export interface TerminalOptions {
+	/** Override TTY detection (uses process.stdout.isTTY if not specified) */
 	isTTY?: boolean;
+	/** Override CI detection (uses CI env variable if not specified) */
 	isCI?: boolean;
 }
 
@@ -82,7 +183,28 @@ const ANSI = {
 // ============================================================================
 
 /**
- * Checks if the current environment supports colors.
+ * Checks if the current environment supports ANSI colors.
+ *
+ * Detection priority:
+ * 1. `NO_COLOR` env variable - if set and non-empty, returns false (per no-color.org)
+ * 2. `FORCE_COLOR` env variable - if set and non-empty, returns true
+ * 3. Falls back to TTY detection via `process.stdout.isTTY`
+ *
+ * @param options - Optional overrides for TTY detection
+ * @returns `true` if colors are supported, `false` otherwise
+ *
+ * @example
+ * ```typescript
+ * if (supportsColor()) {
+ *   console.log("\x1b[32mGreen text\x1b[0m");
+ * } else {
+ *   console.log("Plain text");
+ * }
+ *
+ * // With explicit TTY override for testing
+ * supportsColor({ isTTY: true });  // true (unless NO_COLOR is set)
+ * supportsColor({ isTTY: false }); // false (unless FORCE_COLOR is set)
+ * ```
  */
 export function supportsColor(options?: TerminalOptions): boolean {
 	// NO_COLOR takes priority (per https://no-color.org/)
@@ -107,7 +229,22 @@ export function supportsColor(options?: TerminalOptions): boolean {
 }
 
 /**
- * Gets the terminal width, with fallback for non-TTY.
+ * Gets the terminal width in columns.
+ *
+ * Returns `process.stdout.columns` when in a TTY, or 80 as a fallback
+ * for non-TTY environments (pipes, CI, etc.).
+ *
+ * @param options - Optional overrides for TTY detection
+ * @returns Terminal width in columns (default: 80 if not TTY)
+ *
+ * @example
+ * ```typescript
+ * const width = getTerminalWidth();
+ * console.log(`Terminal is ${width} columns wide`);
+ *
+ * // Force non-TTY mode (always returns 80)
+ * getTerminalWidth({ isTTY: false }); // 80
+ * ```
  */
 export function getTerminalWidth(options?: TerminalOptions): number {
 	const isTTY = options?.isTTY ?? process.stdout.isTTY ?? false;
@@ -121,6 +258,27 @@ export function getTerminalWidth(options?: TerminalOptions): number {
 
 /**
  * Checks if the terminal is interactive.
+ *
+ * A terminal is considered interactive when:
+ * - It is a TTY (process.stdout.isTTY is true)
+ * - It is NOT running in a CI environment (CI env variable is not set)
+ *
+ * Use this to decide whether to show interactive prompts or use
+ * non-interactive fallbacks.
+ *
+ * @param options - Optional overrides for TTY and CI detection
+ * @returns `true` if interactive prompts are safe to use
+ *
+ * @example
+ * ```typescript
+ * if (isInteractive()) {
+ *   // Safe to use interactive prompts
+ *   const answer = await prompt("Continue?");
+ * } else {
+ *   // Use non-interactive defaults
+ *   console.log("Running in non-interactive mode");
+ * }
+ * ```
  */
 export function isInteractive(options?: TerminalOptions): boolean {
 	// Check CI environment first
@@ -142,7 +300,31 @@ export function isInteractive(options?: TerminalOptions): boolean {
 
 /**
  * Creates a theme with semantic and text color functions.
- * Respects NO_COLOR environment variable and TTY detection.
+ *
+ * The theme provides functions that wrap text in ANSI escape codes.
+ * When colors are not supported (NO_COLOR set, non-TTY), functions
+ * return the text unchanged.
+ *
+ * Color support is determined once at theme creation time using
+ * {@link supportsColor}.
+ *
+ * @returns Theme object with color functions
+ *
+ * @example
+ * ```typescript
+ * const theme = createTheme();
+ *
+ * // Semantic colors
+ * console.log(theme.success("Done!"));       // Green
+ * console.log(theme.warning("Caution"));     // Yellow
+ * console.log(theme.error("Failed!"));       // Red
+ * console.log(theme.info("Note"));           // Blue
+ *
+ * // Text colors
+ * console.log(theme.primary("Main text"));   // Default
+ * console.log(theme.secondary("Alt text"));  // Gray
+ * console.log(theme.muted("(optional)"));    // Dim
+ * ```
  */
 export function createTheme(): Theme {
 	const colorEnabled = supportsColor();
@@ -168,8 +350,22 @@ export function createTheme(): Theme {
 }
 
 /**
- * Applies a color to text using ANSI escape codes.
- * Returns plain text if colors are not supported.
+ * Applies a named color to text using ANSI escape codes.
+ *
+ * Returns plain text if colors are not supported (NO_COLOR set, non-TTY).
+ * For semantic colors (success, error, etc.), use {@link createTheme} instead.
+ *
+ * @param text - The text to colorize
+ * @param color - The color name to apply
+ * @returns Text wrapped in ANSI escape codes, or plain text if colors not supported
+ *
+ * @example
+ * ```typescript
+ * console.log(applyColor("Success", "green"));
+ * console.log(applyColor("Warning", "yellow"));
+ * console.log(applyColor("Error", "red"));
+ * console.log(applyColor("Info", "blue"));
+ * ```
  */
 export function applyColor(text: string, color: ColorName): string {
 	if (!supportsColor()) {
@@ -190,20 +386,69 @@ const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
 
 /**
  * Removes ANSI escape codes from text.
+ *
+ * Useful for calculating visible string length or logging to files
+ * where ANSI codes would appear as garbage.
+ *
+ * @param text - Text that may contain ANSI escape codes
+ * @returns Text with all ANSI escape codes removed
+ *
+ * @example
+ * ```typescript
+ * const colored = "\x1b[32mGreen\x1b[0m text";
+ * console.log(stripAnsi(colored)); // "Green text"
+ * ```
  */
 export function stripAnsi(text: string): string {
 	return text.replace(ANSI_REGEX, "");
 }
 
 /**
- * Calculates visible width of text, ignoring ANSI codes.
+ * Calculates the visible width of text, ignoring ANSI escape codes.
+ *
+ * Uses `Bun.stringWidth()` internally, which correctly handles:
+ * - ANSI escape codes (ignored)
+ * - Wide characters (CJK, emoji) counting as 2 columns
+ * - Zero-width characters
+ *
+ * @param text - Text to measure (may contain ANSI codes)
+ * @returns Visible width in terminal columns
+ *
+ * @example
+ * ```typescript
+ * getStringWidth("Hello");                    // 5
+ * getStringWidth("\x1b[31mHello\x1b[0m");     // 5 (ANSI ignored)
+ * getStringWidth("Hello");                    // 5
+ * ```
  */
 export function getStringWidth(text: string): number {
 	return Bun.stringWidth(text);
 }
 
 /**
- * Wraps text at specified width, preserving ANSI codes.
+ * Wraps text at a specified width, preserving ANSI escape codes.
+ *
+ * Performs word-wrapping at the specified column width while:
+ * - Preserving ANSI escape codes across line breaks
+ * - Respecting word boundaries (no mid-word breaks)
+ * - Trimming trailing whitespace from lines
+ *
+ * @param text - Text to wrap (may contain ANSI codes)
+ * @param width - Maximum visible width per line
+ * @returns Wrapped text with newlines
+ *
+ * @example
+ * ```typescript
+ * const long = "This is a long sentence that should be wrapped";
+ * console.log(wrapText(long, 20));
+ * // This is a long
+ * // sentence that
+ * // should be wrapped
+ *
+ * // ANSI codes are preserved across line breaks
+ * const colored = "\x1b[32mGreen text that wraps\x1b[0m";
+ * console.log(wrapText(colored, 10));
+ * ```
  */
 export function wrapText(text: string, width: number): string {
 	const words = text.split(/(\s+)/);
@@ -267,7 +512,25 @@ export function wrapText(text: string, width: number): string {
 }
 
 /**
- * Truncates text with ellipsis, respecting ANSI codes.
+ * Truncates text with ellipsis, respecting ANSI escape codes.
+ *
+ * Preserves ANSI escape sequences while truncating to visible width.
+ * Adds "..." when text exceeds maxWidth. The ellipsis is included
+ * in the maxWidth calculation.
+ *
+ * @param text - Text to truncate (may contain ANSI codes)
+ * @param maxWidth - Maximum visible width including ellipsis
+ * @returns Truncated text with ellipsis if needed
+ *
+ * @example
+ * ```typescript
+ * truncateText("Hello World", 8);  // "Hello..."
+ * truncateText("Short", 10);       // "Short" (no change)
+ *
+ * // ANSI codes are preserved
+ * truncateText("\x1b[32mGreen text\x1b[0m", 8);
+ * // "\x1b[32mGreen\x1b[0m..."
+ * ```
  */
 export function truncateText(text: string, maxWidth: number): string {
 	const visibleWidth = getStringWidth(text);
@@ -327,7 +590,22 @@ export function truncateText(text: string, maxWidth: number): string {
 }
 
 /**
- * Pads text to specified width, handling ANSI codes.
+ * Pads text to a specified width with trailing spaces, handling ANSI codes.
+ *
+ * Uses {@link getStringWidth} to calculate visible width, ignoring ANSI
+ * escape codes. If text is already at or exceeds the target width,
+ * returns it unchanged.
+ *
+ * @param text - Text to pad (may contain ANSI codes)
+ * @param width - Target visible width
+ * @returns Text padded with trailing spaces to reach target width
+ *
+ * @example
+ * ```typescript
+ * padText("Hi", 10);                        // "Hi        "
+ * padText("\x1b[32mHi\x1b[0m", 10);          // "\x1b[32mHi\x1b[0m        "
+ * padText("Already long enough", 5);        // "Already long enough"
+ * ```
  */
 export function padText(text: string, width: number): string {
 	const visibleWidth = getStringWidth(text);
@@ -345,7 +623,37 @@ export function padText(text: string, width: number): string {
 // ============================================================================
 
 /**
- * Renders data as an ASCII table.
+ * Renders an array of objects as an ASCII table with borders.
+ *
+ * Automatically calculates column widths based on content unless
+ * overridden in options. Supports custom header labels and
+ * truncates cell content that exceeds column width.
+ *
+ * @param data - Array of objects to render as rows
+ * @param options - Table rendering options
+ * @returns Formatted table string with borders
+ *
+ * @example
+ * ```typescript
+ * const table = renderTable(
+ *   [
+ *     { id: 1, name: "Alice", status: "Active" },
+ *     { id: 2, name: "Bob", status: "Inactive" },
+ *   ],
+ *   {
+ *     headers: { id: "ID", name: "Name" },
+ *     columnWidths: { status: 10 },
+ *   }
+ * );
+ *
+ * console.log(table);
+ * // +----+-------+----------+
+ * // | ID | Name  | status   |
+ * // +----+-------+----------+
+ * // | 1  | Alice | Active   |
+ * // | 2  | Bob   | Inactive |
+ * // +----+-------+----------+
+ * ```
  */
 export function renderTable(data: Array<Record<string, unknown>>, options?: TableOptions): string {
 	if (data.length === 0) {
@@ -430,6 +738,31 @@ export function renderTable(data: Array<Record<string, unknown>>, options?: Tabl
 
 /**
  * Renders items as a bullet list with optional nesting.
+ *
+ * Supports both simple string items and nested items with children.
+ * Nested items are indented with 2 spaces per level.
+ *
+ * @param items - Array of list items (strings or nested items)
+ * @returns Formatted bullet list string
+ *
+ * @example
+ * ```typescript
+ * // Simple list
+ * console.log(renderList(["First", "Second", "Third"]));
+ * // - First
+ * // - Second
+ * // - Third
+ *
+ * // Nested list
+ * console.log(renderList([
+ *   "Parent item",
+ *   { text: "Item with children", children: ["Child 1", "Child 2"] },
+ * ]));
+ * // - Parent item
+ * // - Item with children
+ * //   - Child 1
+ * //   - Child 2
+ * ```
  */
 export function renderList(items: ListItem[]): string {
 	const lines: string[] = [];
@@ -457,7 +790,36 @@ export function renderList(items: ListItem[]): string {
 }
 
 /**
- * Renders hierarchical data as a tree with unicode box characters.
+ * Renders hierarchical data as a tree with unicode box-drawing characters.
+ *
+ * Uses unicode characters (not, not, |, -) for tree structure.
+ * Nested objects are rendered as child nodes; leaf values (null, primitives)
+ * are rendered as terminal nodes.
+ *
+ * @param tree - Hierarchical object to render
+ * @returns Formatted tree string with box-drawing characters
+ *
+ * @example
+ * ```typescript
+ * const tree = {
+ *   src: {
+ *     components: {
+ *       Button: null,
+ *       Input: null,
+ *     },
+ *     utils: null,
+ *   },
+ *   tests: null,
+ * };
+ *
+ * console.log(renderTree(tree));
+ * // +-- src
+ * // |   +-- components
+ * // |   |   +-- Button
+ * // |   |   L-- Input
+ * // |   L-- utils
+ * // L-- tests
+ * ```
  */
 export function renderTree(tree: Record<string, unknown>): string {
 	const lines: string[] = [];
@@ -487,7 +849,30 @@ export function renderTree(tree: Record<string, unknown>): string {
 }
 
 /**
- * Renders a progress bar.
+ * Renders a progress bar with filled and empty segments.
+ *
+ * Uses unicode block characters: filled segments, empty segments.
+ * Optionally displays percentage after the bar.
+ *
+ * Handles edge cases:
+ * - `total <= 0`: Returns empty bar with 0%
+ * - `current > total`: Caps at 100%
+ * - `current < 0`: Floors at 0%
+ *
+ * @param options - Progress bar configuration
+ * @returns Formatted progress bar string
+ *
+ * @example
+ * ```typescript
+ * renderProgress({ current: 50, total: 100 });
+ * // [##########..........]
+ *
+ * renderProgress({ current: 75, total: 100, showPercent: true });
+ * // [###############.....] 75%
+ *
+ * renderProgress({ current: 30, total: 100, width: 10 });
+ * // [###.......]
+ * ```
  */
 export function renderProgress(options: ProgressOptions): string {
 	const { current, total, width = 20, showPercent = false } = options;
@@ -516,7 +901,32 @@ export function renderProgress(options: ProgressOptions): string {
 // ============================================================================
 
 /**
- * Renders markdown to terminal with styling.
+ * Renders markdown to terminal with ANSI styling.
+ *
+ * Supports the following markdown elements:
+ * - Headings (`# Heading`) - rendered bold
+ * - Bold (`**text**` or `__text__`) - rendered bold
+ * - Italic (`*text*` or `_text_`) - rendered italic
+ * - Inline code (`` `code` ``) - rendered cyan
+ * - Code blocks (` ``` `) - rendered dim
+ *
+ * When colors are not supported, markdown syntax is stripped
+ * but text content is preserved.
+ *
+ * @param markdown - Markdown text to render
+ * @returns Terminal-formatted string with ANSI codes
+ *
+ * @example
+ * ```typescript
+ * const md = `# Heading
+ *
+ * Some **bold** and *italic* text.
+ *
+ * Use \`npm install\` to install.
+ * `;
+ *
+ * console.log(renderMarkdown(md));
+ * ```
  */
 export function renderMarkdown(markdown: string): string {
 	const colorEnabled = supportsColor();
@@ -580,7 +990,22 @@ export function renderMarkdown(markdown: string): string {
 }
 
 /**
- * Renders JSON with syntax coloring.
+ * Renders data as pretty-printed JSON.
+ *
+ * Uses `JSON.stringify` with 2-space indentation.
+ * Suitable for displaying structured data in terminal output.
+ *
+ * @param data - Data to render as JSON
+ * @returns Pretty-printed JSON string
+ *
+ * @example
+ * ```typescript
+ * console.log(renderJson({ name: "test", value: 42 }));
+ * // {
+ * //   "name": "test",
+ * //   "value": 42
+ * // }
+ * ```
  */
 export function renderJson(data: unknown): string {
 	const json = JSON.stringify(data, null, 2);
@@ -588,7 +1013,18 @@ export function renderJson(data: unknown): string {
 }
 
 /**
- * Renders plain text with basic formatting.
+ * Renders plain text unchanged.
+ *
+ * This is a pass-through function that returns the input text as-is.
+ * Useful as a placeholder or for consistent API across render functions.
+ *
+ * @param text - Text to render
+ * @returns The input text unchanged
+ *
+ * @example
+ * ```typescript
+ * renderText("Hello, World!"); // "Hello, World!"
+ * ```
  */
 export function renderText(text: string): string {
 	return text;


### PR DESCRIPTION
## Summary

Adds comprehensive documentation to `@outfitter/ui` package:

- **README.md** — Installation, quick start, color tokens, output shapes, text formatting, terminal detection
- **CHANGELOG.md** — Initial 0.1.0 release notes
- **TSDoc comments** — All exported functions, types, and interfaces documented with `@param`, `@returns`, and `@example`

## Highlights

- Documents semantic color tokens (success, warning, error, info)
- Shows NO_COLOR/FORCE_COLOR/TTY detection behavior
- Covers all output shapes: tables, lists, trees, progress bars
- Explains ANSI-aware text formatting (truncate, wrap, pad)

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)