### PR TITLE
feat(state): add encodeCursor/decodeCursor for pagination

### DIFF
--- a/packages/state/src/__tests__/state.test.ts
+++ b/packages/state/src/__tests__/state.test.ts
@@ -52,6 +52,21 @@ function cleanupTmpDir(dir: string): void {
 	}
 }
 
+const base64Encoder = new TextEncoder();
+
+function toBase64(value: string): string {
+	const bytes = base64Encoder.encode(value);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary);
+}
+
+function toBase64Url(value: string): string {
+	return toBase64(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 // ============================================================================
 // 1. Cursor Creation (6 tests)
 // ============================================================================
@@ -666,7 +681,7 @@ describe("Cursor Encoding", () => {
 	it("decodeCursor returns ValidationError for invalid JSON", () => {
 		// Valid base64 but not valid JSON
 		// "not json" in URL-safe base64
-		const invalidJson = Buffer.from("not json").toString("base64url");
+		const invalidJson = toBase64Url("not json");
 		const result = decodeCursor(invalidJson);
 
 		expect(Result.isError(result)).toBe(true);
@@ -678,7 +693,7 @@ describe("Cursor Encoding", () => {
 	it("decodeCursor returns ValidationError for missing required fields", () => {
 		// Valid JSON but missing required cursor fields
 		const incompleteData = { position: 10 }; // missing id, createdAt
-		const encoded = Buffer.from(JSON.stringify(incompleteData)).toString("base64url");
+		const encoded = toBase64Url(JSON.stringify(incompleteData));
 		const result = decodeCursor(encoded);
 
 		expect(Result.isError(result)).toBe(true);
@@ -693,7 +708,7 @@ describe("Cursor Encoding", () => {
 			position: -1,
 			createdAt: Date.now(),
 		};
-		const encoded = Buffer.from(JSON.stringify(invalidData)).toString("base64url");
+		const encoded = toBase64Url(JSON.stringify(invalidData));
 		const result = decodeCursor(encoded);
 
 		expect(Result.isError(result)).toBe(true);

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -377,6 +377,33 @@ function toBase64Url(base64: string): string {
 	return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+const base64Encoder = new TextEncoder();
+const base64Decoder = new TextDecoder();
+
+/**
+ * Converts UTF-8 text to standard base64.
+ */
+function toBase64(value: string): string {
+	const bytes = base64Encoder.encode(value);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary);
+}
+
+/**
+ * Converts standard base64 to UTF-8 text.
+ */
+function fromBase64(base64: string): string {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i += 1) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return base64Decoder.decode(bytes);
+}
+
 /**
  * Converts URL-safe base64 to standard base64.
  * Replaces - with +, _ with /, and adds padding if needed.
@@ -413,7 +440,7 @@ function fromBase64Url(base64Url: string): string {
 export function encodeCursor(cursor: Cursor): string {
 	const json = JSON.stringify(cursor);
 	// Encode to standard base64, then convert to URL-safe
-	const base64 = Buffer.from(json).toString("base64");
+	const base64 = toBase64(json);
 	return toBase64Url(base64);
 }
 
@@ -448,7 +475,7 @@ export function decodeCursor(
 	let json: string;
 	try {
 		const base64 = fromBase64Url(encoded);
-		json = Buffer.from(base64, "base64").toString("utf-8");
+		json = fromBase64(base64);
 	} catch {
 		return Result.err(
 			new ValidationError({


### PR DESCRIPTION
URL-safe base64 encoding (RFC 4648 Section 5) for opaque cursor tokens.
Handles encoding/decoding of pagination state for API responses.

Closes #47

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>