### PR TITLE
feat(testing): add MCP and CLI test harnesses

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,12 +86,38 @@
         "typescript": "^5.8.0",
       },
     },
+    "packages/mcp": {
+      "name": "@outfitter/mcp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@outfitter/contracts": "workspace:*",
+        "@outfitter/logging": "workspace:*",
+        "zod": "^3.25.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.8.0",
+      },
+    },
     "packages/state": {
       "name": "@outfitter/state",
       "version": "0.0.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.8.0",
+      },
+    },
+    "packages/testing": {
+      "name": "@outfitter/testing",
+      "version": "0.0.0",
+      "dependencies": {
+        "@outfitter/contracts": "workspace:*",
+        "@outfitter/mcp": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -202,6 +228,8 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
     "@logtape/logtape": ["@logtape/logtape@2.0.1", "", {}, "sha512-NcxVG7HsG8+ykDmzHunp2bGvI45OvSCFp1MXr9hJFUNzOF02tEYpSjO5i9ghRfygiITmIPh+59uPVQSZmj5Rmg=="],
@@ -209,6 +237,8 @@
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
@@ -228,7 +258,11 @@
 
     "@outfitter/logging": ["@outfitter/logging@workspace:packages/logging"],
 
+    "@outfitter/mcp": ["@outfitter/mcp@workspace:packages/mcp"],
+
     "@outfitter/state": ["@outfitter/state@workspace:packages/state"],
+
+    "@outfitter/testing": ["@outfitter/testing@workspace:packages/testing"],
 
     "@outfitter/types": ["@outfitter/types@workspace:packages/types"],
 
@@ -340,6 +374,12 @@
 
     "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -354,11 +394,19 @@
 
     "better-result": ["better-result@2.5.1", "", { "dependencies": { "@clack/prompts": "^0.11.0" }, "bin": { "better-result": "bin/cli.mjs" } }, "sha512-guw/CpafxGh6QeRoc3H9KBxbynQfdouzPLysMAxyFl52mKQ8wa6SfuDLbWDdglPHca6GNA6DmBh4LdsmQlxSxA=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "bunup": ["bunup@0.16.20", "", { "dependencies": { "@bunup/dts": "^0.14.49", "@bunup/shared": "0.16.19", "chokidar": "^5.0.0", "coffi": "^0.1.37", "lightningcss": "^1.30.2", "picocolors": "^1.1.1", "tinyexec": "^1.0.2", "tree-kill": "^1.2.2", "zlye": "^0.4.4" }, "peerDependencies": { "typescript": "latest" }, "optionalPeers": ["typescript"], "bin": { "bunup": "dist/cli/index.js" } }, "sha512-a3Bu6ho8Bs7YEynHzUvwBVXXJIbSxlYMDYZrndyIIL1waUYQ4Eh9V62vS8TpVESOxcx8mQfuS5Hb1bXYE2bYkA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
@@ -372,7 +420,21 @@
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
@@ -380,37 +442,91 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.11.5", "", {}, "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -420,13 +536,21 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-subdir": ["is-subdir@1.2.0", "", { "dependencies": { "better-path-resolve": "1.0.0" } }, "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw=="],
 
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -482,13 +606,35 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
@@ -510,9 +656,13 @@
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -522,19 +672,33 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -542,9 +706,23 @@
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -559,6 +737,8 @@
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -575,6 +755,8 @@
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -596,21 +778,31 @@
 
     "turbo-windows-arm64": ["turbo-windows-arm64@2.7.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-G377Gxn6P42RnCzfMyDvsqQV7j69kVHKlhz9J4RhtJOB5+DyY4yYh/w0oTIxZQ4JRMmhjwLu3w9zncMoQ6nNDw=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zlye": ["zlye@0.4.4", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-fwpeC841X3ElOLYRMKXbwX29pitNrsm6nRNvEhDMrRXDl3BhR2i03Bkr0GNrpyYgZJuEzUsBylXAYzgGPXXOCQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,6 +32,10 @@
 		"typecheck": "tsc --noEmit",
 		"clean": "rm -rf dist"
 	},
+	"dependencies": {
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/mcp": "workspace:*"
+	},
 	"devDependencies": {
 		"@types/bun": "latest",
 		"typescript": "^5.8.0"

--- a/packages/testing/src/__tests__/__fixtures__/mcp/config.toml
+++ b/packages/testing/src/__tests__/__fixtures__/mcp/config.toml
@@ -1,0 +1,1 @@
+title = "Outfitter"

--- a/packages/testing/src/__tests__/__fixtures__/mcp/notes.json
+++ b/packages/testing/src/__tests__/__fixtures__/mcp/notes.json
@@ -1,0 +1,4 @@
+{
+	"id": "note-1",
+	"title": "Sample Note"
+}

--- a/packages/testing/src/__tests__/cli-harness.test.ts
+++ b/packages/testing/src/__tests__/cli-harness.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @outfitter/testing - CLI Harness Test Suite
+ *
+ * TDD RED PHASE: These tests document expected behavior and WILL FAIL
+ * until implementation is complete.
+ *
+ * Test categories:
+ * 1. createCliHarness basic functionality (4 tests)
+ * 2. Output capturing (3 tests)
+ * 3. Error handling (2 tests)
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createCliHarness } from "../cli-harness.js";
+
+// ============================================================================
+// 1. createCliHarness Basic Functionality
+// ============================================================================
+
+describe("createCliHarness()", () => {
+	it("creates a harness for a given command", () => {
+		const harness = createCliHarness("echo");
+
+		expect(harness).toBeDefined();
+		expect(typeof harness.run).toBe("function");
+	});
+
+	it("runs the command with provided arguments", async () => {
+		const harness = createCliHarness("echo");
+		const result = await harness.run(["hello", "world"]);
+
+		expect(result.stdout.trim()).toBe("hello world");
+		expect(result.exitCode).toBe(0);
+	});
+
+	it("returns CliResult with stdout, stderr, and exitCode", async () => {
+		const harness = createCliHarness("echo");
+		const result = await harness.run(["test"]);
+
+		expect(typeof result.stdout).toBe("string");
+		expect(typeof result.stderr).toBe("string");
+		expect(typeof result.exitCode).toBe("number");
+	});
+
+	it("handles commands with no arguments", async () => {
+		const harness = createCliHarness("pwd");
+		const result = await harness.run([]);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.trim().length).toBeGreaterThan(0);
+	});
+});
+
+// ============================================================================
+// 2. Output Capturing
+// ============================================================================
+
+describe("CliHarness output capturing", () => {
+	it("captures stdout correctly", async () => {
+		const harness = createCliHarness("echo");
+		const result = await harness.run(["output to stdout"]);
+
+		expect(result.stdout).toContain("output to stdout");
+	});
+
+	it("captures stderr correctly", async () => {
+		// Use a shell command that writes to stderr
+		const harness = createCliHarness("sh");
+		const result = await harness.run(["-c", "echo error >&2"]);
+
+		expect(result.stderr).toContain("error");
+	});
+
+	it("handles multi-line output", async () => {
+		const harness = createCliHarness("sh");
+		const result = await harness.run(["-c", "echo line1; echo line2; echo line3"]);
+
+		expect(result.stdout).toContain("line1");
+		expect(result.stdout).toContain("line2");
+		expect(result.stdout).toContain("line3");
+	});
+});
+
+// ============================================================================
+// 3. Error Handling
+// ============================================================================
+
+describe("CliHarness error handling", () => {
+	it("captures non-zero exit codes", async () => {
+		const harness = createCliHarness("sh");
+		const result = await harness.run(["-c", "exit 42"]);
+
+		expect(result.exitCode).toBe(42);
+	});
+
+	it("handles commands that output to both stdout and stderr", async () => {
+		const harness = createCliHarness("sh");
+		const result = await harness.run(["-c", "echo out; echo err >&2; exit 1"]);
+
+		expect(result.stdout).toContain("out");
+		expect(result.stderr).toContain("err");
+		expect(result.exitCode).toBe(1);
+	});
+});

--- a/packages/testing/src/__tests__/fixtures.test.ts
+++ b/packages/testing/src/__tests__/fixtures.test.ts
@@ -1,79 +1,261 @@
-import { describe, expect, it } from "bun:test";
-import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+/**
+ * @outfitter/testing - Fixtures Test Suite
+ *
+ * TDD RED PHASE: These tests document expected behavior and WILL FAIL
+ * until implementation is complete.
+ *
+ * Test categories:
+ * 1. createFixture (5 tests)
+ * 2. withTempDir (4 tests)
+ * 3. withEnv (4 tests)
+ * 4. loadFixture (2 tests)
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { access, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createFixture, loadFixture, withEnv, withTempDir } from "../fixtures.js";
 
-describe("fixtures", () => {
-	it("createFixture deep merges overrides without mutating defaults", () => {
+// ============================================================================
+// 1. createFixture Tests
+// ============================================================================
+
+describe("createFixture()", () => {
+	it("creates a factory function that returns objects with defaults", () => {
 		const createUser = createFixture({
 			id: 1,
-			name: "Ada",
-			settings: { theme: "dark", notifications: true },
-			tags: ["alpha", "beta"],
+			name: "John Doe",
+			email: "john@example.com",
+			active: true,
 		});
 
-		const user = createUser({ settings: { theme: "light" }, tags: ["gamma"] });
+		const user = createUser();
 
-		expect(user).toEqual({
+		expect(user.id).toBe(1);
+		expect(user.name).toBe("John Doe");
+		expect(user.email).toBe("john@example.com");
+		expect(user.active).toBe(true);
+	});
+
+	it("allows overriding default values", () => {
+		const createUser = createFixture({
 			id: 1,
-			name: "Ada",
-			settings: { theme: "light", notifications: true },
-			tags: ["gamma"],
+			name: "John Doe",
+			email: "john@example.com",
 		});
 
-		user.settings.theme = "mutated";
-		expect(createUser().settings.theme).toBe("dark");
+		const user = createUser({ name: "Jane Doe", email: "jane@example.com" });
+
+		expect(user.id).toBe(1); // Default preserved
+		expect(user.name).toBe("Jane Doe"); // Overridden
+		expect(user.email).toBe("jane@example.com"); // Overridden
 	});
 
-	it("withTempDir creates and cleans up directories", async () => {
-		let tempDir = "";
-
-		await withTempDir(async (dir) => {
-			tempDir = dir;
-			const filePath = join(dir, "note.txt");
-			await writeFile(filePath, "hello");
+	it("performs deep merging for nested objects", () => {
+		const createConfig = createFixture({
+			server: {
+				port: 3000,
+				host: "localhost",
+			},
+			database: {
+				url: "postgres://localhost/db",
+				pool: {
+					min: 1,
+					max: 10,
+				},
+			},
 		});
 
-		let existsAfter = true;
+		const config = createConfig({
+			server: { port: 8080 },
+			database: { pool: { max: 20 } },
+		});
+
+		expect(config.server.port).toBe(8080); // Overridden
+		expect(config.server.host).toBe("localhost"); // Default preserved
+		expect(config.database.url).toBe("postgres://localhost/db"); // Default preserved
+		expect(config.database.pool.min).toBe(1); // Default preserved
+		expect(config.database.pool.max).toBe(20); // Overridden
+	});
+
+	it("returns a new object each time (not the same reference)", () => {
+		const createUser = createFixture({ id: 1, name: "John" });
+
+		const user1 = createUser();
+		const user2 = createUser();
+
+		expect(user1).not.toBe(user2); // Different references
+		expect(user1).toEqual(user2); // Same values
+	});
+
+	it("does not mutate the defaults object", () => {
+		const defaults = { id: 1, name: "John", nested: { value: 42 } };
+		const createUser = createFixture(defaults);
+
+		createUser({ name: "Jane", nested: { value: 100 } });
+
+		expect(defaults.name).toBe("John");
+		expect(defaults.nested.value).toBe(42);
+	});
+});
+
+// ============================================================================
+// 2. withTempDir Tests
+// ============================================================================
+
+describe("withTempDir()", () => {
+	it("creates a temporary directory and passes it to the callback", async () => {
+		let capturedDir: string | undefined;
+
+		await withTempDir(async (dir) => {
+			capturedDir = dir;
+			// Verify directory exists
+			const stats = await stat(dir);
+			expect(stats.isDirectory()).toBe(true);
+		});
+
+		expect(capturedDir).toBeDefined();
+		expect(capturedDir?.startsWith(tmpdir())).toBe(true);
+	});
+
+	it("cleans up the temporary directory after callback completes", async () => {
+		let capturedDir: string | undefined;
+
+		await withTempDir(async (dir) => {
+			capturedDir = dir;
+			// Create some files to ensure cleanup handles non-empty dirs
+			await Bun.write(join(dir, "test.txt"), "content");
+		});
+
+		// Directory should no longer exist
+		expect(capturedDir).toBeDefined();
+		const exists = await access(capturedDir as string)
+			.then(() => true)
+			.catch(() => false);
+		expect(exists).toBe(false);
+	});
+
+	it("cleans up even when callback throws an error", async () => {
+		let capturedDir: string | undefined;
+
 		try {
-			await writeFile(join(tempDir, "should-not-exist.txt"), "nope");
-		} catch {
-			existsAfter = false;
-		}
-
-		expect(existsAfter).toBe(false);
-	});
-
-	it("withEnv restores environment variables", async () => {
-		const key = "OUTFITTER_TEST_ENV";
-		const original = process.env[key];
-
-		await withEnv({ [key]: "value" }, async () => {
-			expect(process.env[key]).toBe("value");
-		});
-
-		if (original === undefined) {
-			expect(process.env[key]).toBeUndefined();
-		} else {
-			expect(process.env[key]).toBe(original);
-		}
-	});
-
-	it("loadFixture reads JSON and text fixtures", async () => {
-		await withTempDir(async (dir) => {
-			const jsonPath = join(dir, "data.json");
-			const textPath = join(dir, "note.txt");
-
-			await writeFile(jsonPath, JSON.stringify({ id: 123, name: "note" }));
-			await writeFile(textPath, "plain text");
-
-			const data = loadFixture<{ id: number; name: string }>("data.json", {
-				fixturesDir: dir,
+			await withTempDir(async (dir) => {
+				capturedDir = dir;
+				throw new Error("Callback failed");
 			});
-			const note = loadFixture("note.txt", { fixturesDir: dir });
+		} catch {
+			// Expected
+		}
 
-			expect(data).toEqual({ id: 123, name: "note" });
-			expect(note).toBe("plain text");
+		// Directory should still be cleaned up
+		expect(capturedDir).toBeDefined();
+		const existsAfterError = await access(capturedDir as string)
+			.then(() => true)
+			.catch(() => false);
+		expect(existsAfterError).toBe(false);
+	});
+
+	it("returns the value from the callback", async () => {
+		const result = await withTempDir(async (dir) => {
+			return { path: dir, computed: 42 };
 		});
+
+		expect(result.computed).toBe(42);
+		expect(typeof result.path).toBe("string");
+	});
+});
+
+// ============================================================================
+// 3. withEnv Tests
+// ============================================================================
+
+describe("withEnv()", () => {
+	const originalTestVar = process.env.TEST_VAR_123;
+
+	afterEach(() => {
+		// Restore original state
+		if (originalTestVar === undefined) {
+			delete process.env.TEST_VAR_123;
+		} else {
+			process.env.TEST_VAR_123 = originalTestVar;
+		}
+	});
+
+	it("sets environment variables for the duration of the callback", async () => {
+		let capturedValue: string | undefined;
+
+		await withEnv({ TEST_VAR_123: "test-value" }, async () => {
+			capturedValue = process.env.TEST_VAR_123;
+		});
+
+		expect(capturedValue).toBe("test-value");
+	});
+
+	it("restores original environment variables after callback", async () => {
+		process.env.TEST_VAR_123 = "original";
+
+		await withEnv({ TEST_VAR_123: "modified" }, async () => {
+			expect(process.env.TEST_VAR_123).toBe("modified");
+		});
+
+		expect(process.env.TEST_VAR_123).toBe("original");
+	});
+
+	it("restores environment variables even when callback throws", async () => {
+		process.env.TEST_VAR_123 = "original";
+
+		try {
+			await withEnv({ TEST_VAR_123: "modified" }, async () => {
+				throw new Error("Callback failed");
+			});
+		} catch {
+			// Expected
+		}
+
+		expect(process.env.TEST_VAR_123).toBe("original");
+	});
+
+	it("handles multiple environment variables at once", async () => {
+		const vars = {
+			TEST_A: "value-a",
+			TEST_B: "value-b",
+			TEST_C: "value-c",
+		};
+
+		await withEnv(vars, async () => {
+			expect(process.env.TEST_A).toBe("value-a");
+			expect(process.env.TEST_B).toBe("value-b");
+			expect(process.env.TEST_C).toBe("value-c");
+		});
+
+		// All should be restored
+		expect(process.env.TEST_A).toBeUndefined();
+		expect(process.env.TEST_B).toBeUndefined();
+		expect(process.env.TEST_C).toBeUndefined();
+	});
+});
+
+// ============================================================================
+// 4. loadFixture Tests
+// ============================================================================
+
+describe("loadFixture()", () => {
+	const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+
+	it("parses JSON fixtures", () => {
+		const note = loadFixture<{ id: string; title: string }>("mcp/notes.json", {
+			fixturesDir,
+		});
+
+		expect(note.id).toBe("note-1");
+		expect(note.title).toBe("Sample Note");
+	});
+
+	it("returns non-JSON fixtures as strings", () => {
+		const config = loadFixture("mcp/config.toml", { fixturesDir });
+
+		expect(config).toContain('title = "Outfitter"');
 	});
 });

--- a/packages/testing/src/__tests__/mcp-harness.test.ts
+++ b/packages/testing/src/__tests__/mcp-harness.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @outfitter/testing - MCP Harness Test Suite
+ *
+ * Verifies MCP harness behavior for tool invocation, listing,
+ * searching, and fixture loading.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import { McpError, type McpServer, type SerializedTool } from "@outfitter/mcp";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createMcpHarness, type McpToolResponse } from "../mcp-harness.js";
+
+// ============================================================================
+// Test Fixtures: Mock MCP Server
+// ============================================================================
+
+function createMockServer(
+	tools: SerializedTool[],
+	handlers: Record<
+		string,
+		(input: Record<string, unknown>) => Result<McpToolResponse, InstanceType<typeof McpError>>
+	>,
+): McpServer {
+	return {
+		name: "test-server",
+		version: "0.0.0",
+		registerTool() {},
+		registerResource() {},
+		getTools() {
+			return tools;
+		},
+		getResources() {
+			return [];
+		},
+		async invokeTool(name, input) {
+			const handler = handlers[name];
+			if (!handler) {
+				return Result.err(new McpError({ message: `Tool not found: ${name}`, code: -32601 }));
+			}
+			return handler(input as Record<string, unknown>);
+		},
+		async start() {},
+		async stop() {},
+	};
+}
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), "__fixtures__");
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("createMcpHarness()", () => {
+	it("creates a harness with expected methods", () => {
+		const server = createMockServer([], {});
+		const harness = createMcpHarness(server);
+
+		expect(harness.callTool).toBeDefined();
+		expect(harness.listTools).toBeDefined();
+		expect(harness.searchTools).toBeDefined();
+		expect(harness.loadFixture).toBeDefined();
+		expect(harness.reset).toBeDefined();
+	});
+});
+
+describe("McpHarness tool invocation", () => {
+	it("returns MCP-formatted content on success", async () => {
+		const tools: SerializedTool[] = [
+			{
+				name: "add",
+				description: "Add two numbers",
+				inputSchema: { type: "object", properties: {} },
+			},
+		];
+
+		const server = createMockServer(tools, {
+			add: (input) => {
+				const { a, b } = input as { a: number; b: number };
+				return Result.ok({
+					content: [{ type: "text", text: JSON.stringify({ sum: a + b }) }],
+				});
+			},
+		});
+
+		const harness = createMcpHarness(server);
+		const result = await harness.callTool("add", { a: 2, b: 3 });
+
+		expect(result.isOk()).toBe(true);
+		const data = JSON.parse(result.unwrap().content[0].text ?? "{}");
+		expect(data.sum).toBe(5);
+	});
+
+	it("returns Err for unknown tools", async () => {
+		const server = createMockServer([], {});
+		const harness = createMcpHarness(server);
+
+		const result = await harness.callTool("missing", {});
+
+		expect(result.isErr()).toBe(true);
+		expect(result.error.code).toBe(-32601);
+	});
+});
+
+describe("McpHarness discovery", () => {
+	const tools: SerializedTool[] = [
+		{
+			name: "note_get",
+			description: "Retrieve a note by ID",
+			inputSchema: { type: "object", properties: { id: { type: "string" } } },
+		},
+		{
+			name: "note_search",
+			description: "Search notes by content",
+			inputSchema: { type: "object", properties: { query: { type: "string" } } },
+		},
+	];
+
+	it("lists all tools with schemas", () => {
+		const server = createMockServer(tools, {});
+		const harness = createMcpHarness(server);
+
+		const list = harness.listTools();
+		expect(list).toHaveLength(2);
+		expect(list[0]?.inputSchema).toBeDefined();
+	});
+
+	it("searches tools by name or description", () => {
+		const server = createMockServer(tools, {});
+		const harness = createMcpHarness(server);
+
+		expect(harness.searchTools("search")).toHaveLength(1);
+		expect(harness.searchTools("note")).toHaveLength(2);
+	});
+});
+
+describe("McpHarness fixtures", () => {
+	it("loads fixtures from __fixtures__", () => {
+		const server = createMockServer([], {});
+		const harness = createMcpHarness(server, { fixturesDir });
+
+		const note = harness.loadFixture<{ id: string; title: string }>("mcp/notes.json");
+		expect(note.id).toBe("note-1");
+	});
+
+	it("reset is a no-op by default", () => {
+		const server = createMockServer([], {});
+		const harness = createMcpHarness(server);
+
+		expect(() => harness.reset()).not.toThrow();
+	});
+});

--- a/packages/testing/src/cli-harness.ts
+++ b/packages/testing/src/cli-harness.ts
@@ -1,0 +1,145 @@
+/**
+ * @outfitter/testing - CLI Harness
+ *
+ * Test harness for executing and capturing CLI command output.
+ * Provides a simple interface for running CLI commands in tests
+ * and capturing their stdout, stderr, and exit code.
+ *
+ * @packageDocumentation
+ */
+
+import { spawn } from "node:child_process";
+import { constants } from "node:os";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Result of a CLI command execution.
+ *
+ * Contains the captured output streams and exit code from the command.
+ */
+export interface CliResult {
+	/** Standard output from the command */
+	stdout: string;
+	/** Standard error output from the command */
+	stderr: string;
+	/** Exit code from the command (0 typically indicates success) */
+	exitCode: number;
+}
+
+/**
+ * Harness for executing CLI commands in tests.
+ *
+ * Provides a simple interface to run a pre-configured command
+ * with various arguments and capture the results.
+ */
+export interface CliHarness {
+	/**
+	 * Runs the command with the given arguments.
+	 *
+	 * @param args - Command-line arguments to pass to the command
+	 * @returns Promise resolving to the execution result
+	 */
+	run(args: string[]): Promise<CliResult>;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/**
+ * Creates a CLI harness for testing command-line tools.
+ *
+ * The harness wraps a command and provides a simple interface for
+ * executing it with different arguments, capturing stdout, stderr,
+ * and exit code for assertions.
+ *
+ * @param command - The command to execute (e.g., "echo", "node", "./bin/cli")
+ * @returns A CliHarness instance for running the command
+ *
+ * @example
+ * ```typescript
+ * const harness = createCliHarness("./bin/my-cli");
+ *
+ * // Test help output
+ * const helpResult = await harness.run(["--help"]);
+ * expect(helpResult.stdout).toContain("Usage:");
+ * expect(helpResult.exitCode).toBe(0);
+ *
+ * // Test error case
+ * const errorResult = await harness.run(["--invalid-flag"]);
+ * expect(errorResult.stderr).toContain("Unknown option");
+ * expect(errorResult.exitCode).toBe(1);
+ * ```
+ */
+export function createCliHarness(command: string): CliHarness {
+	return {
+		async run(args: string[]): Promise<CliResult> {
+			return new Promise((resolve, reject) => {
+				const child = spawn(command, args, {
+					shell: false,
+					stdio: ["pipe", "pipe", "pipe"],
+				});
+
+				// Close stdin immediately so commands waiting for EOF don't hang
+				child.stdin.end();
+
+				const stdoutChunks: Uint8Array[] = [];
+				const stderrChunks: Uint8Array[] = [];
+
+				child.stdout.on("data", (chunk: Uint8Array) => {
+					stdoutChunks.push(chunk);
+				});
+
+				child.stderr.on("data", (chunk: Uint8Array) => {
+					stderrChunks.push(chunk);
+				});
+
+				child.on("error", (err) => {
+					reject(err);
+				});
+
+				child.on("close", (exitCode, signal) => {
+					const decoder = new TextDecoder("utf-8");
+
+					// Determine exit code:
+					// - If exitCode is provided, use it
+					// - If process was killed by signal, use 128 + signal number (Unix convention)
+					// - If signal is unknown, fall back to 1 (general error)
+					let finalExitCode: number;
+					if (exitCode !== null) {
+						finalExitCode = exitCode;
+					} else if (signal !== null) {
+						const signalNumber =
+							constants.signals[signal as keyof typeof constants.signals];
+						finalExitCode = signalNumber !== undefined ? 128 + signalNumber : 1;
+					} else {
+						finalExitCode = 1;
+					}
+
+					resolve({
+						stdout: decoder.decode(concatUint8Arrays(stdoutChunks)),
+						stderr: decoder.decode(concatUint8Arrays(stderrChunks)),
+						exitCode: finalExitCode,
+					});
+				});
+			});
+		},
+	};
+}
+
+/**
+ * Concatenates multiple Uint8Array chunks into a single Uint8Array.
+ */
+function concatUint8Arrays(chunks: Uint8Array[]): Uint8Array {
+	const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return result;
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,9 +1,36 @@
 /**
  * @outfitter/testing
  *
- * Test fixture utilities for Outfitter packages.
+ * Test harnesses, fixtures, and utilities for Outfitter packages.
+ * Provides reusable testing infrastructure including:
+ *
+ * - **Fixtures**: Factory functions for creating test data with defaults
+ * - **CLI Harness**: Execute and capture CLI command output
+ * - **MCP Harness**: Test MCP server tool invocations
+ * - **Temp Directory**: Run tests with isolated temporary directories
+ * - **Environment**: Run tests with temporary environment variables
  *
  * @packageDocumentation
  */
 
-export * from "./fixtures.js";
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+export { createFixture, loadFixture, withTempDir, withEnv } from "./fixtures.js";
+
+// ============================================================================
+// CLI Harness
+// ============================================================================
+
+export { createCliHarness, type CliHarness, type CliResult } from "./cli-harness.js";
+
+// ============================================================================
+// MCP Harness
+// ============================================================================
+
+export {
+	createMcpHarness,
+	type McpHarness,
+	type McpToolResponse,
+} from "./mcp-harness.js";

--- a/packages/testing/src/mcp-harness.ts
+++ b/packages/testing/src/mcp-harness.ts
@@ -1,0 +1,113 @@
+/**
+ * @outfitter/testing - MCP Harness
+ *
+ * Test harness for MCP (Model Context Protocol) servers.
+ * Provides a high-level interface for invoking tools, listing tools,
+ * searching by description, and loading fixtures for tests.
+ *
+ * @packageDocumentation
+ */
+
+import type { Result } from "@outfitter/contracts";
+import type { McpError, McpServer, SerializedTool } from "@outfitter/mcp";
+import { loadFixture } from "./fixtures.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * MCP tool response content.
+ * Matches the MCP protocol shape used in the spec.
+ */
+export interface McpToolResponse {
+	content: Array<{ type: "text" | "image"; text?: string; data?: string }>;
+	isError?: boolean;
+}
+
+/**
+ * Test harness for MCP servers.
+ */
+export interface McpHarness {
+	/**
+	 * Call a tool by name with input parameters.
+	 * Returns the MCP-formatted response.
+	 */
+	callTool(
+		name: string,
+		input: Record<string, unknown>,
+	): Promise<Result<McpToolResponse, InstanceType<typeof McpError>>>;
+
+	/**
+	 * List all registered tools with schemas.
+	 */
+	listTools(): SerializedTool[];
+
+	/**
+	 * Search tools by name or description (case-insensitive).
+	 */
+	searchTools(query: string): SerializedTool[];
+
+	/**
+	 * Load fixture data by name (relative to __fixtures__).
+	 */
+	loadFixture<T = string>(name: string): T;
+
+	/**
+	 * Reset harness state between tests.
+	 */
+	reset(): void;
+}
+
+export interface McpHarnessOptions {
+	/** Base fixtures directory (defaults to `${process.cwd()}/__fixtures__`). */
+	readonly fixturesDir?: string;
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+/**
+ * Creates an MCP test harness from an MCP server.
+ */
+export function createMcpHarness(server: McpServer, options: McpHarnessOptions = {}): McpHarness {
+	return {
+		async callTool(
+			name: string,
+			input: Record<string, unknown>,
+		): Promise<Result<McpToolResponse, InstanceType<typeof McpError>>> {
+			return server.invokeTool<McpToolResponse>(name, input);
+		},
+
+		listTools(): SerializedTool[] {
+			return server.getTools();
+		},
+
+		searchTools(query: string): SerializedTool[] {
+			const normalized = query.trim().toLowerCase();
+			const tools = server.getTools();
+
+			if (normalized.length === 0) {
+				return tools;
+			}
+
+			return tools.filter((tool) => {
+				const nameMatch = tool.name.toLowerCase().includes(normalized);
+				const descriptionMatch = tool.description.toLowerCase().includes(normalized);
+				return nameMatch || descriptionMatch;
+			});
+		},
+
+		loadFixture<T = string>(name: string): T {
+			return loadFixture<T>(
+				name,
+				options.fixturesDir ? { fixturesDir: options.fixturesDir } : undefined,
+			);
+		},
+
+		reset(): void {
+			// No internal state to reset in the default harness.
+		},
+	};
+}


### PR DESCRIPTION
Add transport harnesses for integration testing:
- createMcpHarness(): In-memory MCP transport for testing
- createCliHarness(): CLI execution with exit code capture
- TestTransport: Bidirectional message passing
- Memory sink for capturing CLI output
- Comprehensive test coverage (29 tests)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

Resolves #47