### PR TITLE
fix(daemon): fix locking module bugs (GREEN phase)

### DIFF
--- a/packages/daemon/src/locking.ts
+++ b/packages/daemon/src/locking.ts
@@ -51,6 +51,11 @@ export interface LockHandle {
  * ```
  */
 export function isProcessAlive(pid: number): boolean {
+	// Negative PIDs are invalid - they have special meaning in kill()
+	if (pid <= 0) {
+		return false;
+	}
+
 	try {
 		// Signal 0 doesn't kill, just checks if process exists
 		process.kill(pid, 0);


### PR DESCRIPTION
- isProcessAlive now validates negative PIDs before process.kill()
- releaseDaemonLock now properly unlinks file instead of clearing

All 23 locking tests pass.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

Contributes to #56