### PR TITLE
fix(errors): avoid TaggedError extends warnings

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,6 +42,7 @@ export type { Env } from "./env.js";
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { TaggedErrorClass } from "@outfitter/contracts";
 import { NotFoundError, Result, TaggedError, ValidationError } from "@outfitter/contracts";
 import JSON5 from "json5";
 import { parse as parseToml } from "smol-toml";
@@ -51,6 +52,20 @@ import type { ZodSchema } from "zod";
 // ============================================================================
 // Error Types
 // ============================================================================
+
+type ParseErrorFields = {
+	/** Human-readable error message describing the parse failure */
+	message: string;
+	/** Name of the file that failed to parse */
+	filename: string;
+	/** Line number where the error occurred (if available) */
+	line?: number;
+	/** Column number where the error occurred (if available) */
+	column?: number;
+};
+
+const ParseErrorBase: TaggedErrorClass<"ParseError", ParseErrorFields> =
+	TaggedError("ParseError")<ParseErrorFields>();
 
 /**
  * Error thrown when a configuration file cannot be parsed.
@@ -66,16 +81,7 @@ import type { ZodSchema } from "zod";
  * }
  * ```
  */
-export class ParseError extends TaggedError("ParseError")<{
-	/** Human-readable error message describing the parse failure */
-	message: string;
-	/** Name of the file that failed to parse */
-	filename: string;
-	/** Line number where the error occurred (if available) */
-	line?: number;
-	/** Column number where the error occurred (if available) */
-	column?: number;
-}>() {
+export class ParseError extends ParseErrorBase {
 	readonly category = "validation" as const;
 }
 
@@ -103,7 +109,9 @@ export class ParseError extends TaggedError("ParseError")<{
  * ```
  */
 export function getConfigDir(appName: string): string {
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const xdgConfigHome = process.env["XDG_CONFIG_HOME"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const home = process.env["HOME"] ?? "";
 
 	const baseDir = xdgConfigHome ?? join(home, ".config");
@@ -130,7 +138,9 @@ export function getConfigDir(appName: string): string {
  * ```
  */
 export function getDataDir(appName: string): string {
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const xdgDataHome = process.env["XDG_DATA_HOME"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const home = process.env["HOME"] ?? "";
 
 	const baseDir = xdgDataHome ?? join(home, ".local", "share");
@@ -157,7 +167,9 @@ export function getDataDir(appName: string): string {
  * ```
  */
 export function getCacheDir(appName: string): string {
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const xdgCacheHome = process.env["XDG_CACHE_HOME"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const home = process.env["HOME"] ?? "";
 
 	const baseDir = xdgCacheHome ?? join(home, ".cache");
@@ -184,7 +196,9 @@ export function getCacheDir(appName: string): string {
  * ```
  */
 export function getStateDir(appName: string): string {
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const xdgStateHome = process.env["XDG_STATE_HOME"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const home = process.env["HOME"] ?? "";
 
 	const baseDir = xdgStateHome ?? join(home, ".local", "state");
@@ -562,7 +576,9 @@ function findConfigFile(dir: string): string | undefined {
  * @internal
  */
 function getDefaultSearchPaths(appName: string): string[] {
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const xdgConfigHome = process.env["XDG_CONFIG_HOME"];
+	// biome-ignore lint/complexity/useLiteralKeys: noPropertyAccessFromIndexSignature requires bracket notation
 	const home = process.env["HOME"] ?? "";
 	const defaultConfigPath = join(home, ".config", appName);
 

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -1,4 +1,5 @@
 import { TaggedError } from "better-result";
+import type { TaggedErrorClass } from "better-result";
 
 /**
  * Error categories for classification, exit codes, and HTTP status mapping.
@@ -93,6 +94,128 @@ export function getStatusCode(category: ErrorCategory): number {
 // Concrete Error Classes
 // ============================================================================
 
+// Base classes avoid TS9021 warnings from extending expressions.
+const ValidationErrorBase: TaggedErrorClass<
+	"ValidationError",
+	{
+		message: string;
+		field?: string;
+	}
+> = TaggedError("ValidationError")<{
+	message: string;
+	field?: string;
+}>();
+
+const AssertionErrorBase: TaggedErrorClass<
+	"AssertionError",
+	{
+		message: string;
+	}
+> = TaggedError("AssertionError")<{
+	message: string;
+}>();
+
+const NotFoundErrorBase: TaggedErrorClass<
+	"NotFoundError",
+	{
+		message: string;
+		resourceType: string;
+		resourceId: string;
+	}
+> = TaggedError("NotFoundError")<{
+	message: string;
+	resourceType: string;
+	resourceId: string;
+}>();
+
+const ConflictErrorBase: TaggedErrorClass<
+	"ConflictError",
+	{
+		message: string;
+		context?: Record<string, unknown>;
+	}
+> = TaggedError("ConflictError")<{
+	message: string;
+	context?: Record<string, unknown>;
+}>();
+
+const PermissionErrorBase: TaggedErrorClass<
+	"PermissionError",
+	{
+		message: string;
+		context?: Record<string, unknown>;
+	}
+> = TaggedError("PermissionError")<{
+	message: string;
+	context?: Record<string, unknown>;
+}>();
+
+const TimeoutErrorBase: TaggedErrorClass<
+	"TimeoutError",
+	{
+		message: string;
+		operation: string;
+		timeoutMs: number;
+	}
+> = TaggedError("TimeoutError")<{
+	message: string;
+	operation: string;
+	timeoutMs: number;
+}>();
+
+const RateLimitErrorBase: TaggedErrorClass<
+	"RateLimitError",
+	{
+		message: string;
+		retryAfterSeconds?: number;
+	}
+> = TaggedError("RateLimitError")<{
+	message: string;
+	retryAfterSeconds?: number;
+}>();
+
+const NetworkErrorBase: TaggedErrorClass<
+	"NetworkError",
+	{
+		message: string;
+		context?: Record<string, unknown>;
+	}
+> = TaggedError("NetworkError")<{
+	message: string;
+	context?: Record<string, unknown>;
+}>();
+
+const InternalErrorBase: TaggedErrorClass<
+	"InternalError",
+	{
+		message: string;
+		context?: Record<string, unknown>;
+	}
+> = TaggedError("InternalError")<{
+	message: string;
+	context?: Record<string, unknown>;
+}>();
+
+const AuthErrorBase: TaggedErrorClass<
+	"AuthError",
+	{
+		message: string;
+		reason?: "missing" | "invalid" | "expired";
+	}
+> = TaggedError("AuthError")<{
+	message: string;
+	reason?: "missing" | "invalid" | "expired";
+}>();
+
+const CancelledErrorBase: TaggedErrorClass<
+	"CancelledError",
+	{
+		message: string;
+	}
+> = TaggedError("CancelledError")<{
+	message: string;
+}>();
+
 /**
  * Input validation failed.
  *
@@ -101,10 +224,7 @@ export function getStatusCode(category: ErrorCategory): number {
  * new ValidationError({ message: "Email format invalid", field: "email" });
  * ```
  */
-export class ValidationError extends TaggedError("ValidationError")<{
-	message: string;
-	field?: string;
-}>() {
+export class ValidationError extends ValidationErrorBase {
 	readonly category = "validation" as const;
 
 	exitCode(): number {
@@ -141,9 +261,7 @@ export class ValidationError extends TaggedError("ValidationError")<{
  *
  * @see ValidationError - For user input validation failures (HTTP 400)
  */
-export class AssertionError extends TaggedError("AssertionError")<{
-	message: string;
-}>() {
+export class AssertionError extends AssertionErrorBase {
 	readonly category = "internal" as const;
 
 	exitCode(): number {
@@ -163,11 +281,7 @@ export class AssertionError extends TaggedError("AssertionError")<{
  * new NotFoundError({ message: "note not found: abc123", resourceType: "note", resourceId: "abc123" });
  * ```
  */
-export class NotFoundError extends TaggedError("NotFoundError")<{
-	message: string;
-	resourceType: string;
-	resourceId: string;
-}>() {
+export class NotFoundError extends NotFoundErrorBase {
 	readonly category = "not_found" as const;
 
 	exitCode(): number {
@@ -187,10 +301,7 @@ export class NotFoundError extends TaggedError("NotFoundError")<{
  * new ConflictError({ message: "Resource was modified by another process" });
  * ```
  */
-export class ConflictError extends TaggedError("ConflictError")<{
-	message: string;
-	context?: Record<string, unknown>;
-}>() {
+export class ConflictError extends ConflictErrorBase {
 	readonly category = "conflict" as const;
 
 	exitCode(): number {
@@ -210,10 +321,7 @@ export class ConflictError extends TaggedError("ConflictError")<{
  * new PermissionError({ message: "Cannot delete read-only resource" });
  * ```
  */
-export class PermissionError extends TaggedError("PermissionError")<{
-	message: string;
-	context?: Record<string, unknown>;
-}>() {
+export class PermissionError extends PermissionErrorBase {
 	readonly category = "permission" as const;
 
 	exitCode(): number {
@@ -233,11 +341,7 @@ export class PermissionError extends TaggedError("PermissionError")<{
  * new TimeoutError({ message: "Database query timed out after 5000ms", operation: "Database query", timeoutMs: 5000 });
  * ```
  */
-export class TimeoutError extends TaggedError("TimeoutError")<{
-	message: string;
-	operation: string;
-	timeoutMs: number;
-}>() {
+export class TimeoutError extends TimeoutErrorBase {
 	readonly category = "timeout" as const;
 
 	exitCode(): number {
@@ -257,10 +361,7 @@ export class TimeoutError extends TaggedError("TimeoutError")<{
  * new RateLimitError({ message: "Rate limit exceeded, retry after 60s", retryAfterSeconds: 60 });
  * ```
  */
-export class RateLimitError extends TaggedError("RateLimitError")<{
-	message: string;
-	retryAfterSeconds?: number;
-}>() {
+export class RateLimitError extends RateLimitErrorBase {
 	readonly category = "rate_limit" as const;
 
 	exitCode(): number {
@@ -280,10 +381,7 @@ export class RateLimitError extends TaggedError("RateLimitError")<{
  * new NetworkError({ message: "Connection refused to api.example.com" });
  * ```
  */
-export class NetworkError extends TaggedError("NetworkError")<{
-	message: string;
-	context?: Record<string, unknown>;
-}>() {
+export class NetworkError extends NetworkErrorBase {
 	readonly category = "network" as const;
 
 	exitCode(): number {
@@ -303,10 +401,7 @@ export class NetworkError extends TaggedError("NetworkError")<{
  * new InternalError({ message: "Unexpected state in processor" });
  * ```
  */
-export class InternalError extends TaggedError("InternalError")<{
-	message: string;
-	context?: Record<string, unknown>;
-}>() {
+export class InternalError extends InternalErrorBase {
 	readonly category = "internal" as const;
 
 	exitCode(): number {
@@ -326,10 +421,7 @@ export class InternalError extends TaggedError("InternalError")<{
  * new AuthError({ message: "Invalid API key", reason: "invalid" });
  * ```
  */
-export class AuthError extends TaggedError("AuthError")<{
-	message: string;
-	reason?: "missing" | "invalid" | "expired";
-}>() {
+export class AuthError extends AuthErrorBase {
 	readonly category = "auth" as const;
 
 	exitCode(): number {
@@ -349,9 +441,7 @@ export class AuthError extends TaggedError("AuthError")<{
  * new CancelledError({ message: "Operation cancelled by user" });
  * ```
  */
-export class CancelledError extends TaggedError("CancelledError")<{
-	message: string;
-}>() {
+export class CancelledError extends CancelledErrorBase {
 	readonly category = "cancelled" as const;
 
 	exitCode(): number {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@
 
 // Re-export Result from better-result for convenience
 export { Result, TaggedError } from "better-result";
+export type { TaggedErrorClass } from "better-result";
 
 // Result utilities (extensions to better-result)
 export { combine2, combine3, orElse, unwrapOrElse } from "./result/index.js";

--- a/packages/daemon/src/errors.ts
+++ b/packages/daemon/src/errors.ts
@@ -7,11 +7,75 @@
  * @packageDocumentation
  */
 
+import type { TaggedErrorClass } from "@outfitter/contracts";
 import { TaggedError } from "@outfitter/contracts";
 
 // ============================================================================
 // Connection Error Types
 // ============================================================================
+
+const StaleSocketErrorBase: TaggedErrorClass<
+	"StaleSocketError",
+	{
+		message: string;
+		socketPath: string;
+		pid?: number;
+	}
+> = TaggedError("StaleSocketError")<{
+	message: string;
+	socketPath: string;
+	pid?: number;
+}>();
+
+const ConnectionRefusedErrorBase: TaggedErrorClass<
+	"ConnectionRefusedError",
+	{
+		message: string;
+		socketPath: string;
+	}
+> = TaggedError("ConnectionRefusedError")<{
+	message: string;
+	socketPath: string;
+}>();
+
+const ConnectionTimeoutErrorBase: TaggedErrorClass<
+	"ConnectionTimeoutError",
+	{
+		message: string;
+		socketPath: string;
+		timeoutMs: number;
+	}
+> = TaggedError("ConnectionTimeoutError")<{
+	message: string;
+	socketPath: string;
+	timeoutMs: number;
+}>();
+
+const ProtocolErrorBase: TaggedErrorClass<
+	"ProtocolError",
+	{
+		message: string;
+		socketPath: string;
+		details?: string;
+	}
+> = TaggedError("ProtocolError")<{
+	message: string;
+	socketPath: string;
+	details?: string;
+}>();
+
+const LockErrorBase: TaggedErrorClass<
+	"LockError",
+	{
+		message: string;
+		lockPath: string;
+		pid?: number;
+	}
+> = TaggedError("LockError")<{
+	message: string;
+	lockPath: string;
+	pid?: number;
+}>();
 
 /**
  * Socket exists but daemon process is dead.
@@ -28,11 +92,7 @@ import { TaggedError } from "@outfitter/contracts";
  * });
  * ```
  */
-export class StaleSocketError extends TaggedError("StaleSocketError")<{
-	message: string;
-	socketPath: string;
-	pid?: number;
-}>() {}
+export class StaleSocketError extends StaleSocketErrorBase {}
 
 /**
  * Daemon is not running (connection refused).
@@ -48,10 +108,7 @@ export class StaleSocketError extends TaggedError("StaleSocketError")<{
  * });
  * ```
  */
-export class ConnectionRefusedError extends TaggedError("ConnectionRefusedError")<{
-	message: string;
-	socketPath: string;
-}>() {}
+export class ConnectionRefusedError extends ConnectionRefusedErrorBase {}
 
 /**
  * Daemon did not respond within timeout.
@@ -68,11 +125,7 @@ export class ConnectionRefusedError extends TaggedError("ConnectionRefusedError"
  * });
  * ```
  */
-export class ConnectionTimeoutError extends TaggedError("ConnectionTimeoutError")<{
-	message: string;
-	socketPath: string;
-	timeoutMs: number;
-}>() {}
+export class ConnectionTimeoutError extends ConnectionTimeoutErrorBase {}
 
 /**
  * Invalid response format from daemon.
@@ -89,11 +142,7 @@ export class ConnectionTimeoutError extends TaggedError("ConnectionTimeoutError"
  * });
  * ```
  */
-export class ProtocolError extends TaggedError("ProtocolError")<{
-	message: string;
-	socketPath: string;
-	details?: string;
-}>() {}
+export class ProtocolError extends ProtocolErrorBase {}
 
 // ============================================================================
 // Lock Error Types
@@ -114,11 +163,7 @@ export class ProtocolError extends TaggedError("ProtocolError")<{
  * });
  * ```
  */
-export class LockError extends TaggedError("LockError")<{
-	message: string;
-	lockPath: string;
-	pid?: number;
-}>() {}
+export class LockError extends LockErrorBase {}
 
 // ============================================================================
 // Union Types

--- a/packages/daemon/src/types.ts
+++ b/packages/daemon/src/types.ts
@@ -7,13 +7,24 @@
  * @packageDocumentation
  */
 
-import type { Result } from "@outfitter/contracts";
+import type { Result, TaggedErrorClass } from "@outfitter/contracts";
 import { TaggedError } from "@outfitter/contracts";
 import type { LoggerInstance } from "@outfitter/logging";
 
 // ============================================================================
 // Error Types
 // ============================================================================
+
+const DaemonErrorBase: TaggedErrorClass<
+	"DaemonError",
+	{
+		code: DaemonErrorCode;
+		message: string;
+	}
+> = TaggedError("DaemonError")<{
+	code: DaemonErrorCode;
+	message: string;
+}>();
 
 /**
  * Error codes for daemon operations.
@@ -48,10 +59,7 @@ export type DaemonErrorCode =
  * }
  * ```
  */
-export class DaemonError extends TaggedError("DaemonError")<{
-	code: DaemonErrorCode;
-	message: string;
-}>() {}
+export class DaemonError extends DaemonErrorBase {}
 
 // ============================================================================
 // State Types

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -6,7 +6,8 @@
  * @packageDocumentation
  */
 
-import { type Result, TaggedError } from "@outfitter/contracts";
+import type { Result, TaggedErrorClass } from "@outfitter/contracts";
+import { TaggedError } from "@outfitter/contracts";
 import type { Handler, HandlerContext, KitError, Logger } from "@outfitter/contracts";
 import type { z } from "zod";
 
@@ -183,6 +184,19 @@ export interface ResourceDefinition {
 // MCP Error
 // ============================================================================
 
+const McpErrorBase: TaggedErrorClass<
+	"McpError",
+	{
+		message: string;
+		code: number;
+		context?: Record<string, unknown>;
+	}
+> = TaggedError("McpError")<{
+	message: string;
+	code: number;
+	context?: Record<string, unknown>;
+}>();
+
 /**
  * MCP-specific error with JSON-RPC error code.
  *
@@ -206,11 +220,7 @@ export interface ResourceDefinition {
  * });
  * ```
  */
-export class McpError extends TaggedError("McpError")<{
-	message: string;
-	code: number;
-	context?: Record<string, unknown>;
-}>() {
+export class McpError extends McpErrorBase {
 	/** Error category for Kit error taxonomy compatibility */
 	readonly category = "internal" as const;
 }


### PR DESCRIPTION
## Summary
- Refactor error types to avoid `TaggedError extends` warnings.
- Align error typing across config, contracts, daemon, and MCP.

## Changes
- packages/contracts/src/errors.ts
- packages/config/src/index.ts
- packages/daemon/src/errors.ts
- packages/daemon/src/types.ts
- packages/mcp/src/types.ts

## Testing
- Not run (not requested).