### PR TITLE
chore(gitattributes): prefer ours for bun lockfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Binary lockfiles: always favor ours on merge (regenerate as needed)
+bun.lock merge=ours
+bun.lockb merge=ours


### PR DESCRIPTION
## Summary
- Prefer `ours` when resolving bun lockfile conflicts.

## Changes
- .gitattributes

## Testing
- Not run (not requested).