### PR TITLE
docs(rc): add v0.1-rc docs

### DIFF
--- a/docs/v0.1-rc/DELTAS.md
+++ b/docs/v0.1-rc/DELTAS.md
@@ -1,0 +1,33 @@
+# v0.1-rc Deltas (Spec/Plan vs Current Code)
+
+**Date**: 2026-01-24
+**Baseline**: `SPEC.md` + `PLAN.md` frozen as of 2026-01-24
+
+Legend:
+- **Keep (intentional improvement)** — current code is better; document in RC notes.
+- **Align to spec** — spec is better; change code or add compatibility.
+- **Needs decision** — ambiguous; choose a direction and document.
+
+| Area | Spec/Plan Expectation | Current Code | Status | RC Action |
+| --- | --- | --- | --- | --- |
+| `@outfitter/testing` MCP harness | `createMCPTestHarness({ tools, fixtures? })` | `createMcpHarness(server, { fixturesDir? })` | **Keep + compat** | Keep server-based API; add `createMCPTestHarness` wrapper + alias for spec compatibility. |
+| `@outfitter/testing` CLI helpers | `captureCLI`, `mockStdin` | `createCliHarness(command)` | **Keep + add** | Keep harness; add `captureCLI` + `mockStdin` for unit-level testing. |
+| `@outfitter/testing` mock factories | `createTestContext`, `createTestLogger`, `createTestConfig` | Not implemented | **Align to spec** | Implement these helpers in `@outfitter/testing`. |
+| `@outfitter/testing` fixtures/utils | Spec does not mention | `createFixture`, `withTempDir`, `withEnv` | **Keep** | Document as improvement. |
+| Templates: placeholder vars | `{{name}}`, `{{packageName}}`, `{{description}}`, `{{author}}`, `{{year}}` | `{{projectName}}`, `{{binName}}`, `{{description}}` (+ `{{name}}` in basic) | **Keep + unify** | Support unified placeholder set (projectName/binName/packageName/description/author/year) with aliases; note `year` optional (for LICENSE/NOTICE headers). Author can be person or org. |
+| Templates: scripts | `test:watch`, `lint:fix`, `dev:daemon` (for daemon) | Missing `test:watch`/`lint:fix` (CLI/MCP/Daemon) | **Align to spec** | Add missing scripts; define a standard script set for templates. |
+| `outfitter init` UX | Only `init cli|mcp|daemon` | Adds `init` with `--template` (default `basic`) + `templates/basic` | **Keep + enhance** | Keep extra flexibility; add TTY wizard for template + naming (non-TTY remains deterministic). |
+| `outfitter doctor` | Not specified | Implemented | **Keep** | Keep as enhancement; document in RC notes. |
+| `@outfitter/mcp` runtime | Core tools, tool-search compat, transport auto-negotiation | Not implemented | **RC scope** | v0.1-rc: implement tool-search compatibility + minimal core tools (docs/config/query) with safe defaults/extension points; use explicit transport (stdio for now). Defer auto-negotiation; plan HTTP transport (streaming) later. |
+| `@outfitter/index` | Version headers + migration scaffolding; compactor hooks; watcher invalidation | Not implemented | **Split** | v0.1-rc: implement version headers + migration scaffold; defer compactor/watcher hooks (file Linear issues). |
+| Local scaffold install | Spec assumes working install | `bun install` fails for templates (packages not on npm) | **Hybrid** | Add `--local/--workspace` for dev + publish `0.1.0-*` tags for real installs. |
+
+## Smoke Test Notes
+- `outfitter init cli` succeeded locally (2026-01-24).
+- `bun install` inside generated project failed because `@outfitter/*` packages are not published yet.
+
+## Deferred Issues (Linear / MONO / Kit project)
+- MONO-76: MCP: add HTTP transport (streaming)
+- MONO-77: MCP: add transport auto-negotiation (stdio ↔ HTTP)
+- MONO-78: Index: add compactor hooks
+- MONO-79: Index: add watcher invalidation hooks

--- a/docs/v0.1-rc/PLAN.md
+++ b/docs/v0.1-rc/PLAN.md
@@ -1,0 +1,39 @@
+# v0.1-rc Plan (Phase 7 Reframe)
+
+**Date**: 2026-01-24
+**Status**: Active
+
+## Intent
+Freeze `SPEC.md` and `PLAN.md` as historical baselines, then drive a focused v0.1-rc scope that closes remaining gaps, documents intentional divergences, and validates real-world usage (fresh scaffold + Waymark migration).
+
+## Scope
+**In**
+- v0.1-rc backlog and validation (scaffolds, migrations, gap closures).
+- Document deltas vs spec/plan (see `DELTAS.md`) and decide keep vs align.
+- Waymark migration (local) after verifying scaffolds.
+
+**Out**
+- New feature expansion beyond spec gaps (e.g., Cloudflare adapters, telemetry).
+- Tooling tier packages unless required for RC (`@outfitter/scripts`, `@outfitter/actions`, `@outfitter/release`).
+
+## Remaining Work (v0.1-rc)
+[ ] `@outfitter/testing`: add spec-compat APIs (createMCPTestHarness wrapper + alias), add `captureCLI`/`mockStdin`, add mock factories.
+[ ] Templates: implement unified placeholder set (projectName/binName/packageName/description/author/year) with aliases; `author` can be org, `year` optional.
+[ ] Templates: add missing scripts (`test:watch`, `lint:fix`) and define a standard script set.
+[ ] `outfitter init`: add TTY wizard for template + naming; keep deterministic default for non-TTY.
+[ ] `outfitter init`: implement hybrid install path (`--local/--workspace`) + publish `0.1.0-*` for real installs.
+[ ] `@outfitter/mcp`: implement tool-search compatibility + minimal core tools (docs/config/query); explicit stdio transport for RC. Track HTTP + auto-negotiation in Linear (MONO-76, MONO-77).
+[ ] `@outfitter/index`: add version headers + migration scaffold; track compactor/watcher hooks in Linear (MONO-78, MONO-79).
+[ ] Consider capability manifest (CLI ↔ MCP parity) based on `navigator/packages/core/src/capabilities/manifest.ts` (in the `outfitter/navigator` repo).
+[ ] Run scaffold smoke tests for `cli`, `mcp`, `daemon` templates and record results.
+[ ] Migrate Waymark (local) to use kit packages; verify tests + dev workflow.
+[ ] Decide Firewatch migration timing (optional for RC).
+
+## Validation Checklist
+- `bun run test`, `bun run typecheck`, `bun run lint`, `bun run build` from repo root.
+- `outfitter init cli|mcp|daemon` scaffolds, and generated project commands are viable (local mode + published RC mode).
+- Waymark migration passes its tests and dev workflows.
+
+## Notes
+- `SPEC.md` and `PLAN.md` are frozen as of 2026-01-24.
+- Phase 7 is treated as the v0.1-rc scope, not an additional phase.

--- a/docs/v0.1-rc/README.md
+++ b/docs/v0.1-rc/README.md
@@ -1,0 +1,82 @@
+# Outfitter Kit v0.1-rc
+
+**Date**: 2026-01-24  
+**Status**: Active
+
+## Purpose
+Freeze `SPEC.md` and `PLAN.md` as historical baselines and drive a focused v0.1-rc scope that closes remaining gaps, documents intentional divergences, and validates real-world usage (fresh scaffolds + Waymark migration).
+
+## What’s Frozen
+- `SPEC.md` and `PLAN.md` are frozen as of 2026-01-24.
+- Any remaining work is tracked here and in `DELTAS.md`.
+
+## Locked Decisions (RC)
+- **Testing harness**: keep server-based MCP harness; add spec-compatible wrapper + alias.
+- **CLI testing**: keep `createCliHarness`; add `captureCLI` + `mockStdin`.
+- **Mock factories**: implement `createTestContext`, `createTestLogger`, `createTestConfig`.
+- **Templates (placeholders)**: unified schema with aliases (see below).
+- **Templates (scripts)**: add missing scripts and standardize a common set.
+- **Init UX**: keep `init --template` + `templates/basic`; add TTY wizard for template + naming.
+- **Doctor**: keep `outfitter doctor` and document as enhancement.
+- **MCP**: implement tool-search compatibility + minimal core tools (docs/config/query) with safe defaults; explicit stdio transport for RC.
+- **Index**: add version headers + migration scaffold; defer compactor/watcher hooks.
+- **Hybrid installs**: add `--local/--workspace` mode for local dev + publish `0.1.0-*` for real installs.
+
+## Standard Template Placeholder Schema
+Canonical keys:
+- `{{projectName}}` — human-readable project name (default from folder name)
+- `{{packageName}}` — `package.json` name (supports scoped)
+- `{{binName}}` — CLI binary name (defaults to `projectName`)
+- `{{description}}`
+- `{{author}}` — person or org (from git config when available)
+- `{{year}}` — optional; for LICENSE/NOTICE headers when used
+
+Aliases for compatibility:
+- `{{name}}` → `{{projectName}}`
+
+## Standard Template Scripts
+Baseline scripts (all templates):
+- `dev`
+- `build`
+- `typecheck`
+- `test`
+- `test:watch`
+- `lint`
+- `lint:fix`
+- `format`
+
+Daemon template additionally includes:
+- `dev:daemon`
+
+## MCP v0.1-rc Scope
+In:
+- Tool search compatibility and description discipline
+- Core tools (minimal): `docs`, `config`, `query` with safe defaults and extension points
+- Explicit stdio transport
+
+Deferred:
+- HTTP transport (streaming/SSE)
+- Transport auto-negotiation
+
+## Index v0.1-rc Scope
+In:
+- Version headers + migration scaffolding
+
+Deferred:
+- Compactor hooks
+- Watcher invalidation hooks
+
+## Hybrid Install Strategy
+- **Local dev**: `outfitter init --local/--workspace` rewrites deps for monorepo testing.
+- **Published RC**: templates target `0.1.0-*` for real installs.
+
+## Deferred Issues (Linear / MONO / Kit project)
+- MONO-76: MCP: add HTTP transport (streaming)
+- MONO-77: MCP: add transport auto-negotiation (stdio ↔ HTTP)
+- MONO-78: Index: add compactor hooks
+- MONO-79: Index: add watcher invalidation hooks
+
+## Validation / Exit Criteria
+- `bun run test`, `bun run typecheck`, `bun run lint`, `bun run build` from repo root
+- `outfitter init cli|mcp|daemon` works in both local mode and published RC mode
+- Waymark migration passes tests and dev workflows


### PR DESCRIPTION
## Summary
- establish v0.1-rc intent, frozen baselines, and locked decisions
- document standard placeholder/script schema and RC scope
- capture deferred items and validation checklist

## Testing
- `turbo run test`
