### PR TITLE
feat(testing): add rc test helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
     },
     "packages/cli": {
       "name": "@outfitter/cli",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "@outfitter/contracts": "workspace:*",
@@ -59,7 +59,7 @@
     },
     "packages/config": {
       "name": "@outfitter/config",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/contracts": {
       "name": "@outfitter/contracts",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "better-result": "^2.5.0",
         "zod": "^3.25.0",
@@ -85,7 +85,7 @@
     },
     "packages/daemon": {
       "name": "@outfitter/daemon",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -98,7 +98,7 @@
     },
     "packages/file-ops": {
       "name": "@outfitter/file-ops",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -110,7 +110,7 @@
     },
     "packages/index": {
       "name": "@outfitter/index",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -158,7 +158,7 @@
     },
     "packages/logging": {
       "name": "@outfitter/logging",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@logtape/logtape": "^2.0.0",
         "@outfitter/contracts": "workspace:*",
@@ -170,7 +170,7 @@
     },
     "packages/mcp": {
       "name": "@outfitter/mcp",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@outfitter/contracts": "workspace:*",
@@ -184,7 +184,7 @@
     },
     "packages/state": {
       "name": "@outfitter/state",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -196,10 +196,11 @@
     },
     "packages/testing": {
       "name": "@outfitter/testing",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/mcp": "workspace:*",
+        "zod": "^3.25.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -208,7 +209,7 @@
     },
     "packages/types": {
       "name": "@outfitter/types",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.8.0",
@@ -216,7 +217,7 @@
     },
     "packages/ui": {
       "name": "@outfitter/ui",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@outfitter/config": "workspace:*",
         "@outfitter/contracts": "workspace:*",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -34,7 +34,8 @@
 	},
 	"dependencies": {
 		"@outfitter/contracts": "workspace:*",
-		"@outfitter/mcp": "workspace:*"
+		"@outfitter/mcp": "workspace:*",
+		"zod": "^3.25.0"
 	},
 	"devDependencies": {
 		"@types/bun": "latest",

--- a/packages/testing/src/__tests__/cli-helpers.test.ts
+++ b/packages/testing/src/__tests__/cli-helpers.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @outfitter/testing - CLI Helpers Test Suite
+ */
+
+import { describe, expect, it } from "bun:test";
+import { captureCLI, mockStdin } from "../cli-helpers.js";
+
+describe("captureCLI()", () => {
+	it("captures stdout, stderr, and exit code", async () => {
+		const result = await captureCLI(async () => {
+			// biome-ignore lint/suspicious/noConsole: captureCLI tests console output
+			console.log("hello");
+			// biome-ignore lint/suspicious/noConsole: captureCLI tests console output
+			console.error("oops");
+			process.exit(2);
+		});
+
+		expect(result.stdout).toContain("hello");
+		expect(result.stderr).toContain("oops");
+		expect(result.exitCode).toBe(2);
+	});
+
+	it("returns exit code 1 on thrown errors", async () => {
+		const result = await captureCLI(() => {
+			throw new Error("boom");
+		});
+
+		expect(result.exitCode).toBe(1);
+	});
+});
+
+describe("mockStdin()", () => {
+	it("provides input via stdin", async () => {
+		const { restore } = mockStdin("test-input");
+		let collected = "";
+		for await (const chunk of process.stdin) {
+			collected += Buffer.from(chunk).toString("utf-8");
+		}
+		restore();
+
+		expect(collected).toBe("test-input");
+	});
+});

--- a/packages/testing/src/__tests__/mock-factories.test.ts
+++ b/packages/testing/src/__tests__/mock-factories.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @outfitter/testing - Mock Factories Test Suite
+ */
+
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { createTestConfig, createTestContext, createTestLogger } from "../mock-factories.js";
+
+describe("createTestLogger()", () => {
+	it("captures log entries and merges context", () => {
+		const logger = createTestLogger({ requestId: "req-1" });
+		logger.info("hello", { user: "alice" });
+
+		expect(logger.logs).toHaveLength(1);
+		expect(logger.logs[0]).toEqual({
+			level: "info",
+			message: "hello",
+			data: { requestId: "req-1", user: "alice" },
+		});
+	});
+
+	it("shares logs across child loggers", () => {
+		const logger = createTestLogger({ requestId: "req-1" });
+		const child = logger.child({ operation: "test" });
+		child.debug("child log");
+
+		expect(logger.logs).toHaveLength(1);
+		expect(logger.logs[0]?.data).toEqual({ requestId: "req-1", operation: "test" });
+	});
+});
+
+describe("createTestConfig()", () => {
+	it("validates schema and provides accessors", () => {
+		const Schema = z.object({
+			database: z.object({
+				path: z.string().default(":memory:"),
+			}),
+			mode: z.string().default("dev"),
+		});
+
+		const config = createTestConfig(Schema, { database: { path: ":memory:" } });
+
+		expect(config.get<string>("database.path")).toBe(":memory:");
+		expect(config.get<string>("mode")).toBe("dev");
+		expect(() => config.getRequired("missing")).toThrow();
+	});
+});
+
+describe("createTestContext()", () => {
+	it("creates a handler context with defaults", () => {
+		const ctx = createTestContext();
+		expect(ctx.requestId).toBeDefined();
+		expect(ctx.logger).toBeDefined();
+		expect(ctx.cwd).toBe(process.cwd());
+		expect(ctx.env).toBeDefined();
+	});
+
+	it("respects overrides", () => {
+		const ctx = createTestContext({ requestId: "req-123" });
+		expect(ctx.requestId).toBe("req-123");
+	});
+});

--- a/packages/testing/src/cli-harness.ts
+++ b/packages/testing/src/cli-harness.ts
@@ -112,8 +112,7 @@ export function createCliHarness(command: string): CliHarness {
 					if (exitCode !== null) {
 						finalExitCode = exitCode;
 					} else if (signal !== null) {
-						const signalNumber =
-							constants.signals[signal as keyof typeof constants.signals];
+						const signalNumber = constants.signals[signal as keyof typeof constants.signals];
 						finalExitCode = signalNumber !== undefined ? 128 + signalNumber : 1;
 					} else {
 						finalExitCode = 1;

--- a/packages/testing/src/cli-helpers.ts
+++ b/packages/testing/src/cli-helpers.ts
@@ -1,0 +1,155 @@
+/**
+ * @outfitter/testing - CLI Helpers
+ *
+ * Utilities for capturing CLI output and mocking stdin in tests.
+ *
+ * @packageDocumentation
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CliTestResult {
+	/** Captured stdout */
+	stdout: string;
+	/** Captured stderr */
+	stderr: string;
+	/** Process exit code */
+	exitCode: number;
+}
+
+// ============================================================================
+// Output Capture
+// ============================================================================
+
+class ExitError extends Error {
+	readonly code: number;
+
+	constructor(code: number) {
+		super(`Process exited with code ${code}`);
+		this.code = code;
+	}
+}
+
+/**
+ * Capture stdout/stderr and exit code from an async CLI function.
+ */
+export async function captureCLI(fn: () => Promise<void> | void): Promise<CliTestResult> {
+	const stdoutChunks: Uint8Array[] = [];
+	const stderrChunks: Uint8Array[] = [];
+
+	const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+	const originalStderrWrite = process.stderr.write.bind(process.stderr);
+	const originalExit = process.exit.bind(process);
+	const originalConsoleLog = console.log;
+	const originalConsoleError = console.error;
+
+	process.stdout.write = ((
+		chunk: Uint8Array | string,
+		_encoding?: unknown,
+		cb?: () => void,
+	): boolean => {
+		stdoutChunks.push(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+		if (typeof cb === "function") cb();
+		return true;
+	}) as typeof process.stdout.write;
+
+	process.stderr.write = ((
+		chunk: Uint8Array | string,
+		_encoding?: unknown,
+		cb?: () => void,
+	): boolean => {
+		stderrChunks.push(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+		if (typeof cb === "function") cb();
+		return true;
+	}) as typeof process.stderr.write;
+
+	// biome-ignore lint/suspicious/noConsole: captureCLI intercepts console output
+	console.log = (...args: unknown[]): void => {
+		const line = `${args.map(String).join(" ")}\n`;
+		stdoutChunks.push(new TextEncoder().encode(line));
+	};
+
+	// biome-ignore lint/suspicious/noConsole: captureCLI intercepts console output
+	console.error = (...args: unknown[]): void => {
+		const line = `${args.map(String).join(" ")}\n`;
+		stderrChunks.push(new TextEncoder().encode(line));
+	};
+
+	process.exit = ((code?: number): never => {
+		throw new ExitError(code ?? 0);
+	}) as typeof process.exit;
+
+	let exitCode = 0;
+	try {
+		await fn();
+	} catch (error) {
+		if (error instanceof ExitError) {
+			exitCode = error.code;
+		} else {
+			exitCode = 1;
+		}
+	} finally {
+		process.stdout.write = originalStdoutWrite;
+		process.stderr.write = originalStderrWrite;
+		process.exit = originalExit;
+		// biome-ignore lint/suspicious/noConsole: captureCLI intercepts console output
+		console.log = originalConsoleLog;
+		// biome-ignore lint/suspicious/noConsole: captureCLI intercepts console output
+		console.error = originalConsoleError;
+	}
+
+	const decoder = new TextDecoder("utf-8");
+
+	return {
+		stdout: decoder.decode(concatChunks(stdoutChunks)),
+		stderr: decoder.decode(concatChunks(stderrChunks)),
+		exitCode,
+	};
+}
+
+// ============================================================================
+// Stdin Mock
+// ============================================================================
+
+/**
+ * Mock stdin with provided input.
+ *
+ * Returns a restore function for convenience.
+ */
+export function mockStdin(input: string): { restore: () => void } {
+	const originalStdin = process.stdin;
+	const encoded = new TextEncoder().encode(input);
+
+	const mockStream = {
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		[Symbol.asyncIterator]: async function* (): AsyncGenerator<any, void, unknown> {
+			yield encoded;
+		},
+		isTTY: false,
+	};
+
+	process.stdin = mockStream as unknown as NodeJS.ReadStream;
+
+	return {
+		restore: () => {
+			process.stdin = originalStdin;
+		},
+	};
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+	const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return result;
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -24,6 +24,7 @@ export { createFixture, loadFixture, withTempDir, withEnv } from "./fixtures.js"
 // ============================================================================
 
 export { createCliHarness, type CliHarness, type CliResult } from "./cli-harness.js";
+export { captureCLI, mockStdin, type CliTestResult } from "./cli-helpers.js";
 
 // ============================================================================
 // MCP Harness
@@ -31,6 +32,21 @@ export { createCliHarness, type CliHarness, type CliResult } from "./cli-harness
 
 export {
 	createMcpHarness,
+	createMCPTestHarness,
+	createMcpTestHarness,
 	type McpHarness,
 	type McpToolResponse,
+	type McpTestHarnessOptions,
 } from "./mcp-harness.js";
+
+// ============================================================================
+// Mock Factories
+// ============================================================================
+
+export {
+	createTestConfig,
+	createTestContext,
+	createTestLogger,
+	type LogEntry,
+	type TestLogger,
+} from "./mock-factories.js";

--- a/packages/testing/src/mock-factories.ts
+++ b/packages/testing/src/mock-factories.ts
@@ -1,0 +1,169 @@
+/**
+ * @outfitter/testing - Mock Factories
+ *
+ * Helpers for creating test contexts, loggers, and configs.
+ *
+ * @packageDocumentation
+ */
+
+import {
+	generateRequestId,
+	type HandlerContext,
+	type Logger,
+	type ResolvedConfig,
+} from "@outfitter/contracts";
+import type { z } from "zod";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LogEntry {
+	level: "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+	message: string;
+	data?: Record<string, unknown>;
+}
+
+export interface TestLogger extends Logger {
+	/** Captured log entries for assertions */
+	logs: LogEntry[];
+	/** Clear captured logs */
+	clear(): void;
+}
+
+// ============================================================================
+// Logger Factory
+// ============================================================================
+
+export function createTestLogger(context: Record<string, unknown> = {}): TestLogger {
+	return createTestLoggerWithContext(context, []);
+}
+
+function createTestLoggerWithContext(
+	context: Record<string, unknown>,
+	logs: LogEntry[],
+): TestLogger {
+	const write = (level: LogEntry["level"], message: string, data?: Record<string, unknown>) => {
+		const merged = { ...context, ...(data ?? {}) };
+		const entry: LogEntry = {
+			level,
+			message,
+		};
+
+		if (Object.keys(merged).length > 0) {
+			entry.data = merged;
+		}
+
+		logs.push(entry);
+	};
+
+	return {
+		logs,
+		clear() {
+			logs.length = 0;
+		},
+		trace(message, metadata) {
+			write("trace", message, metadata);
+		},
+		debug(message, metadata) {
+			write("debug", message, metadata);
+		},
+		info(message, metadata) {
+			write("info", message, metadata);
+		},
+		warn(message, metadata) {
+			write("warn", message, metadata);
+		},
+		error(message, metadata) {
+			write("error", message, metadata);
+		},
+		fatal(message, metadata) {
+			write("fatal", message, metadata);
+		},
+		child(childContext) {
+			return createTestLoggerWithContext({ ...context, ...childContext }, logs);
+		},
+	};
+}
+
+// ============================================================================
+// Config Factory
+// ============================================================================
+
+export function createTestConfig<T>(schema: z.ZodType<T>, values: Partial<T>): ResolvedConfig {
+	const parsed = schema.safeParse(values);
+	let data: T;
+	if (parsed.success) {
+		data = parsed.data;
+	} else {
+		const maybePartial = (schema as unknown as { partial?: () => z.ZodType<Partial<T>> }).partial;
+		if (typeof maybePartial !== "function") {
+			throw parsed.error;
+		}
+
+		const partialSchema = maybePartial.call(schema);
+		const partialParsed = partialSchema.safeParse(values);
+		if (!partialParsed.success) {
+			throw partialParsed.error;
+		}
+
+		data = partialParsed.data as T;
+	}
+
+	return {
+		get<TValue>(key: string): TValue | undefined {
+			return getPath<TValue>(data as Record<string, unknown>, key);
+		},
+		getRequired<TValue>(key: string): TValue {
+			const value = getPath<TValue>(data as Record<string, unknown>, key);
+			if (value === undefined) {
+				throw new Error(`Missing required config value: ${key}`);
+			}
+			return value;
+		},
+	};
+}
+
+// ============================================================================
+// Context Factory
+// ============================================================================
+
+export function createTestContext(overrides: Partial<HandlerContext> = {}): HandlerContext {
+	const logger = overrides.logger ?? createTestLogger();
+	const requestId = overrides.requestId ?? generateRequestId();
+
+	const context: HandlerContext = {
+		requestId,
+		logger,
+		cwd: overrides.cwd ?? process.cwd(),
+		env: overrides.env ?? { ...process.env },
+	};
+
+	if (overrides.config !== undefined) {
+		context.config = overrides.config;
+	}
+	if (overrides.signal !== undefined) {
+		context.signal = overrides.signal;
+	}
+	if (overrides.workspaceRoot !== undefined) {
+		context.workspaceRoot = overrides.workspaceRoot;
+	}
+
+	return context;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getPath<TValue>(obj: Record<string, unknown>, key: string): TValue | undefined {
+	const parts = key.split(".").filter((part) => part.length > 0);
+	let current: unknown = obj;
+	for (const part of parts) {
+		if (current === null || typeof current !== "object") {
+			return undefined;
+		}
+		current = (current as Record<string, unknown>)[part];
+	}
+	return current as TValue | undefined;
+}


### PR DESCRIPTION
## Summary
- add MCP test harness wrapper/alias for spec parity
- add CLI helpers (`captureCLI`, `mockStdin`) and mock factories
- update testing deps and fixtures to support new APIs

## Testing
- `turbo run test`
