### PR TITLE
feat(mcp): add core tools and stdio transport

### DIFF
--- a/packages/mcp/src/__tests__/core-tools.test.ts
+++ b/packages/mcp/src/__tests__/core-tools.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @outfitter/mcp - Core tools tests
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import { z } from "zod";
+import {
+	createMcpServer,
+	defineTool,
+	defineDocsTool,
+	defineConfigTool,
+	defineQueryTool,
+} from "../index.js";
+
+describe("core tool metadata", () => {
+	it("marks core tools as non-deferred", () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(defineDocsTool());
+		server.registerTool(defineConfigTool());
+		server.registerTool(defineQueryTool());
+
+		const tools = server.getTools();
+		expect(tools.every((tool) => tool.defer_loading === false)).toBe(true);
+	});
+
+	it("defaults domain tools to deferred", () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(
+			defineTool({
+				name: "hello",
+				description: "Say hello",
+				inputSchema: z.object({ name: z.string().optional() }),
+				handler: async (input) =>
+					Result.ok({ content: [{ type: "text", text: `Hello ${input.name ?? "world"}` }] }),
+			}),
+		);
+
+		const tools = server.getTools();
+		expect(tools[0]?.defer_loading).toBe(true);
+	});
+});
+
+describe("docs tool", () => {
+	it("returns requested section when provided", async () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(
+			defineDocsTool({
+				docs: {
+					overview: "Docs overview",
+					tools: [{ name: "query", summary: "Search things" }],
+				},
+			}),
+		);
+
+		const result = await server.invokeTool("docs", { section: "overview" });
+		expect(result.isOk()).toBe(true);
+		expect(result.unwrap().overview).toBe("Docs overview");
+		expect(result.unwrap().tools).toBeUndefined();
+	});
+});
+
+describe("config tool", () => {
+	it("reads, writes, and lists config values", async () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(defineConfigTool({ initial: { mode: "dev" } }));
+
+		const list = await server.invokeTool("config", { action: "list" });
+		expect(list.isOk()).toBe(true);
+		expect(list.unwrap().config?.mode).toBe("dev");
+
+		const set = await server.invokeTool("config", { action: "set", key: "mode", value: "prod" });
+		expect(set.isOk()).toBe(true);
+
+		const get = await server.invokeTool("config", { action: "get", key: "mode" });
+		expect(get.isOk()).toBe(true);
+		expect(get.unwrap().value).toBe("prod");
+		expect(get.unwrap().found).toBe(true);
+	});
+
+	it("returns validation error when key is missing", async () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(defineConfigTool());
+
+		const result = await server.invokeTool("config", { action: "get" });
+		expect(result.isErr()).toBe(true);
+		expect(result.error.code).toBe(-32602);
+	});
+});
+
+describe("query tool", () => {
+	it("returns empty results by default", async () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(defineQueryTool());
+
+		const result = await server.invokeTool("query", { q: "hello" });
+		expect(result.isOk()).toBe(true);
+		expect(result.unwrap().results).toEqual([]);
+		expect(result.unwrap()._meta?.note).toBe("No query handler configured.");
+	});
+
+	it("accepts query alias", async () => {
+		const server = createMcpServer({ name: "test", version: "0.0.0" });
+		server.registerTool(defineQueryTool());
+
+		const result = await server.invokeTool("query", { query: "hello" });
+		expect(result.isOk()).toBe(true);
+	});
+});

--- a/packages/mcp/src/core-tools.ts
+++ b/packages/mcp/src/core-tools.ts
@@ -1,0 +1,308 @@
+/**
+ * @outfitter/mcp - Core MCP Tools
+ *
+ * Core tools that are always available for MCP tool search:
+ * - docs: documentation and examples
+ * - config: read/write configuration
+ * - query: search and discovery
+ *
+ * @packageDocumentation
+ */
+
+import { Result, ValidationError } from "@outfitter/contracts";
+import type { HandlerContext, KitError } from "@outfitter/contracts";
+import { z } from "zod";
+import type { ToolDefinition } from "./types.js";
+
+// =============================================================================
+// Docs Tool
+// =============================================================================
+
+export type DocsSection = "overview" | "tools" | "examples" | "schemas";
+
+export interface DocsToolInput {
+	section?: DocsSection | undefined;
+}
+
+export interface DocsToolEntry {
+	name: string;
+	summary?: string;
+	examples?: Array<{
+		input: Record<string, unknown>;
+		description?: string;
+	}>;
+}
+
+export interface DocsToolResponse {
+	overview?: string;
+	tools?: DocsToolEntry[];
+	examples?: Array<{
+		name?: string;
+		description?: string;
+		input?: Record<string, unknown>;
+		output?: unknown;
+	}>;
+	schemas?: Record<string, unknown>;
+}
+
+export interface DocsToolOptions {
+	/** Optional override for the docs tool description. */
+	description?: string;
+	/** Static docs payload (used when getDocs is not provided). */
+	docs?: DocsToolResponse;
+	/** Dynamic docs provider. */
+	getDocs?: (section?: DocsSection) => DocsToolResponse | Promise<DocsToolResponse>;
+}
+
+const DEFAULT_DOCS: DocsToolResponse = {
+	overview: "No documentation configured yet.",
+	tools: [],
+	examples: [],
+	schemas: {},
+};
+
+const docsSchema = z.object({
+	section: z.enum(["overview", "tools", "examples", "schemas"]).optional(),
+});
+
+function pickDocsSection(payload: DocsToolResponse, section?: DocsSection): DocsToolResponse {
+	if (!section) {
+		return payload;
+	}
+
+	return {
+		[section]: payload[section],
+	} as DocsToolResponse;
+}
+
+export function defineDocsTool(
+	options: DocsToolOptions = {},
+): ToolDefinition<DocsToolInput, DocsToolResponse> {
+	return {
+		name: "docs",
+		description:
+			options.description ?? "Documentation, usage patterns, and examples for this MCP server.",
+		deferLoading: false,
+		inputSchema: docsSchema,
+		handler: async (input) => {
+			const payload = options.getDocs
+				? await options.getDocs(input.section)
+				: (options.docs ?? DEFAULT_DOCS);
+
+			return Result.ok(pickDocsSection(payload, input.section));
+		},
+	};
+}
+
+// =============================================================================
+// Config Tool
+// =============================================================================
+
+export type ConfigAction = "get" | "set" | "list";
+
+export interface ConfigToolInput {
+	action: ConfigAction;
+	key?: string | undefined;
+	value?: unknown | undefined;
+}
+
+export interface ConfigToolResponse {
+	action: ConfigAction;
+	key?: string;
+	value?: unknown;
+	found?: boolean;
+	config?: Record<string, unknown>;
+}
+
+export interface ConfigStore {
+	get(
+		key: string,
+	): { value: unknown; found: boolean } | Promise<{ value: unknown; found: boolean }>;
+	set(key: string, value: unknown): void | Promise<void>;
+	list(): Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+export interface ConfigToolOptions {
+	/** Optional override for the config tool description. */
+	description?: string;
+	/** Initial config values when using the default in-memory store. */
+	initial?: Record<string, unknown>;
+	/** Custom config store implementation. */
+	store?: ConfigStore;
+}
+
+const configSchema = z.object({
+	action: z.enum(["get", "set", "list"]),
+	key: z.string().optional(),
+	value: z.unknown().optional(),
+});
+
+function createInMemoryStore(initial: Record<string, unknown> = {}): ConfigStore {
+	const store = new Map<string, unknown>(Object.entries(initial));
+
+	return {
+		get(key) {
+			return { value: store.get(key), found: store.has(key) };
+		},
+		set(key, value) {
+			store.set(key, value);
+		},
+		list() {
+			return Object.fromEntries(store.entries());
+		},
+	};
+}
+
+export function defineConfigTool(
+	options: ConfigToolOptions = {},
+): ToolDefinition<ConfigToolInput, ConfigToolResponse> {
+	const store = options.store ?? createInMemoryStore(options.initial);
+
+	return {
+		name: "config",
+		description: options.description ?? "Read or modify server configuration values.",
+		deferLoading: false,
+		inputSchema: configSchema,
+		handler: async (input) => {
+			switch (input.action) {
+				case "list": {
+					const config = await store.list();
+					return Result.ok({ action: "list", config });
+				}
+				case "get": {
+					if (!input.key) {
+						return Result.err(
+							new ValidationError({
+								message: "Config key is required for action 'get'.",
+								field: "key",
+							}),
+						);
+					}
+					const { value, found } = await store.get(input.key);
+					return Result.ok({ action: "get", key: input.key, value, found });
+				}
+				case "set": {
+					if (!input.key) {
+						return Result.err(
+							new ValidationError({
+								message: "Config key is required for action 'set'.",
+								field: "key",
+							}),
+						);
+					}
+					await store.set(input.key, input.value);
+					return Result.ok({ action: "set", key: input.key, value: input.value });
+				}
+			}
+		},
+	};
+}
+
+// =============================================================================
+// Query Tool
+// =============================================================================
+
+export interface QueryToolInput {
+	q?: string | undefined;
+	query?: string | undefined;
+	limit?: number | undefined;
+	cursor?: string | undefined;
+	filters?: Record<string, unknown> | undefined;
+}
+
+export interface QueryToolResponse<T = unknown> {
+	results: T[];
+	nextCursor?: string;
+	_meta?: Record<string, unknown>;
+}
+
+export interface QueryToolOptions<T = unknown> {
+	/** Optional override for the query tool description. */
+	description?: string;
+	/** Custom query handler implementation. */
+	handler?: (
+		input: NormalizedQueryInput,
+		ctx: HandlerContext,
+	) => Promise<Result<QueryToolResponse<T>, KitError>>;
+}
+
+const querySchema = z
+	.object({
+		q: z
+			.string()
+			.min(1)
+			.describe("Search query. Supports natural language or filter syntax.")
+			.optional(),
+		query: z
+			.string()
+			.min(1)
+			.describe("Alias for q. Supports natural language or filter syntax.")
+			.optional(),
+		limit: z.number().int().positive().optional(),
+		cursor: z.string().optional(),
+		filters: z.record(z.string(), z.unknown()).optional(),
+	})
+	.refine(
+		(value) => {
+			const queryValue = (value.q ?? value.query)?.trim();
+			return typeof queryValue === "string" && queryValue.length > 0;
+		},
+		{
+			message: "Query is required.",
+			path: ["q"],
+		},
+	);
+
+export function defineQueryTool<T = unknown>(
+	options: QueryToolOptions<T> = {},
+): ToolDefinition<QueryToolInput, QueryToolResponse<T>> {
+	return {
+		name: "query",
+		description:
+			options.description ?? "Search and discover resources with filters and pagination.",
+		deferLoading: false,
+		inputSchema: querySchema,
+		handler: async (input, ctx) => {
+			const normalized = {
+				...input,
+				q: (input.q ?? input.query ?? "").trim(),
+			};
+
+			if (options.handler) {
+				return options.handler(normalized, ctx);
+			}
+
+			return Result.ok({
+				results: [],
+				_meta: {
+					note: "No query handler configured.",
+				},
+			});
+		},
+	};
+}
+
+// =============================================================================
+// Core Tools Bundle
+// =============================================================================
+
+export interface CoreToolsOptions {
+	docs?: DocsToolOptions;
+	config?: ConfigToolOptions;
+	query?: QueryToolOptions;
+}
+
+export type NormalizedQueryInput = Required<Pick<QueryToolInput, "q">> & Omit<QueryToolInput, "q">;
+
+export type CoreToolDefinition =
+	| ToolDefinition<DocsToolInput, DocsToolResponse>
+	| ToolDefinition<ConfigToolInput, ConfigToolResponse>
+	| ToolDefinition<QueryToolInput, QueryToolResponse>;
+
+export function createCoreTools(options: CoreToolsOptions = {}): CoreToolDefinition[] {
+	return [
+		defineDocsTool(options.docs),
+		defineConfigTool(options.config),
+		defineQueryTool(options.query),
+	];
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -49,3 +49,28 @@ export { createMcpServer, defineTool, defineResource } from "./server.js";
 
 // Schema utilities
 export { type JsonSchema, zodToJsonSchema } from "./schema.js";
+
+// Core tools
+export {
+	createCoreTools,
+	defineDocsTool,
+	defineConfigTool,
+	defineQueryTool,
+	type DocsSection,
+	type DocsToolEntry,
+	type DocsToolInput,
+	type DocsToolResponse,
+	type DocsToolOptions,
+	type ConfigAction,
+	type ConfigToolInput,
+	type ConfigToolResponse,
+	type ConfigToolOptions,
+	type ConfigStore,
+	type QueryToolInput,
+	type QueryToolResponse,
+	type QueryToolOptions,
+	type CoreToolsOptions,
+} from "./core-tools.js";
+
+// Transport helpers
+export { connectStdio, createSdkServer, type McpToolResponse } from "./transport.js";

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -1,0 +1,132 @@
+/**
+ * @outfitter/mcp - Transport Helpers
+ *
+ * Bridges the @outfitter/mcp server with the MCP SDK transports.
+ * v0.1-rc supports explicit stdio transport.
+ *
+ * @packageDocumentation
+ */
+
+import { safeStringify } from "@outfitter/contracts";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+	type CallToolResult,
+	CallToolRequestSchema,
+	ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "./types.js";
+
+export type McpToolResponse = CallToolResult;
+
+function isMcpToolResponse(value: unknown): value is McpToolResponse {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const content = (value as { content?: unknown }).content;
+	return Array.isArray(content);
+}
+
+function toTextPayload(value: unknown): string {
+	if (typeof value === "string") {
+		return value;
+	}
+	return safeStringify(value);
+}
+
+type ErrorRecord = {
+	_tag?: unknown;
+	message?: unknown;
+	code?: unknown;
+	context?: unknown;
+};
+
+function serializeError(error: unknown): Record<string, unknown> {
+	if (error && typeof error === "object") {
+		const record = error as ErrorRecord;
+		return {
+			_tag: record._tag ?? "McpError",
+			message: record.message ?? "Unknown error",
+			code: record.code,
+			context: record.context,
+		};
+	}
+
+	return {
+		_tag: "McpError",
+		message: String(error),
+	};
+}
+
+function wrapToolResult(value: unknown): McpToolResponse {
+	if (isMcpToolResponse(value)) {
+		return value;
+	}
+
+	const structuredContent =
+		value && typeof value === "object" && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: undefined;
+
+	return {
+		content: [
+			{
+				type: "text",
+				text: toTextPayload(value),
+			},
+		],
+		...(structuredContent ? { structuredContent } : {}),
+	};
+}
+
+function wrapToolError(error: unknown): McpToolResponse {
+	return {
+		content: [
+			{
+				type: "text",
+				text: toTextPayload(serializeError(error)),
+			},
+		],
+		isError: true,
+	};
+}
+
+/**
+ * Create an MCP SDK server from an Outfitter MCP server.
+ */
+export function createSdkServer(server: McpServer): Server {
+	const sdkServer = new Server(
+		{ name: server.name, version: server.version },
+		{ capabilities: { tools: {} } },
+	);
+
+	sdkServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+		tools: server.getTools(),
+	}));
+
+	sdkServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+		const { name, arguments: args } = request.params;
+		const result = await server.invokeTool(name, (args ?? {}) as Record<string, unknown>);
+
+		if (result.isErr()) {
+			return wrapToolError(result.error);
+		}
+
+		return wrapToolResult(result.value);
+	});
+
+	return sdkServer;
+}
+
+/**
+ * Connect an MCP server over stdio transport.
+ */
+export async function connectStdio(
+	server: McpServer,
+	transport: StdioServerTransport = new StdioServerTransport(),
+): Promise<Server> {
+	const sdkServer = createSdkServer(server);
+	await sdkServer.connect(transport);
+	return sdkServer;
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -107,6 +107,12 @@ export interface ToolDefinition<TInput, TOutput, TError extends KitError = KitEr
 	description: string;
 
 	/**
+	 * Whether the tool should be deferred for tool search.
+	 * Defaults to true for domain tools; core tools set this to false.
+	 */
+	deferLoading?: boolean;
+
+	/**
 	 * Zod schema for validating and parsing input.
 	 * The schema defines the expected input structure.
 	 */
@@ -132,6 +138,9 @@ export interface SerializedTool {
 
 	/** JSON Schema representation of the input schema */
 	inputSchema: Record<string, unknown>;
+
+	/** MCP tool-search hint: whether tool is deferred */
+	defer_loading?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add core MCP tools (docs/config/query) with safe defaults
- add tool search metadata for discoverability
- add stdio transport helpers for RC

## Testing
- `turbo run test`
