### PR TITLE
feat(capabilities): add action capability manifest

### DIFF
--- a/docs/v0.1-rc/PLAN.md
+++ b/docs/v0.1-rc/PLAN.md
@@ -25,8 +25,8 @@ Freeze `SPEC.md` and `PLAN.md` as historical baselines, then drive a focused v0.
 [ ] Publish `0.1.0-*` packages for real installs.
 [x] `@outfitter/mcp`: implement tool-search compatibility + minimal core tools (docs/config/query); explicit stdio transport for RC. Track HTTP + auto-negotiation in Linear (MONO-76, MONO-77).
 [x] `@outfitter/index`: add version headers + migration scaffold; track compactor/watcher hooks in Linear (MONO-78, MONO-79).
-[ ] Consider capability manifest (CLI ↔ MCP parity) based on `navigator/packages/core/src/capabilities/manifest.ts` (in the `outfitter/navigator` repo).
-[ ] Run scaffold smoke tests for `cli`, `mcp`, `daemon` templates and record results.
+[x] Consider capability manifest (CLI ↔ MCP parity) based on `navigator/packages/core/src/capabilities/manifest.ts` (in the `outfitter/navigator` repo).
+[x] Run scaffold smoke tests for `cli`, `mcp`, `daemon` templates and record results.
 [ ] Migrate Waymark (local) to use kit packages; verify tests + dev workflow.
 [ ] Decide Firewatch migration timing (optional for RC).
 
@@ -38,3 +38,4 @@ Freeze `SPEC.md` and `PLAN.md` as historical baselines, then drive a focused v0.
 ## Notes
 - `SPEC.md` and `PLAN.md` are frozen as of 2026-01-24.
 - Phase 7 is treated as the v0.1-rc scope, not an additional phase.
+- Scaffold smoke tests: `tmp/smoke-20260124-153400/cli`, `tmp/smoke-20260124-153800/mcp`, `tmp/smoke-20260124-153800/daemon`.

--- a/docs/v0.1-rc/README.md
+++ b/docs/v0.1-rc/README.md
@@ -58,6 +58,16 @@ Deferred:
 - HTTP transport (streaming/SSE)
 - Transport auto-negotiation
 
+## Capability Manifest (CLI ↔ MCP Parity)
+To avoid CLI/MCP divergence, the canonical action capability manifest lives in
+`packages/contracts/src/capabilities.ts`.
+
+Defaults:
+- `capability()` assumes `["cli", "mcp"]` (most actions).
+- `capabilityAll()` marks actions available everywhere without repeating surfaces.
+- If you want "always add tools" by default, use `capabilityAll()` for new actions
+  (or treat missing entries as "all surfaces" in downstream tooling).
+
 ## Index v0.1-rc Scope
 In:
 - Version headers + migration scaffolding

--- a/packages/contracts/src/__tests__/capabilities.test.ts
+++ b/packages/contracts/src/__tests__/capabilities.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @outfitter/contracts - capability manifest tests
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+	ACTION_CAPABILITIES,
+	CAPABILITY_SURFACES,
+	DEFAULT_ACTION_SURFACES,
+	capability,
+	capabilityAll,
+	getActionsForSurface,
+} from "../capabilities.js";
+
+describe("capability helpers", () => {
+	it("defaults to CLI+MCP surfaces", () => {
+		expect(capability().surfaces).toEqual(DEFAULT_ACTION_SURFACES);
+	});
+
+	it("supports all surfaces helper", () => {
+		expect(capabilityAll().surfaces).toEqual(CAPABILITY_SURFACES);
+	});
+});
+
+describe("action manifest", () => {
+	it("includes server-only actions", () => {
+		expect(ACTION_CAPABILITIES.download.surfaces).toEqual(["server"]);
+	});
+
+	it("filters actions by surface", () => {
+		const serverActions = getActionsForSurface("server");
+		expect(serverActions).toContain("download");
+		expect(serverActions).not.toContain("navigate");
+
+		const mcpActions = getActionsForSurface("mcp");
+		expect(mcpActions).toContain("navigate");
+		expect(mcpActions).not.toContain("download");
+	});
+});

--- a/packages/contracts/src/capabilities.ts
+++ b/packages/contracts/src/capabilities.ts
@@ -1,0 +1,90 @@
+/**
+ * @outfitter/contracts - Capability manifest
+ *
+ * Shared action capability manifest for CLI/MCP/server parity.
+ *
+ * @packageDocumentation
+ */
+
+export const CAPABILITY_SURFACES = ["cli", "mcp", "server"] as const;
+
+export type CapabilitySurface = (typeof CAPABILITY_SURFACES)[number];
+
+export type ActionCapability = {
+	surfaces: readonly CapabilitySurface[];
+	notes?: string;
+};
+
+export const DEFAULT_ACTION_SURFACES = ["cli", "mcp"] as const;
+
+export function capability(
+	surfaces: readonly CapabilitySurface[] = DEFAULT_ACTION_SURFACES,
+	notes?: string,
+): ActionCapability {
+	return notes ? { surfaces, notes } : { surfaces };
+}
+
+export function capabilityAll(notes?: string): ActionCapability {
+	return capability(CAPABILITY_SURFACES, notes);
+}
+
+export const ACTION_CAPABILITIES: Record<string, ActionCapability> = {
+	// Navigation
+	navigate: capability(),
+	back: capability(),
+	forward: capability(),
+	reload: capability(),
+	// Tabs
+	tab: capability(),
+	tabs: capability(),
+	newTab: capability(),
+	closeTab: capability(),
+	// Interaction
+	click: capability(),
+	type: capability(),
+	select: capability(),
+	hover: capability(),
+	focus: capability(["mcp"]),
+	scroll: capability(),
+	press: capability(),
+	fill: capability(),
+	find: capability(),
+	check: capability(),
+	uncheck: capability(),
+	upload: capability(),
+	download: capability(["server"], "Server-only for now"),
+	dialog: capability(),
+	// Wait
+	waitFor: capability(["mcp"]),
+	waitForNavigation: capability(["mcp"]),
+	wait: capability(["mcp"]),
+	// Capture
+	snap: capability(),
+	screenshot: capability(),
+	html: capability(["mcp"]),
+	text: capability(["mcp"]),
+	// Markers
+	marker: capability(),
+	markers: capability(),
+	markerGet: capability(),
+	markerRead: capability(["mcp"]),
+	markerCompare: capability(),
+	markerDelete: capability(),
+	markerResolve: capability(["cli"], "CLI-only for now"),
+	// Display
+	viewport: capability(),
+	colorScheme: capability(),
+	mode: capability(["mcp"]),
+	// Evaluate
+	evaluate: capability(["mcp"]),
+	// Session
+	session: capability(),
+	sessions: capability(["mcp"]),
+	steps: capability(),
+};
+
+export function getActionsForSurface(surface: CapabilitySurface): string[] {
+	return Object.entries(ACTION_CAPABILITIES)
+		.filter(([, capability]) => capability.surfaces.includes(surface))
+		.map(([action]) => action);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -136,3 +136,15 @@ export type {
 	AuthAdapter,
 	StorageAdapter,
 } from "./adapters.js";
+
+// Capability manifest
+export {
+	CAPABILITY_SURFACES,
+	DEFAULT_ACTION_SURFACES,
+	ACTION_CAPABILITIES,
+	capability,
+	capabilityAll,
+	getActionsForSurface,
+} from "./capabilities.js";
+
+export type { CapabilitySurface, ActionCapability } from "./capabilities.js";


### PR DESCRIPTION
## Summary
- add action capability manifest for CLI/MCP/server parity
- add capability helpers + tests
- update RC docs with manifest guidance + smoke test notes

## Testing
- `turbo run test`
