### PR TITLE
feat(contracts): add action registry

### DIFF
--- a/packages/contracts/src/__tests__/actions.test.ts
+++ b/packages/contracts/src/__tests__/actions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { Result } from "../index.js";
+import { createActionRegistry, defineAction } from "../actions.js";
+
+describe("action registry", () => {
+	it("registers and retrieves actions", () => {
+		const registry = createActionRegistry();
+
+		registry.add(
+			defineAction({
+				id: "alpha",
+				description: "Alpha action",
+				surfaces: ["cli"],
+				input: z.object({}),
+				handler: async () => Result.ok({ ok: true }),
+			}),
+		);
+
+		expect(registry.get("alpha")?.id).toBe("alpha");
+		expect(registry.list()).toHaveLength(1);
+	});
+
+	it("filters actions by surface", () => {
+		const registry = createActionRegistry();
+
+		registry.add(
+			defineAction({
+				id: "cli-only",
+				surfaces: ["cli"],
+				input: z.object({}),
+				handler: async () => Result.ok({ ok: true }),
+			}),
+		);
+
+		registry.add(
+			defineAction({
+				id: "mcp-only",
+				surfaces: ["mcp"],
+				input: z.object({}),
+				handler: async () => Result.ok({ ok: true }),
+			}),
+		);
+
+		expect(registry.forSurface("cli").map((action) => action.id)).toEqual(["cli-only"]);
+		expect(registry.forSurface("mcp").map((action) => action.id)).toEqual(["mcp-only"]);
+	});
+
+	it("defaults to all surfaces when none are provided", () => {
+		const registry = createActionRegistry();
+
+		registry.add(
+			defineAction({
+				id: "default",
+				input: z.object({}),
+				handler: async () => Result.ok({ ok: true }),
+			}),
+		);
+
+		expect(registry.forSurface("cli").map((action) => action.id)).toEqual(["default"]);
+		expect(registry.forSurface("mcp").map((action) => action.id)).toEqual(["default"]);
+		expect(registry.forSurface("api").map((action) => action.id)).toEqual(["default"]);
+		expect(registry.forSurface("server").map((action) => action.id)).toEqual(["default"]);
+	});
+});

--- a/packages/contracts/src/actions.ts
+++ b/packages/contracts/src/actions.ts
@@ -1,0 +1,102 @@
+import type { z } from "zod";
+import type { Handler, SyncHandler } from "./handler.js";
+import type { KitError } from "./errors.js";
+
+export const ACTION_SURFACES = ["cli", "mcp", "api", "server"] as const;
+
+export type ActionSurface = (typeof ACTION_SURFACES)[number];
+
+export const DEFAULT_REGISTRY_SURFACES: readonly ActionSurface[] = ACTION_SURFACES;
+
+export interface ActionCliOption {
+	readonly flags: string;
+	readonly description: string;
+	readonly defaultValue?: unknown;
+	readonly required?: boolean;
+}
+
+export interface ActionCliInputContext {
+	readonly args: readonly string[];
+	readonly flags: Record<string, unknown>;
+}
+
+export interface ActionCliSpec<TInput = unknown> {
+	readonly group?: string;
+	readonly command?: string;
+	readonly description?: string;
+	readonly aliases?: readonly string[];
+	readonly options?: readonly ActionCliOption[];
+	readonly mapInput?: (context: ActionCliInputContext) => TInput;
+}
+
+export interface ActionMcpSpec<TInput = unknown> {
+	readonly tool?: string;
+	readonly description?: string;
+	readonly deferLoading?: boolean;
+	readonly mapInput?: (input: unknown) => TInput;
+}
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface ActionApiSpec {
+	readonly method?: HttpMethod;
+	readonly path?: string;
+	readonly tags?: readonly string[];
+}
+
+export interface ActionTrpcSpec {
+	readonly path?: string;
+}
+
+export interface ActionSpec<TInput, TOutput, TError extends KitError = KitError> {
+	readonly id: string;
+	readonly description?: string;
+	readonly surfaces?: readonly ActionSurface[];
+	readonly input: z.ZodType<TInput>;
+	readonly output?: z.ZodType<TOutput>;
+	readonly handler: Handler<TInput, TOutput, TError> | SyncHandler<TInput, TOutput, TError>;
+	readonly cli?: ActionCliSpec<TInput>;
+	readonly mcp?: ActionMcpSpec<TInput>;
+	readonly api?: ActionApiSpec;
+	readonly trpc?: ActionTrpcSpec;
+}
+
+export type AnyActionSpec = ActionSpec<unknown, unknown, KitError>;
+
+export interface ActionRegistry {
+	add<TInput, TOutput, TError extends KitError = KitError>(
+		action: ActionSpec<TInput, TOutput, TError>,
+	): ActionRegistry;
+	list(): AnyActionSpec[];
+	get(id: string): AnyActionSpec | undefined;
+	forSurface(surface: ActionSurface): AnyActionSpec[];
+}
+
+export function defineAction<TInput, TOutput, TError extends KitError = KitError>(
+	action: ActionSpec<TInput, TOutput, TError>,
+): ActionSpec<TInput, TOutput, TError> {
+	return action;
+}
+
+export function createActionRegistry(): ActionRegistry {
+	const actions = new Map<string, AnyActionSpec>();
+
+	return {
+		add(action) {
+			actions.set(action.id, action as AnyActionSpec);
+			return this;
+		},
+		list() {
+			return Array.from(actions.values());
+		},
+		get(id) {
+			return actions.get(id);
+		},
+		forSurface(surface) {
+			const defaults = DEFAULT_REGISTRY_SURFACES as readonly ActionSurface[];
+			return Array.from(actions.values()).filter((action) =>
+				(action.surfaces ?? defaults).includes(surface),
+			);
+		},
+	};
+}

--- a/packages/contracts/src/capabilities.ts
+++ b/packages/contracts/src/capabilities.ts
@@ -1,12 +1,12 @@
 /**
  * @outfitter/contracts - Capability manifest
  *
- * Shared action capability manifest for CLI/MCP/server parity.
+ * Shared action capability manifest for CLI/MCP/API/server parity.
  *
  * @packageDocumentation
  */
 
-export const CAPABILITY_SURFACES = ["cli", "mcp", "server"] as const;
+export const CAPABILITY_SURFACES = ["cli", "mcp", "api", "server"] as const;
 
 export type CapabilitySurface = (typeof CAPABILITY_SURFACES)[number];
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -148,3 +148,25 @@ export {
 } from "./capabilities.js";
 
 export type { CapabilitySurface, ActionCapability } from "./capabilities.js";
+
+// Action registry
+export {
+	ACTION_SURFACES,
+	DEFAULT_REGISTRY_SURFACES,
+	createActionRegistry,
+	defineAction,
+} from "./actions.js";
+
+export type {
+	ActionSurface,
+	ActionSpec,
+	ActionRegistry,
+	AnyActionSpec,
+	ActionCliOption,
+	ActionCliSpec,
+	ActionCliInputContext,
+	ActionMcpSpec,
+	ActionApiSpec,
+	ActionTrpcSpec,
+	HttpMethod,
+} from "./actions.js";


### PR DESCRIPTION
## Summary
- add action registry types/specs with surface filtering
- expose registry helpers for defining and registering actions
- cover registry behavior with unit tests

## Testing
- turbo run test