### PR TITLE
feat(cli): add action registry adapter

### DIFF
--- a/packages/cli/src/__tests__/actions.test.ts
+++ b/packages/cli/src/__tests__/actions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { Result, createActionRegistry, defineAction } from "@outfitter/contracts";
+import { buildCliCommands } from "../actions.js";
+import { createCLI } from "../cli.js";
+
+describe("buildCliCommands", () => {
+	it("registers and runs a simple action", async () => {
+		let called = false;
+		const registry = createActionRegistry().add(
+			defineAction({
+				id: "ping",
+				description: "Ping action",
+				surfaces: ["cli"],
+				input: z.object({}),
+				cli: { command: "ping" },
+				handler: async () => {
+					called = true;
+					return Result.ok({ ok: true });
+				},
+			}),
+		);
+
+		const cli = createCLI({
+			name: "test",
+			version: "0.0.0",
+			onError: (error) => {
+				throw error;
+			},
+			onExit: (code) => {
+				throw new Error(`exit ${code}`);
+			},
+		});
+
+		for (const command of buildCliCommands(registry)) {
+			cli.register(command);
+		}
+
+		await cli.parse(["node", "test", "ping"]);
+
+		expect(called).toBe(true);
+	});
+
+	it("supports grouped subcommands", async () => {
+		let baseCalled = false;
+		let subCalled = false;
+		const registry = createActionRegistry()
+			.add(
+				defineAction({
+					id: "init",
+					surfaces: ["cli"],
+					input: z.object({}),
+					cli: { group: "init", command: "[directory]", mapInput: () => ({}) },
+					handler: async () => {
+						baseCalled = true;
+						return Result.ok({ ok: true });
+					},
+				}),
+			)
+			.add(
+				defineAction({
+					id: "init.cli",
+					surfaces: ["cli"],
+					input: z.object({}),
+					cli: { group: "init", command: "cli [directory]", mapInput: () => ({}) },
+					handler: async () => {
+						subCalled = true;
+						return Result.ok({ ok: true });
+					},
+				}),
+			);
+
+		const cli = createCLI({
+			name: "test",
+			version: "0.0.0",
+			onError: (error) => {
+				throw error;
+			},
+			onExit: (code) => {
+				throw new Error(`exit ${code}`);
+			},
+		});
+
+		for (const command of buildCliCommands(registry)) {
+			cli.register(command);
+		}
+
+		await cli.parse(["node", "test", "init", "cli"]);
+
+		expect(baseCalled).toBe(false);
+		expect(subCalled).toBe(true);
+	});
+});

--- a/packages/cli/src/actions.ts
+++ b/packages/cli/src/actions.ts
@@ -1,0 +1,242 @@
+import { Command } from "commander";
+import {
+	type ActionRegistry,
+	type AnyActionSpec,
+	type ActionSurface,
+	type ActionCliInputContext,
+	DEFAULT_REGISTRY_SURFACES,
+	createContext as createHandlerContext,
+	type HandlerContext,
+	validateInput,
+} from "@outfitter/contracts";
+
+export interface BuildCliCommandsOptions {
+	readonly createContext?: (input: {
+		action: AnyActionSpec;
+		args: readonly string[];
+		flags: Record<string, unknown>;
+	}) => HandlerContext;
+	readonly includeSurfaces?: readonly ActionSurface[];
+}
+
+type ActionSource = ActionRegistry | readonly AnyActionSpec[];
+
+const ARGUMENT_PREFIXES = ["<", "["];
+
+function isArgumentToken(token: string | undefined): boolean {
+	if (!token) {
+		return false;
+	}
+	return ARGUMENT_PREFIXES.some((prefix) => token.startsWith(prefix));
+}
+
+function splitCommandSpec(spec: string): { name: string | undefined; args: string[] } {
+	const parts = spec.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0) {
+		return { name: undefined, args: [] };
+	}
+	return { name: parts[0], args: parts.slice(1) };
+}
+
+function applyArguments(command: Command, args: string[]): void {
+	for (const arg of args) {
+		command.argument(arg);
+	}
+}
+
+function applyCliOptions(command: Command, action: AnyActionSpec): void {
+	const options = action.cli?.options ?? [];
+	for (const option of options) {
+		if (option.required) {
+			command.requiredOption(option.flags, option.description, option.defaultValue);
+		} else {
+			command.option(option.flags, option.description, option.defaultValue);
+		}
+	}
+}
+
+function resolveDescription(action: AnyActionSpec): string {
+	return action.cli?.description ?? action.description ?? action.id;
+}
+
+function resolveAliases(action: AnyActionSpec): readonly string[] {
+	return action.cli?.aliases ?? [];
+}
+
+function resolveCommandSpec(action: AnyActionSpec): string {
+	return action.cli?.command ?? action.id;
+}
+
+function resolveFlags(command: Command): Record<string, unknown> {
+	return (command.optsWithGlobals?.() ?? command.opts()) as Record<string, unknown>;
+}
+
+function resolveInput(action: AnyActionSpec, context: ActionCliInputContext): unknown {
+	if (action.cli?.mapInput) {
+		return action.cli.mapInput(context);
+	}
+
+	const hasFlags = Object.keys(context.flags).length > 0;
+	if (!hasFlags && context.args.length === 0) {
+		return {};
+	}
+
+	return {
+		...context.flags,
+		...(context.args.length > 0 ? { args: context.args } : {}),
+	};
+}
+
+async function runAction(
+	action: AnyActionSpec,
+	command: Command,
+	createContext: (input: {
+		action: AnyActionSpec;
+		args: readonly string[];
+		flags: Record<string, unknown>;
+	}) => HandlerContext,
+): Promise<void> {
+	const flags = resolveFlags(command);
+	const args = command.args as string[];
+	const inputContext: ActionCliInputContext = { args, flags };
+	const input = resolveInput(action, inputContext);
+	const validation = validateInput(action.input, input);
+
+	if (validation.isErr()) {
+		throw validation.error;
+	}
+
+	const ctx = createContext({ action, args, flags });
+
+	const result = await action.handler(validation.value, ctx);
+	if (result.isErr()) {
+		throw result.error;
+	}
+}
+
+function createCommand(
+	action: AnyActionSpec,
+	createContext: (input: {
+		action: AnyActionSpec;
+		args: readonly string[];
+		flags: Record<string, unknown>;
+	}) => HandlerContext,
+	spec?: string,
+): Command {
+	const commandSpec = spec ?? resolveCommandSpec(action);
+	const { name, args } = splitCommandSpec(commandSpec);
+
+	if (!name) {
+		throw new Error(`Missing CLI command name for action ${action.id}`);
+	}
+
+	const command = new Command(name);
+	command.description(resolveDescription(action));
+	applyCliOptions(command, action);
+	applyArguments(command, args);
+
+	for (const alias of resolveAliases(action)) {
+		command.alias(alias);
+	}
+
+	command.action(async (...argsList: unknown[]) => {
+		const commandInstance = argsList[argsList.length - 1] as Command;
+		await runAction(action, commandInstance, createContext);
+	});
+
+	return command;
+}
+
+export function buildCliCommands(
+	source: ActionSource,
+	options: BuildCliCommandsOptions = {},
+): Command[] {
+	const actions = isActionRegistry(source) ? source.list() : source;
+	const includeSurfaces: readonly ActionSurface[] = options.includeSurfaces ?? ["cli"];
+	const commands: Command[] = [];
+	const createContext =
+		options.createContext ??
+		((_input) =>
+			createHandlerContext({
+				cwd: process.cwd(),
+				env: process.env as Record<string, string | undefined>,
+			}));
+
+	const grouped = new Map<string, AnyActionSpec[]>();
+	const ungrouped: AnyActionSpec[] = [];
+
+	for (const action of actions) {
+		const surfaces: readonly ActionSurface[] = action.surfaces ?? DEFAULT_REGISTRY_SURFACES;
+		if (!surfaces.some((surface) => includeSurfaces.includes(surface))) {
+			continue;
+		}
+
+		const group = action.cli?.group;
+		if (group) {
+			const groupActions = grouped.get(group) ?? [];
+			groupActions.push(action);
+			grouped.set(group, groupActions);
+		} else {
+			ungrouped.push(action);
+		}
+	}
+
+	for (const action of ungrouped) {
+		commands.push(createCommand(action, createContext));
+	}
+
+	for (const [groupName, groupActions] of grouped.entries()) {
+		const groupCommand = new Command(groupName);
+		let baseAction: AnyActionSpec | undefined;
+		const subcommands: AnyActionSpec[] = [];
+
+		for (const action of groupActions) {
+			const spec = action.cli?.command?.trim() ?? "";
+			const { name, args } = splitCommandSpec(spec);
+
+			if (!name || isArgumentToken(name)) {
+				if (baseAction) {
+					throw new Error(
+						`Group '${groupName}' defines multiple base actions: '${baseAction.id}' and '${action.id}'.`,
+					);
+				}
+				baseAction = action;
+				groupCommand.description(resolveDescription(action));
+				applyCliOptions(groupCommand, action);
+				applyArguments(groupCommand, name ? [name, ...args] : args);
+
+				for (const alias of resolveAliases(action)) {
+					groupCommand.alias(alias);
+				}
+
+				groupCommand.action(async (...argsList: unknown[]) => {
+					const commandInstance = argsList[argsList.length - 1] as Command;
+					await runAction(action, commandInstance, createContext);
+				});
+			} else {
+				subcommands.push(action);
+			}
+		}
+
+		for (const action of subcommands) {
+			const spec = resolveCommandSpec(action);
+			const { name, args } = splitCommandSpec(spec);
+			if (!name) {
+				continue;
+			}
+			const subcommand = createCommand(action, createContext, [name, ...args].join(" "));
+			groupCommand.addCommand(subcommand);
+		}
+
+		if (!baseAction) {
+			groupCommand.description(groupName);
+		}
+
+		commands.push(groupCommand);
+	}
+
+	return commands;
+}
+function isActionRegistry(source: ActionSource): source is ActionRegistry {
+	return "list" in source;
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -86,8 +86,12 @@ export function createCLI(config: CLIConfig): CLI {
 
 	const cli: CLI = {
 		program,
-		register: (builder: CommandBuilder): CLI => {
-			program.addCommand(builder.build());
+		register: (builderOrCommand: CommandBuilder | Command): CLI => {
+			if ("build" in builderOrCommand) {
+				program.addCommand(builderOrCommand.build());
+			} else {
+				program.addCommand(builderOrCommand);
+			}
 			return cli;
 		},
 		parse,

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -45,7 +45,7 @@ class CommandBuilderImpl implements CommandBuilder {
 	action<TFlags extends CommandFlags = CommandFlags>(handler: CommandAction<TFlags>): this {
 		this.command.action(async (...args: unknown[]) => {
 			const command = args[args.length - 1] as Command;
-			const flags = command.opts() as TFlags;
+			const flags = (command.optsWithGlobals?.() ?? command.opts()) as TFlags;
 			const positional = command.args as string[];
 			await handler({ args: positional, flags, command });
 		});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,6 +43,10 @@ export { createCLI } from "./cli.js";
 // Command builder
 export { command } from "./command.js";
 
+// Action adapter
+export { buildCliCommands } from "./actions.js";
+export type { BuildCliCommandsOptions } from "./actions.js";
+
 // Output utilities
 export { output, exitWithError } from "./output.js";
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -45,7 +45,7 @@ export interface CLIConfig {
  */
 export interface CLI {
 	/** Register a command with the CLI */
-	register(command: CommandBuilder): this;
+	register(command: CommandBuilder | Command): this;
 
 	/** Parse arguments and execute the matched command */
 	parse(argv?: readonly string[]): Promise<void>;

--- a/packages/contracts/src/actions.ts
+++ b/packages/contracts/src/actions.ts
@@ -11,7 +11,7 @@ export const DEFAULT_REGISTRY_SURFACES: readonly ActionSurface[] = ACTION_SURFAC
 export interface ActionCliOption {
 	readonly flags: string;
 	readonly description: string;
-	readonly defaultValue?: unknown;
+	readonly defaultValue?: string | boolean | string[];
 	readonly required?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- add buildCliCommands adapter for action registry definitions
- support grouped commands and default input mapping
- update CLI register types and add adapter tests

## Testing
- turbo run test