### PR TITLE
feat(mcp): add action registry adapter

### DIFF
--- a/packages/mcp/src/__tests__/actions.test.ts
+++ b/packages/mcp/src/__tests__/actions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { Result, createActionRegistry, defineAction, createContext } from "@outfitter/contracts";
+import { buildMcpTools } from "../actions.js";
+
+describe("buildMcpTools", () => {
+	it("builds tools from registry actions", async () => {
+		const registry = createActionRegistry().add(
+			defineAction({
+				id: "greet",
+				description: "Greet someone",
+				surfaces: ["mcp"],
+				input: z.object({ name: z.string() }),
+				handler: async (input) => Result.ok({ greeting: `Hello, ${input.name}` }),
+			}),
+		);
+
+		const tools = buildMcpTools(registry);
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("greet");
+
+		const ctx = createContext({ env: {} });
+		const result = await tools[0].handler({ name: "Ada" }, ctx);
+		expect(result.isOk()).toBe(true);
+	});
+
+	it("skips actions without MCP surface", () => {
+		const registry = createActionRegistry().add(
+			defineAction({
+				id: "cli-only",
+				surfaces: ["cli"],
+				input: z.object({}),
+				handler: async () => Result.ok({ ok: true }),
+			}),
+		);
+
+		const tools = buildMcpTools(registry);
+		expect(tools).toHaveLength(0);
+	});
+});

--- a/packages/mcp/src/actions.ts
+++ b/packages/mcp/src/actions.ts
@@ -1,0 +1,39 @@
+import type { ActionRegistry, AnyActionSpec, ActionSurface } from "@outfitter/contracts";
+import { DEFAULT_REGISTRY_SURFACES } from "@outfitter/contracts";
+import type { ToolDefinition } from "./types.js";
+import { defineTool } from "./server.js";
+
+export interface BuildMcpToolsOptions {
+	readonly includeSurfaces?: readonly ActionSurface[];
+}
+
+type ActionSource = ActionRegistry | readonly AnyActionSpec[];
+
+function isActionRegistry(source: ActionSource): source is ActionRegistry {
+	return "list" in source;
+}
+
+export function buildMcpTools(
+	source: ActionSource,
+	options: BuildMcpToolsOptions = {},
+): ToolDefinition<unknown, unknown>[] {
+	const actions = isActionRegistry(source) ? source.list() : source;
+	const includeSurfaces: readonly ActionSurface[] = options.includeSurfaces ?? ["mcp"];
+
+	return actions
+		.filter((action) => {
+			const surfaces: readonly ActionSurface[] = action.surfaces ?? DEFAULT_REGISTRY_SURFACES;
+			return surfaces.some((surface) => includeSurfaces.includes(surface));
+		})
+		.map((action) =>
+			defineTool({
+				name: action.mcp?.tool ?? action.id,
+				description: action.mcp?.description ?? action.description ?? action.id,
+				inputSchema: action.input,
+				handler: async (input, ctx) => action.handler(input, ctx),
+				...(action.mcp?.deferLoading !== undefined
+					? { deferLoading: action.mcp.deferLoading }
+					: {}),
+			}),
+		);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -74,3 +74,7 @@ export {
 
 // Transport helpers
 export { connectStdio, createSdkServer, type McpToolResponse } from "./transport.js";
+
+// Action adapter
+export { buildMcpTools } from "./actions.js";
+export type { BuildMcpToolsOptions } from "./actions.js";


### PR DESCRIPTION
## Summary
- add buildMcpTools adapter for action registry definitions
- pass through MCP metadata like tool names and deferLoading
- add adapter test coverage

## Testing
- turbo run test