### PR TITLE
docs(rc): add migration survey notes

### DIFF
--- a/docs/v0.1-rc/MIGRATION.md
+++ b/docs/v0.1-rc/MIGRATION.md
@@ -1,0 +1,174 @@
+# Agent-Guided Init + Migration (Stub)
+
+**Date**: 2026-01-25  
+**Status**: Draft (repo survey captured, needs decisions)
+
+## Purpose
+Define an agent-guided experience for:
+1) **Init**: smarter scaffold + naming + defaults, driven by an agent.
+2) **Migrate**: adopt Kit in existing repos with minimal divergence and clear checkpoints.
+
+Tracking: `MONO-80`
+
+## Goals
+- Provide a repeatable migration flow with clear checkpoints.
+- Normalize package/scripts/config alignment across repos.
+- Avoid destructive changes; keep PRs small, staged, and reversible.
+- Capture project-specific deltas and feed learnings back into Kit.
+
+## Non-Goals (for RC)
+- Full automation without human approval.
+- One-click migration for every repo shape.
+- Rewriting app architecture beyond Kit adoption.
+
+## Agent-Guided Init (Concept)
+- **Prompted flow**: template selection, package/bin names, runtime deps.
+- **Intent capture**: CLI/MCP/server surfaces, transport preference, logging,
+  config strategy, testing.
+- **Output**: scaffolded project + a migration checklist for next steps.
+
+### Draft Prompt Set (v0)
+**Project identity**
+- Project name, package name (scoped?), bin name, description
+- Author (person/org), year (optional), license
+
+**Surfaces & transport**
+- CLI / MCP / daemon / server (select all that apply)
+- MCP transport: stdio now; plan for HTTP/SSE later?
+- API style (tRPC default; REST/OpenAPI when needed)
+
+**Runtime + tooling**
+- Bun vs Node (default Bun)
+- Lint/format baseline (Biome)
+- Testing (Bun test; Playwright optional)
+- Config/logging defaults (Kit config + logtape)
+
+**Data + storage**
+- SQLite default (bun:sqlite) vs Postgres/Supabase/Neon
+- Indexing needs (FTS5 / @outfitter/index)
+
+**Publish + local dev**
+- Local dev mode (`workspace:*`) vs published RC pins
+- NPM scope + dist tags (rc vs latest)
+
+**Outputs**
+- Scaffolded project (templates + configs)
+- Decision log (what was chosen + why)
+- Follow‑up checklist (migration, parity, tests)
+
+## Migration Skill (Concept)
+### Inputs
+- Repo type (single package / monorepo).
+- Runtime (Bun/Node) + package manager.
+- Existing CLI/MCP/server surface.
+- Current scripts, config, and testing setup.
+
+### Phases
+1) **Inventory**
+   - Identify packages, entrypoints, commands, and transports.
+   - Record tooling: lint, format, test, build, CI.
+2) **Align Tooling**
+   - Standardize scripts and baseline config where feasible.
+   - Add Kit packages with minimal surface changes.
+3) **Surface Bridging**
+   - Map CLI/MCP/API to Kit action registry + capability manifest.
+   - Ensure tool search compatibility for MCP.
+4) **Adopt Defaults**
+   - Swap logging/config/testing helpers to Kit variants.
+   - Add migrations/version headers where relevant (index).
+5) **Verify**
+   - Run test/build/typecheck.
+   - Smoke test CLI/MCP behavior.
+
+### Outputs
+- Minimal set of PRs with tight scope.
+- Documented deltas (kept vs aligned).
+- Known follow-ups tracked as Linear issues.
+
+## Repo Survey (Current)
+| Repo | Shape | Surfaces | Notes | Migration Risks |
+| --- | --- | --- | --- | --- |
+| firewatch | Monorepo (`apps/*`, `packages/*`) | CLI (`fw`), MCP (`fw-mcp`) | Bun + TS, oxlint/oxfmt, tests in `apps/*/tests` | Not using Kit contracts/handlers, format mismatch, commander v13, plugin folder not a package |
+| north | Monorepo (`packages/north`, `examples`, `harness`) | CLI (`north`), MCP (`north-mcp`), lib | Bun + TS, native deps | `better-sqlite3`/`ast-grep` coupling, tests layout, zod v4, commander v12 |
+| navigator | Monorepo (`packages/*`) + extension | CLI (`nav`), MCP (`navigator-mcp`), HTTP server, extension | Bun + TS, Biome (single quotes) | Formatting mismatch, handler contract mismatch, extension surface complexity |
+| waymark | Monorepo (`apps/mcp`, `packages/*`) | CLI (`wm`/`waymark`), MCP (`waymark-mcp`) | Bun + TS, Turbo, ultracite | zod v4 vs v3 split, logging/prompt stack mismatch |
+
+### Repo Deep Dives
+- `docs/v0.1-rc/migrations/firewatch.md`
+- `docs/v0.1-rc/migrations/north.md`
+- `docs/v0.1-rc/migrations/navigator.md`
+- `docs/v0.1-rc/migrations/waymark.md`
+
+### Firewatch Notes
+**Shape**: Workspaces in root (`apps/*`, `packages/*`), plus `packages/claude-plugin/firewatch` (no `package.json`).  
+**Surfaces**: CLI (`fw`), MCP (`fw-mcp`), core/shared libs.  
+**Concerns**:
+- No Kit handler contract or error taxonomy (ad-hoc Result types).
+- Oxlint/oxfmt vs Kit Biome config (format drift).
+- Tests live in `apps/*/tests` and `packages/*/tests`, not `src/__tests__`.
+- CLI uses `commander@^13` (Kit prefers 14+).
+**Migration Checklist**:
+- Introduce `@outfitter/contracts` Result + error taxonomy in core.
+- Rewire CLI/MCP adapters to Kit (`@outfitter/cli`, `@outfitter/mcp`).
+- Align lint/format to Kit Biome; reformat.
+- Normalize test layout or adjust tooling.
+- Decide where `packages/claude-plugin` lives (apps/docs/templates).
+
+### North Notes
+**Shape**: Monorepo with `packages/north`, `examples/nextjs-shadcn`, `harness`.  
+**Surfaces**: CLI + MCP + library.  
+**Concerns**:
+- Native deps (`better-sqlite3`, `@ast-grep/napi`) complicate portability; consider Kit `@outfitter/index`/`bun:sqlite`.
+- Direct use of Commander/MCP SDK; not Kit adapters.
+- Biome config uses spaces; Kit requires tabs/double quotes.
+- zod v4 + commander v12 mismatch.
+**Migration Checklist**:
+- Move handlers to Kit Result contract + errors.
+- Adopt `@outfitter/cli`, `@outfitter/mcp`, `@outfitter/config`, `@outfitter/logging`.
+- Normalize deps (zod v4, commander v14+).
+- Align formatting + test layout.
+
+### Navigator Notes
+**Shape**: Monorepo `packages/*` (core/server/mcp/cli/extension/agents).  
+**Surfaces**: CLI, MCP, HTTP server, Chrome extension.  
+**Concerns**:
+- Format mismatch (single quotes, semicolons as-needed).
+- Tests live in `packages/*/tests`, not `src/__tests__`.
+- Capability manifest exists; needs mapping to Kit action registry.
+- TS strict flags differ from Kit; update required.
+**Migration Checklist**:
+- Preserve capability manifest or map to Kit registry.
+- Port CLI/MCP to Kit adapters; keep server Hono surface.
+- Align Biome config + TS strict flags.
+- Decide how to treat extension within Kit (app vs separate repo).
+
+### Waymark Notes
+**Shape**: Monorepo with `apps/mcp`, `packages/{cli,core,grammar}`, `packages/agents` (content).  
+**Surfaces**: CLI (`wm`/`waymark`), MCP (`waymark-mcp`).  
+**Concerns**:
+- Zod v4 in core/cli vs Zod v3 in MCP; Kit prefers v4.
+- Logging/prompt stack uses pino/ora/inquirer; Kit uses logtape + clack.
+- No Kit handler contract.
+**Migration Checklist**:
+- Normalize zod + adopt Kit Result contract.
+- Replace logging/prompt stack with Kit packages.
+- Align lint/format and tests layout.
+- Decide where `packages/agents` belongs (docs/templates).
+
+## Areas of Concern (Expanded)
+- workspace vs published deps (`workspace:*` in templates vs npm publish)
+- CLI/MCP parity + action registry drift
+- Transport choices (stdio vs HTTP)
+- Existing testing harness compatibility
+- Version pinning and release flow
+- Formatting config mismatch (Biome tabs/double quotes vs repo defaults)
+- Zod version drift (v4 baseline vs older versions)
+- Test layout mismatch (`tests/` vs `src/__tests__`)
+- Native deps + bundling constraints (sqlite/ast-grep)
+- Extension/front-end surfaces that don’t fit Kit tiering
+
+## Open Questions
+- What should be the default “agent init” prompt set?
+- Which migrations are always safe vs opt-in?
+- How do we record project-specific divergences in a reusable way?
+- Should the migration skill live as a Kit CLI command, or an agent-only workflow?

--- a/docs/v0.1-rc/migrations/firewatch.md
+++ b/docs/v0.1-rc/migrations/firewatch.md
@@ -1,0 +1,66 @@
+# Firewatch → Kit Migration
+
+**Date**: 2026-01-25  
+**Status**: Draft
+
+## Snapshot
+- **Repo**: `/Users/mg/Developer/outfitter/firewatch`
+- **Shape**: Monorepo (`apps/*`, `packages/*`)
+- **Workspaces**: `packages/*`, `apps/*`
+- **Runtime**: Bun + TypeScript (ESM)
+- **Tooling**: oxlint/oxfmt, Bun test, custom verify scripts
+- **Surfaces**:
+  - CLI: `fw` (`apps/cli/bin/fw.ts`)
+  - MCP: `fw-mcp` (`apps/mcp/bin/fw-mcp.ts`)
+  - Core libs: `packages/core`, `packages/shared`
+  - Plugin assets: `packages/claude-plugin/firewatch` (not a package)
+
+## Key Entrypoints
+- **CLI**: `apps/cli/bin/fw.ts` → `apps/cli/src/index.ts`
+- **MCP**: `apps/mcp/bin/fw-mcp.ts` → `apps/mcp/src/index.ts`
+- **Core**: `packages/core/src/index.ts`
+- **Shared**: `packages/shared/src/index.ts`
+
+## Kit Deltas
+- **Handler contract**: core logic does not use Kit `Result<T,E>` + error taxonomy.
+- **Adapters**: CLI/MCP use raw Commander + MCP SDK instead of `@outfitter/cli` + `@outfitter/mcp`.
+- **Formatting**: oxlint/oxfmt vs Kit Biome conventions (tabs, double quotes).
+- **Tests**: `apps/*/tests` and `packages/*/tests` (Kit expects `src/__tests__`).
+- **Deps**: Commander `^13` (Kit prefers `^14`).
+- **Non-package assets**: `packages/claude-plugin/firewatch` needs a clear home.
+
+## Migration Plan (Phased)
+### Phase 0 — Inventory
+- Map CLI + MCP commands to core functions (identify shared handlers).
+- Enumerate output shapes + error handling (baseline for parity).
+- Identify plugin asset usage + distribution requirements.
+
+### Phase 1 — Tooling Alignment
+- Adopt Kit Biome config; remove oxlint/oxfmt or scope them to legacy.
+- Normalize scripts to Kit baseline (build/test/typecheck/lint/format).
+- Decide on test layout migration (`tests/` → `src/__tests__`).
+
+### Phase 2 — Handler Contract
+- Introduce `@outfitter/contracts` in core logic (Result + error taxonomy).
+- Wrap existing core ops into transport-agnostic handlers.
+- Add small adapter tests around handlers.
+
+### Phase 3 — CLI + MCP Adapters
+- Replace CLI wiring with `@outfitter/cli` adapter.
+- Replace MCP wiring with `@outfitter/mcp` server + tool registry.
+- Keep command/tool names stable for compatibility.
+
+### Phase 4 — Verification
+- Run full test suite + targeted CLI/MCP smoke tests.
+- Validate output parity for key commands.
+- Add regression tests for CLI/MCP wiring where missing.
+
+## Risks / Decisions
+- **Plugin assets**: decide if `packages/claude-plugin/firewatch` becomes `apps/` or `docs/` assets.
+- **Formatting migration**: large diff risk; may need a dedicated formatting PR.
+- **Test layout move**: can be deferred if tooling supports current layout.
+
+## Quick Wins
+- Add `@outfitter/contracts` + Result in core without changing CLI/MCP.
+- Introduce a minimal action registry map for CLI/MCP parity.
+- Add Kit-compatible scripts without altering code structure.

--- a/docs/v0.1-rc/migrations/navigator.md
+++ b/docs/v0.1-rc/migrations/navigator.md
@@ -1,0 +1,66 @@
+# Navigator → Kit Migration
+
+**Date**: 2026-01-25  
+**Status**: Draft
+
+## Snapshot
+- **Repo**: `/Users/mg/Developer/outfitter/navigator`
+- **Shape**: Monorepo (`packages/*`) + extension package
+- **Workspaces**: `packages/*`
+- **Runtime**: Bun + TypeScript (ESM)
+- **Tooling**: Biome (single quotes), Bun test, Turbo-style scripts
+- **Surfaces**:
+  - CLI: `nav` (`packages/cli/src/index.ts`)
+  - MCP: `navigator-mcp` (`packages/mcp/src/index.ts`)
+  - HTTP server: `packages/server/src/index.ts`
+  - Extension: `packages/extension` (Vite/CRX)
+
+## Key Entrypoints
+- **CLI**: `packages/cli/src/index.ts`
+- **MCP**: `packages/mcp/src/index.ts`
+- **Server**: `packages/server/src/index.ts`
+- **Core schema**: `packages/core/src/schema/*`
+- **Capability manifest**: `packages/core/src/capabilities/manifest.ts`
+
+## Kit Deltas
+- **Formatting**: Biome single quotes / semicolons as-needed vs Kit tabs/double quotes.
+- **Handler contract**: core + server aren’t aligned to Kit Result/error taxonomy.
+- **Adapters**: CLI/MCP do not use Kit adapters.
+- **Tests**: `packages/*/tests` vs `src/__tests__` layout.
+- **Extension**: non-Kit surface that may remain outside migration scope.
+
+## Migration Plan (Phased)
+### Phase 0 — Inventory
+- Map commands/tools to core actions + capability manifest.
+- Identify shared handler candidates across CLI/MCP/server.
+- Define extension integration boundaries (in-scope vs out-of-scope).
+
+### Phase 1 — Tooling Alignment
+- Align Biome config to Kit conventions.
+- Normalize scripts to Kit baseline (build/test/typecheck/lint/format).
+- Decide on test layout migration or tooling compatibility.
+
+### Phase 2 — Handler Contract
+- Refactor core actions to Kit Result/error taxonomy.
+- Introduce handler layer shared by CLI/MCP/server.
+- Add handler unit tests using `@outfitter/testing`.
+
+### Phase 3 — CLI + MCP Adapters
+- Replace CLI wiring with `@outfitter/cli`.
+- Replace MCP wiring with `@outfitter/mcp` tool registry.
+- Preserve capability manifest as source-of-truth; map to Kit action registry.
+
+### Phase 4 — Verification
+- Run `bun run test` and focused CLI/MCP smoke tests.
+- Validate HTTP server behavior unchanged.
+- Ensure extension continues to function if out of migration scope.
+
+## Risks / Decisions
+- **Extension scope**: keep as separate app or migrate into Kit `apps/`?
+- **Capability manifest**: align existing manifest to Kit `capabilities.ts` or keep separate.
+- **Formatting**: large diff risk; consider a formatting-only PR.
+
+## Quick Wins
+- Introduce Kit contracts layer without refactoring transports.
+- Add a minimal action registry map for CLI/MCP parity.
+- Document capability manifest mapping to Kit actions.

--- a/docs/v0.1-rc/migrations/north.md
+++ b/docs/v0.1-rc/migrations/north.md
@@ -1,0 +1,64 @@
+# North → Kit Migration
+
+**Date**: 2026-01-25  
+**Status**: Draft
+
+## Snapshot
+- **Repo**: `/Users/mg/Developer/outfitter/north`
+- **Shape**: Monorepo (`packages/*`, `examples/*`, `harness/`)
+- **Workspaces**: `packages/*`, `examples/*`
+- **Runtime**: Bun + TypeScript (ESM)
+- **Tooling**: Turbo, Biome (spaces), lefthook, Bun test
+- **Surfaces**:
+  - CLI: `north` (`packages/north/src/cli/index.ts`)
+  - MCP: `north-mcp` (`packages/north/src/mcp/index.ts`)
+  - Library: `packages/north/src/index.ts`
+
+## Key Entrypoints
+- **CLI**: `packages/north/src/cli/index.ts`
+- **MCP**: `packages/north/src/mcp/index.ts`
+- **Core library**: `packages/north/src/index.ts`
+- **MCP tools**: `packages/north/src/mcp/tools/*`
+
+## Kit Deltas
+- **Native deps**: `better-sqlite3` + `@ast-grep/napi` are externalized; consider Kit `@outfitter/index` or `bun:sqlite` to reduce native coupling.
+- **Adapters**: CLI/MCP use raw Commander + MCP SDK.
+- **Formatting**: Biome spaces vs Kit tabs/double quotes.
+- **Deps**: zod v4 + commander v12 (Kit prefers zod v4 / commander v14+).
+- **Handler contract**: no Kit Result/error taxonomy in core.
+
+## Migration Plan (Phased)
+### Phase 0 — Inventory
+- Map CLI commands → MCP tools → shared handler candidates.
+- Identify data flow around indexing, parsing, and storage.
+- Inventory config/state paths (alignment with Kit config expectations).
+
+### Phase 1 — Tooling Alignment
+- Update Biome config to Kit defaults (tabs, double quotes, 100 cols).
+- Add Kit standard scripts if missing (lint:fix, test:watch, format).
+- Decide on test layout migration or compatibility shim.
+
+### Phase 2 — Handler Contract
+- Introduce `@outfitter/contracts` in core logic with Result + error taxonomy.
+- Wrap key operations (scan/index/check/context) as handlers.
+- Add handler-level tests with Kit testing helpers.
+
+### Phase 3 — CLI + MCP Adapters
+- Move CLI wiring to `@outfitter/cli`.
+- Rebuild MCP tool registry via `@outfitter/mcp` (keep tool names stable).
+- Ensure tool search metadata alignment for MCP.
+
+### Phase 4 — Verification
+- Run `bun run test` + targeted CLI/MCP smoke tests.
+- Confirm parity for key commands and MCP tool outputs.
+- Validate build pipeline with Kit conventions.
+
+## Risks / Decisions
+- **Native deps**: decide whether to keep native SQLite/ast-grep or switch to Kit index stack.
+- **Zod version**: ensure any v3 usage is upgraded to v4 for baseline parity.
+- **Script parity**: avoid breaking existing automation (harness/scripts).
+
+## Quick Wins
+- Add Kit contracts + error taxonomy without changing CLI/MCP.
+- Add `capability` manifest mapping for tool parity.
+- Document a migration compatibility layer for `better-sqlite3` before swapping.

--- a/docs/v0.1-rc/migrations/waymark.md
+++ b/docs/v0.1-rc/migrations/waymark.md
@@ -1,0 +1,64 @@
+# Waymark → Kit Migration
+
+**Date**: 2026-01-25  
+**Status**: Draft
+
+## Snapshot
+- **Repo**: `/Users/mg/Developer/outfitter/waymark`
+- **Shape**: Monorepo (`packages/*`, `apps/*`)
+- **Workspaces**: `packages/*`, `apps/*`
+- **Runtime**: Bun + TypeScript (ESM)
+- **Tooling**: Turbo, Biome/Ultracite, markdownlint
+- **Surfaces**:
+  - CLI: `wm` / `waymark` (`packages/cli/src/index.ts`)
+  - MCP: `waymark-mcp` (`apps/mcp/src/index.ts`)
+  - Core libs: `packages/core`, `packages/grammar`
+  - Agent assets: `packages/agents` (content, not a package)
+
+## Key Entrypoints
+- **CLI**: `packages/cli/src/index.ts`
+- **MCP**: `apps/mcp/src/index.ts`
+- **Core**: `packages/core/src/index.ts`
+- **Grammar**: `packages/grammar/src/index.ts`
+
+## Kit Deltas
+- **Zod drift**: core/cli use v4, MCP uses v3; Kit prefers v4.
+- **Logging/UX**: pino/ora/inquirer vs Kit logtape + clack.
+- **Adapters**: CLI/MCP use raw Commander + MCP SDK.
+- **Handler contract**: no Kit Result/error taxonomy in core.
+- **Agents assets**: `packages/agents` is not a package; decide where it belongs.
+
+## Migration Plan (Phased)
+### Phase 0 — Inventory
+- Map CLI commands and MCP tools to shared handler candidates.
+- Identify config/state paths and how they map to Kit config.
+- Decide scope for `packages/agents` content.
+
+### Phase 1 — Tooling Alignment
+- Align Biome config to Kit defaults (tabs/double quotes).
+- Normalize scripts to Kit baseline (build/test/typecheck/lint/format).
+- Decide on test layout migration or compatibility.
+
+### Phase 2 — Handler Contract
+- Introduce `@outfitter/contracts` Result + error taxonomy.
+- Wrap core operations in handlers (scan/format/lint/etc.).
+- Add handler tests using `@outfitter/testing` helpers.
+
+### Phase 3 — CLI + MCP Adapters
+- Rewire CLI to `@outfitter/cli` adapters.
+- Rewire MCP to `@outfitter/mcp` tool registry.
+- Preserve command/tool names to avoid breaking user flows.
+
+### Phase 4 — Verification
+- Run `bun run test` + targeted CLI/MCP smoke tests.
+- Validate output parity for core commands.
+
+## Risks / Decisions
+- **Zod migration**: v3 → v4 alignment requires careful schema updates.
+- **Logging/UX**: replacing prompts/spinners may change UX.
+- **Agent assets**: decide if this becomes `docs/` or template content.
+
+## Quick Wins
+- Introduce Kit contracts + error taxonomy in core.
+- Add a capability manifest for CLI/MCP parity.
+- Start replacing logging with `@outfitter/logging` in isolated modules.


### PR DESCRIPTION
## Summary
- expand migration doc with agent-guided init prompt set
- add per-repo migration deep dives for firewatch, north, navigator, waymark
- link deep dives from MIGRATION.md for easy navigation

## Testing
- turbo run test
