### PR TITLE
fix(types): add missing dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,7 +94,6 @@
         "zod": "^4.3.5",
       },
       "devDependencies": {
-        "@outfitter/types": "workspace:*",
         "@types/bun": "latest",
         "typescript": "^5.8.0",
       },
@@ -228,6 +227,10 @@
     "packages/types": {
       "name": "@outfitter/types",
       "version": "0.1.0-rc.1",
+      "dependencies": {
+        "@outfitter/contracts": "workspace:*",
+        "better-result": "^2.5.0",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.8.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -121,7 +121,6 @@
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
-		"@outfitter/types": "workspace:*",
 		"@types/bun": "latest",
 		"typescript": "^5.8.0"
 	},

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -66,6 +66,10 @@
 		"typecheck": "tsc --noEmit",
 		"clean": "rm -rf dist"
 	},
+	"dependencies": {
+		"@outfitter/contracts": "workspace:*",
+		"better-result": "^2.5.0"
+	},
 	"devDependencies": {
 		"@types/bun": "latest",
 		"typescript": "^5.8.0"


### PR DESCRIPTION
## Summary
- declare @outfitter/contracts and better-result as @outfitter/types dependencies
- remove unused @outfitter/types devDependency from contracts to avoid cycles

## Testing
- bun run lint
- bun run format:check
- bun run typecheck
- turbo run test
