### PR TITLE
ci: add NPM publishing automation with provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run check
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Create Release Pull Request or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: bun run version-packages
+          publish: bun run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@outfitter:registry=https://registry.npmjs.org/

--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -1,25 +1,49 @@
 {
   "name": "outfitter",
-  "version": "0.1.0-rc.1",
   "description": "Outfitter umbrella CLI for scaffolding and project management",
+  "version": "0.1.0-rc.1",
   "type": "module",
-  "bin": {
-    "outfitter": "./dist/cli.js"
-  },
   "files": [
     "dist",
     "templates"
   ],
-  "module": "./dist/cli.js",
-  "types": "./dist/cli.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/cli.d.ts",
-        "default": "./dist/cli.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./actions": {
+      "import": {
+        "types": "./dist/actions.d.ts",
+        "default": "./dist/actions.js"
+      }
+    },
+    "./commands/doctor": {
+      "import": {
+        "types": "./dist/commands/doctor.d.ts",
+        "default": "./dist/commands/doctor.js"
+      }
+    },
+    "./commands/init": {
+      "import": {
+        "types": "./dist/commands/init.d.ts",
+        "default": "./dist/commands/init.js"
+      }
+    },
+    "./commands/shared-deps": {
+      "import": {
+        "types": "./dist/commands/shared-deps.d.ts",
+        "default": "./dist/commands/shared-deps.js"
       }
     },
     "./package.json": "./package.json"
+  },
+  "bin": {
+    "outfitter": "./dist/cli.js"
   },
   "sideEffects": false,
   "scripts": {

--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 import {
   type ActionCliInputContext,
   type ActionCliOption,
+  type ActionRegistry,
   createActionRegistry,
   defineAction,
   InternalError,
@@ -163,7 +164,7 @@ const doctorAction = defineAction({
   },
 });
 
-export const outfitterActions = createActionRegistry()
+export const outfitterActions: ActionRegistry = createActionRegistry()
   .add(
     createInitAction({
       id: "init",

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -101,6 +101,10 @@ export default defineWorkspace(
       name: "@outfitter/stack",
       root: "packages/stack",
     },
+    {
+      name: "outfitter",
+      root: "apps/outfitter",
+    },
   ],
   {
     // Entry points: all source files except tests

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -51,5 +51,21 @@
   },
   "peerDependencies": {
     "bun": ">=1.0.0"
+  },
+  "keywords": [
+    "outfitter",
+    "agents",
+    "ai",
+    "scaffolding",
+    "typescript"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/outfitter-dev/outfitter.git",
+    "directory": "packages/agents"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -46,5 +46,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/config"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -136,5 +136,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/contracts"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -48,5 +48,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/daemon"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/file-ops/package.json
+++ b/packages/file-ops/package.json
@@ -46,5 +46,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/file-ops"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -71,5 +71,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/index"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -46,5 +46,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/logging"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -60,5 +60,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/mcp"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -46,5 +46,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/state"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -53,5 +53,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/testing"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -85,5 +85,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/types"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,5 +49,8 @@
     "type": "git",
     "url": "https://github.com/outfitter-dev/outfitter.git",
     "directory": "packages/ui"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Add publishConfig to all 12 packages for explicit public access
- Add .npmrc with registry configuration
- Add GitHub Actions release workflow using changesets/action
- Add CI workflow for PR validation (typecheck, lint, build, test)
- Enable NPM provenance for trusted publishing via OIDC

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>