### PR TITLE
fix(build): run bunup from monorepo root to ensure workspace config is used

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,12 @@
         "default": "./dist/render/index.js"
       }
     },
+    "./render/format": {
+      "import": {
+        "types": "./dist/render/format.d.ts",
+        "default": "./dist/render/format.js"
+      }
+    },
     "./render/shapes": {
       "import": {
         "types": "./dist/render/shapes.d.ts",
@@ -55,6 +61,12 @@
       "import": {
         "types": "./dist/render/format-relative.d.ts",
         "default": "./dist/render/format-relative.js"
+      }
+    },
+    "./render/date": {
+      "import": {
+        "types": "./dist/render/date.d.ts",
+        "default": "./dist/render/date.js"
       }
     },
     "./render/json": {
@@ -133,7 +145,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "bunup --filter @outfitter/cli",
+    "build": "cd ../.. && bunup --filter @outfitter/cli",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "lint": "biome lint ./src",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -109,7 +109,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "bunup --filter @outfitter/contracts",
+    "build": "cd ../.. && bunup --filter @outfitter/contracts",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
     "test": "bun test",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -43,7 +43,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "bunup --filter @outfitter/index",
+    "build": "cd ../.. && bunup --filter @outfitter/index",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
     "test": "bun test",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -61,7 +61,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "bunup --filter @outfitter/types",
+    "build": "cd ../.. && bunup --filter @outfitter/types",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary

Fixes bunup build scripts to run from monorepo root, ensuring workspace config (entry patterns, plugins) is correctly applied.

**Problem**: Package-level `bunup --filter` commands weren't respecting the workspace `bunup.config.ts`, causing subpath exports (`./render`, `./terminal`) to not be built.

**Solution**: Changed build scripts to `cd ../.. && bunup --filter @package-name` so bunup runs from root with full workspace context.

Closes #68

## Test plan

- [x] All packages build successfully with subpath exports
- [x] TypeScript compilation passes
- [x] All tests pass