### PR TITLE
feat(cli): add parseDateRange utility

### DIFF
--- a/packages/cli/src/__tests__/date.test.ts
+++ b/packages/cli/src/__tests__/date.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for parseDateRange()
+ *
+ * TDD RED PHASE: These tests define expected behavior for date range parsing.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { endOfDay, parseDateRange, startOfDay } from "../render/date.js";
+
+// ============================================================================
+// Helper Function Tests
+// ============================================================================
+
+describe("startOfDay()", () => {
+  it("returns date at 00:00:00.000", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const result = startOfDay(date);
+
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it("preserves the date", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const result = startOfDay(date);
+
+    expect(result.getFullYear()).toBe(date.getFullYear());
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it("does not mutate the original date", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const originalTime = date.getTime();
+
+    startOfDay(date);
+
+    expect(date.getTime()).toBe(originalTime);
+  });
+});
+
+describe("endOfDay()", () => {
+  it("returns date at 23:59:59.999", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const result = endOfDay(date);
+
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+    expect(result.getSeconds()).toBe(59);
+    expect(result.getMilliseconds()).toBe(999);
+  });
+
+  it("preserves the date", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const result = endOfDay(date);
+
+    expect(result.getFullYear()).toBe(date.getFullYear());
+    expect(result.getMonth()).toBe(date.getMonth());
+    expect(result.getDate()).toBe(date.getDate());
+  });
+
+  it("does not mutate the original date", () => {
+    const date = new Date("2024-06-15T14:30:45.123Z");
+    const originalTime = date.getTime();
+
+    endOfDay(date);
+
+    expect(date.getTime()).toBe(originalTime);
+  });
+});
+
+// ============================================================================
+// parseDateRange() Tests
+// ============================================================================
+
+describe("parseDateRange()", () => {
+  let originalNow: typeof Date.now;
+  let fixedNow: Date;
+
+  beforeEach(() => {
+    // Fix "now" to 2024-06-15 12:00:00 UTC for predictable tests
+    originalNow = Date.now;
+    fixedNow = new Date("2024-06-15T12:00:00.000Z");
+    Date.now = () => fixedNow.getTime();
+  });
+
+  afterEach(() => {
+    Date.now = originalNow;
+  });
+
+  // ==========================================================================
+  // Named Ranges
+  // ==========================================================================
+
+  describe("named ranges", () => {
+    it('parses "today" as current day', () => {
+      const result = parseDateRange("today");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Start should be 00:00:00.000 on 2024-06-15 (local time)
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(5); // June is 5 (0-indexed)
+      expect(range.start.getDate()).toBe(15);
+      expect(range.start.getHours()).toBe(0);
+      expect(range.start.getMinutes()).toBe(0);
+      expect(range.start.getSeconds()).toBe(0);
+      expect(range.start.getMilliseconds()).toBe(0);
+
+      // End should be 23:59:59.999 on same day
+      expect(range.end.getHours()).toBe(23);
+      expect(range.end.getMinutes()).toBe(59);
+      expect(range.end.getSeconds()).toBe(59);
+      expect(range.end.getMilliseconds()).toBe(999);
+    });
+
+    it('parses "yesterday" as previous day', () => {
+      const result = parseDateRange("yesterday");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Should be 2024-06-14
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(5);
+      expect(range.start.getDate()).toBe(14);
+      expect(range.start.getHours()).toBe(0);
+
+      expect(range.end.getDate()).toBe(14);
+      expect(range.end.getHours()).toBe(23);
+      expect(range.end.getMinutes()).toBe(59);
+    });
+
+    it('parses "last week" as last 7 days', () => {
+      const result = parseDateRange("last week");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Start should be 7 days ago (2024-06-08) at 00:00:00
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(5);
+      expect(range.start.getDate()).toBe(8);
+      expect(range.start.getHours()).toBe(0);
+
+      // End should be today at 23:59:59.999
+      expect(range.end.getFullYear()).toBe(2024);
+      expect(range.end.getMonth()).toBe(5);
+      expect(range.end.getDate()).toBe(15);
+      expect(range.end.getHours()).toBe(23);
+      expect(range.end.getMinutes()).toBe(59);
+    });
+
+    it('parses "last month" as last 30 days', () => {
+      const result = parseDateRange("last month");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Start should be 30 days ago (2024-05-16) at 00:00:00
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(4); // May is 4 (0-indexed)
+      expect(range.start.getDate()).toBe(16);
+      expect(range.start.getHours()).toBe(0);
+
+      // End should be today at 23:59:59.999
+      expect(range.end.getFullYear()).toBe(2024);
+      expect(range.end.getMonth()).toBe(5);
+      expect(range.end.getDate()).toBe(15);
+      expect(range.end.getHours()).toBe(23);
+    });
+
+    it("handles case-insensitive named ranges", () => {
+      expect(parseDateRange("TODAY").isOk()).toBe(true);
+      expect(parseDateRange("Today").isOk()).toBe(true);
+      expect(parseDateRange("YESTERDAY").isOk()).toBe(true);
+      expect(parseDateRange("Last Week").isOk()).toBe(true);
+      expect(parseDateRange("LAST MONTH").isOk()).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Explicit Range (YYYY-MM-DD..YYYY-MM-DD)
+  // ==========================================================================
+
+  describe("explicit range", () => {
+    it("parses valid date range with .. separator", () => {
+      const result = parseDateRange("2024-01-01..2024-12-31");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Start: 2024-01-01 00:00:00.000
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(0);
+      expect(range.start.getDate()).toBe(1);
+      expect(range.start.getHours()).toBe(0);
+      expect(range.start.getMinutes()).toBe(0);
+
+      // End: 2024-12-31 23:59:59.999
+      expect(range.end.getFullYear()).toBe(2024);
+      expect(range.end.getMonth()).toBe(11);
+      expect(range.end.getDate()).toBe(31);
+      expect(range.end.getHours()).toBe(23);
+      expect(range.end.getMinutes()).toBe(59);
+    });
+
+    it("parses same-day range", () => {
+      const result = parseDateRange("2024-06-15..2024-06-15");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(5);
+      expect(range.start.getDate()).toBe(15);
+
+      expect(range.end.getFullYear()).toBe(2024);
+      expect(range.end.getMonth()).toBe(5);
+      expect(range.end.getDate()).toBe(15);
+    });
+
+    it("returns error when start > end", () => {
+      const result = parseDateRange("2024-12-31..2024-01-01");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+      expect(error?.message).toContain("start date must be before");
+    });
+
+    it("returns error for invalid start date in range", () => {
+      const result = parseDateRange("invalid..2024-12-31");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+      expect(error?.message).toContain("Invalid start date");
+    });
+
+    it("returns error for invalid end date in range", () => {
+      const result = parseDateRange("2024-01-01..invalid");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+      expect(error?.message).toContain("Invalid end date");
+    });
+
+    it("handles ranges crossing year boundaries", () => {
+      const result = parseDateRange("2023-12-01..2024-01-31");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      expect(range.start.getFullYear()).toBe(2023);
+      expect(range.end.getFullYear()).toBe(2024);
+    });
+  });
+
+  // ==========================================================================
+  // Single Date (YYYY-MM-DD)
+  // ==========================================================================
+
+  describe("single date", () => {
+    it("parses valid single date", () => {
+      const result = parseDateRange("2024-06-15");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      // Start: 2024-06-15 00:00:00.000
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(5);
+      expect(range.start.getDate()).toBe(15);
+      expect(range.start.getHours()).toBe(0);
+      expect(range.start.getMinutes()).toBe(0);
+
+      // End: 2024-06-15 23:59:59.999
+      expect(range.end.getFullYear()).toBe(2024);
+      expect(range.end.getMonth()).toBe(5);
+      expect(range.end.getDate()).toBe(15);
+      expect(range.end.getHours()).toBe(23);
+      expect(range.end.getMinutes()).toBe(59);
+    });
+
+    it("returns error for invalid single date", () => {
+      const result = parseDateRange("2024-13-45");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+    });
+
+    it("returns error for malformed date format", () => {
+      const result = parseDateRange("06-15-2024");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+    });
+  });
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe("edge cases", () => {
+    it("returns error for empty string", () => {
+      const result = parseDateRange("");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+      expect(error?.message).toContain("cannot be empty");
+    });
+
+    it("returns error for whitespace-only string", () => {
+      const result = parseDateRange("   ");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+    });
+
+    it("trims whitespace from input", () => {
+      const result = parseDateRange("  today  ");
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("returns error for unrecognized input", () => {
+      const result = parseDateRange("invalid");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+      expect(error?._tag).toBe("ValidationError");
+    });
+
+    it("returns error for partial range with single dot", () => {
+      const result = parseDateRange("2024-01-01.2024-12-31");
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("returns error for incomplete range", () => {
+      const result = parseDateRange("2024-01-01..");
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("returns error for range with only separator", () => {
+      const result = parseDateRange("..");
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("handles leap year date", () => {
+      const result = parseDateRange("2024-02-29");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+      expect(range.start.getFullYear()).toBe(2024);
+      expect(range.start.getMonth()).toBe(1);
+      expect(range.start.getDate()).toBe(29);
+    });
+
+    it("returns error for invalid leap year date", () => {
+      const result = parseDateRange("2023-02-29");
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Type Safety
+  // ==========================================================================
+
+  describe("type safety", () => {
+    it("returns DateRange with Date objects", () => {
+      const result = parseDateRange("today");
+
+      expect(result.isOk()).toBe(true);
+      const range = result.unwrap();
+
+      expect(range.start).toBeInstanceOf(Date);
+      expect(range.end).toBeInstanceOf(Date);
+    });
+
+    it("returns ValidationError on failure", () => {
+      const result = parseDateRange("invalid");
+
+      expect(result.isErr()).toBe(true);
+      const error = result.error;
+
+      expect(error?._tag).toBe("ValidationError");
+      expect(typeof error?.message).toBe("string");
+    });
+  });
+});

--- a/packages/cli/src/render/date.ts
+++ b/packages/cli/src/render/date.ts
@@ -1,0 +1,290 @@
+/**
+ * Date range parsing utilities.
+ *
+ * Provides utilities for parsing date range strings into structured DateRange objects.
+ * Supports named ranges (today, yesterday, last week, last month), explicit ranges
+ * (YYYY-MM-DD..YYYY-MM-DD), and single dates (YYYY-MM-DD).
+ *
+ * @packageDocumentation
+ */
+
+import { Result, ValidationError } from "@outfitter/contracts";
+
+/**
+ * Represents a date range with start and end dates.
+ */
+export interface DateRange {
+  /** Start of the range (inclusive, at 00:00:00.000) */
+  start: Date;
+  /** End of the range (inclusive, at 23:59:59.999) */
+  end: Date;
+}
+
+/** ISO date format regex: YYYY-MM-DD */
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Named range keywords (lowercase) */
+const NAMED_RANGES = ["today", "yesterday", "last week", "last month"] as const;
+
+type NamedRange = (typeof NAMED_RANGES)[number];
+
+/**
+ * Returns a new Date set to the start of the day (00:00:00.000).
+ *
+ * @param date - The date to adjust
+ * @returns A new Date object at 00:00:00.000 on the same day
+ *
+ * @example
+ * ```typescript
+ * startOfDay(new Date("2024-06-15T14:30:00Z"))
+ * // Returns 2024-06-15T00:00:00.000 (local time)
+ * ```
+ */
+export function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+/**
+ * Returns a new Date set to the end of the day (23:59:59.999).
+ *
+ * @param date - The date to adjust
+ * @returns A new Date object at 23:59:59.999 on the same day
+ *
+ * @example
+ * ```typescript
+ * endOfDay(new Date("2024-06-15T14:30:00Z"))
+ * // Returns 2024-06-15T23:59:59.999 (local time)
+ * ```
+ */
+export function endOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+/**
+ * Checks if a string is a valid named range.
+ */
+function isNamedRange(input: string): input is NamedRange {
+  return NAMED_RANGES.includes(input as NamedRange);
+}
+
+/**
+ * Parses a named range into a DateRange.
+ */
+function parseNamedRange(name: NamedRange): DateRange {
+  const now = new Date(Date.now());
+
+  switch (name) {
+    case "today": {
+      return {
+        start: startOfDay(now),
+        end: endOfDay(now),
+      };
+    }
+    case "yesterday": {
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      return {
+        start: startOfDay(yesterday),
+        end: endOfDay(yesterday),
+      };
+    }
+    case "last week": {
+      const weekAgo = new Date(now);
+      weekAgo.setDate(weekAgo.getDate() - 7);
+      return {
+        start: startOfDay(weekAgo),
+        end: endOfDay(now),
+      };
+    }
+    case "last month": {
+      const monthAgo = new Date(now);
+      monthAgo.setDate(monthAgo.getDate() - 30);
+      return {
+        start: startOfDay(monthAgo),
+        end: endOfDay(now),
+      };
+    }
+    default: {
+      // Exhaustive check: all NamedRange cases are handled above
+      const _exhaustive: never = name;
+      throw new Error(`Unhandled named range: ${_exhaustive}`);
+    }
+  }
+}
+
+/**
+ * Parses a YYYY-MM-DD string into a Date, validating the date is real.
+ * Returns null if the date is invalid.
+ */
+function parseIsoDate(dateStr: string): Date | null {
+  if (!ISO_DATE_REGEX.test(dateStr)) {
+    return null;
+  }
+
+  // Parse components manually to avoid timezone issues
+  const parts = dateStr.split("-");
+  const yearStr = parts[0];
+  const monthStr = parts[1];
+  const dayStr = parts[2];
+
+  if (yearStr === undefined || monthStr === undefined || dayStr === undefined) {
+    return null;
+  }
+
+  const year = Number.parseInt(yearStr, 10);
+  const month = Number.parseInt(monthStr, 10) - 1; // JS months are 0-indexed
+  const day = Number.parseInt(dayStr, 10);
+
+  // Create date and verify it's valid (e.g., 2024-02-30 would become 2024-03-01)
+  const date = new Date(year, month, day);
+
+  // Validate the date didn't overflow (e.g., Feb 30 becoming Mar 2)
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+/**
+ * Parses date range strings into structured DateRange.
+ *
+ * Supported formats:
+ * - `"today"` - Current day (00:00:00 to 23:59:59)
+ * - `"yesterday"` - Previous day
+ * - `"last week"` - Last 7 days
+ * - `"last month"` - Last 30 days
+ * - `"2024-01-01..2024-12-31"` - Explicit range
+ * - `"2024-01-01"` - Single day
+ *
+ * @param input - The date range string to parse
+ * @returns Result containing DateRange on success, or ValidationError on failure
+ *
+ * @example
+ * ```typescript
+ * parseDateRange("today")
+ * // Ok({ start: today 00:00, end: today 23:59:59 })
+ *
+ * parseDateRange("2024-01-01..2024-12-31")
+ * // Ok({ start: 2024-01-01 00:00, end: 2024-12-31 23:59:59 })
+ *
+ * parseDateRange("invalid")
+ * // Err(ValidationError)
+ * ```
+ */
+export function parseDateRange(
+  input: string
+): Result<DateRange, InstanceType<typeof ValidationError>> {
+  // Trim whitespace
+  const trimmed = input.trim();
+
+  // Check for empty input
+  if (trimmed === "") {
+    return Result.err(
+      new ValidationError({
+        message: "Date range input cannot be empty",
+        field: "dateRange",
+      })
+    );
+  }
+
+  // Normalize to lowercase for named range matching
+  const normalized = trimmed.toLowerCase();
+
+  // Try named ranges first
+  if (isNamedRange(normalized)) {
+    return Result.ok(parseNamedRange(normalized));
+  }
+
+  // Check for explicit range (YYYY-MM-DD..YYYY-MM-DD)
+  if (trimmed.includes("..")) {
+    const parts = trimmed.split("..");
+
+    // Validate we have exactly two parts
+    if (parts.length !== 2 || parts[0] === "" || parts[1] === "") {
+      return Result.err(
+        new ValidationError({
+          message:
+            'Invalid date range format. Expected "YYYY-MM-DD..YYYY-MM-DD"',
+          field: "dateRange",
+        })
+      );
+    }
+
+    const startStr = parts[0];
+    const endStr = parts[1];
+
+    // Already validated parts.length === 2 above, but satisfy the linter
+    if (startStr === undefined || endStr === undefined) {
+      return Result.err(
+        new ValidationError({
+          message:
+            'Invalid date range format. Expected "YYYY-MM-DD..YYYY-MM-DD"',
+          field: "dateRange",
+        })
+      );
+    }
+
+    const startDate = parseIsoDate(startStr);
+    const endDate = parseIsoDate(endStr);
+
+    if (startDate === null) {
+      return Result.err(
+        new ValidationError({
+          message: `Invalid start date: "${startStr}". Expected format: YYYY-MM-DD`,
+          field: "dateRange",
+        })
+      );
+    }
+
+    if (endDate === null) {
+      return Result.err(
+        new ValidationError({
+          message: `Invalid end date: "${endStr}". Expected format: YYYY-MM-DD`,
+          field: "dateRange",
+        })
+      );
+    }
+
+    // Validate start <= end
+    if (startDate.getTime() > endDate.getTime()) {
+      return Result.err(
+        new ValidationError({
+          message:
+            "Invalid date range: start date must be before or equal to end date",
+          field: "dateRange",
+        })
+      );
+    }
+
+    return Result.ok({
+      start: startOfDay(startDate),
+      end: endOfDay(endDate),
+    });
+  }
+
+  // Try single date (YYYY-MM-DD)
+  const singleDate = parseIsoDate(trimmed);
+  if (singleDate !== null) {
+    return Result.ok({
+      start: startOfDay(singleDate),
+      end: endOfDay(singleDate),
+    });
+  }
+
+  // Unrecognized input
+  return Result.err(
+    new ValidationError({
+      message: `Unrecognized date range: "${trimmed}". Expected "today", "yesterday", "last week", "last month", "YYYY-MM-DD", or "YYYY-MM-DD..YYYY-MM-DD"`,
+      field: "dateRange",
+    })
+  );
+}


### PR DESCRIPTION
## Summary

Adds `parseDateRange()` for parsing natural language date range expressions.

Supported formats:
- Named ranges: `"today"`, `"yesterday"`, `"last week"`, `"last month"`
- Explicit ranges: `"2024-01-01..2024-12-31"`
- Single dates: `"2024-01-01"`

Returns `Result<DateRange, ValidationError>` for consistent error handling.

Closes #60

## Test plan

- [x] Unit tests for all supported formats
- [x] Error cases (invalid dates, malformed input)
- [x] TypeScript compilation passes