### PR TITLE
feat(file-ops): add withSharedLock for reader-writer locking

### DIFF
--- a/packages/file-ops/src/index.ts
+++ b/packages/file-ops/src/index.ts
@@ -127,6 +127,35 @@ export interface FileLock {
   timestamp: number;
 }
 
+/**
+ * Represents an acquired shared (reader) file lock.
+ *
+ * Extends FileLock with a lock type discriminator. Multiple processes can
+ * hold shared locks simultaneously, but shared locks block exclusive locks.
+ */
+export interface SharedFileLock extends FileLock {
+  /** Discriminator indicating this is a shared/reader lock */
+  lockType: "shared";
+  /** Unique identifier for this reader (allows multiple readers from same PID) */
+  readerId: string;
+}
+
+/**
+ * Options for lock acquisition.
+ */
+export interface LockOptions {
+  /**
+   * Maximum time in milliseconds to wait for lock acquisition.
+   * If not specified, fails immediately if lock cannot be acquired.
+   */
+  timeout?: number;
+  /**
+   * Interval in milliseconds between retry attempts when waiting.
+   * @defaultValue 50
+   */
+  retryInterval?: number;
+}
+
 // ============================================================================
 // Workspace Detection
 // ============================================================================
@@ -580,10 +609,13 @@ export function globSync(
 // ============================================================================
 
 /**
- * Acquires an advisory lock on a file.
+ * Acquires an exclusive advisory lock on a file.
  *
  * Creates a .lock file next to the target file with lock metadata (PID, timestamp).
  * Uses atomic file creation (wx flag) to prevent race conditions.
+ *
+ * Exclusive locks block and are blocked by both shared and exclusive locks.
+ * Use shared locks (acquireSharedLock) for read-only operations.
  *
  * Important: This is advisory locking. All processes must cooperate by using
  * these locking APIs. The filesystem does not enforce the lock.
@@ -591,51 +623,95 @@ export function globSync(
  * Prefer using withLock for automatic lock release.
  *
  * @param path - Absolute path to the file to lock
+ * @param options - Lock options including timeout and retry interval
  * @returns Result containing FileLock on success, or ConflictError if already locked
  */
 export async function acquireLock(
-  path: string
+  path: string,
+  options?: LockOptions
 ): Promise<Result<FileLock, InstanceType<typeof ConflictError>>> {
   const lockPath = `${path}.lock`;
+  const startTime = Date.now();
+  const timeout = options?.timeout ?? 0;
+  const retryInterval = options?.retryInterval ?? 50;
 
-  // Check if lock file already exists
-  const lockFile = Bun.file(lockPath);
-  if (await lockFile.exists()) {
-    return Result.err(
-      new ConflictError({
-        message: `File is already locked: ${path}`,
-      })
-    );
-  }
+  while (true) {
+    // Check if lock file already exists
+    const lockFile = Bun.file(lockPath);
+    if (await lockFile.exists()) {
+      // Check if it's a shared lock or exclusive lock
+      try {
+        const lockContent = await lockFile.text();
+        const lockData = JSON.parse(lockContent) as LockData;
 
-  const lock: FileLock = {
-    path,
-    lockPath,
-    pid: process.pid,
-    timestamp: Date.now(),
-  };
+        // Block on both shared and exclusive locks
+        if (lockData.type === "shared" && lockData.readers.length > 0) {
+          if (timeout > 0 && Date.now() - startTime < timeout) {
+            await Bun.sleep(retryInterval);
+            continue;
+          }
+          return Result.err(
+            new ConflictError({
+              message: `File has shared locks: ${path}`,
+            })
+          );
+        }
+      } catch {
+        // Couldn't parse as new format - treat as legacy exclusive lock
+      }
 
-  // Create lock file with lock information
-  try {
-    await fsWriteFile(
-      lockPath,
-      JSON.stringify({ pid: lock.pid, timestamp: lock.timestamp }),
-      { flag: "wx" } // Fail if file exists (atomic check-and-create)
-    );
-  } catch (error) {
-    // If file already exists (race condition), return conflict error
-    if (error instanceof Error && "code" in error && error.code === "EEXIST") {
+      if (timeout > 0 && Date.now() - startTime < timeout) {
+        await Bun.sleep(retryInterval);
+        continue;
+      }
       return Result.err(
         new ConflictError({
           message: `File is already locked: ${path}`,
         })
       );
     }
-    // Re-throw unexpected errors
-    throw error;
-  }
 
-  return Result.ok(lock);
+    const lock: FileLock = {
+      path,
+      lockPath,
+      pid: process.pid,
+      timestamp: Date.now(),
+    };
+
+    // Create lock file with exclusive lock information
+    const exclusiveLockData: ExclusiveLockData = {
+      type: "exclusive",
+      pid: lock.pid,
+      timestamp: lock.timestamp,
+    };
+
+    try {
+      await fsWriteFile(lockPath, JSON.stringify(exclusiveLockData), {
+        flag: "wx",
+      }); // Fail if file exists (atomic check-and-create)
+    } catch (error) {
+      // If file already exists (race condition), retry or return conflict error
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "EEXIST"
+      ) {
+        if (timeout > 0 && Date.now() - startTime < timeout) {
+          await Bun.sleep(retryInterval);
+          continue;
+        }
+        return Result.err(
+          new ConflictError({
+            message: `File is already locked: ${path}`,
+          })
+        );
+      }
+      // Re-throw unexpected errors
+      throw error;
+    }
+
+    return Result.ok(lock);
+  }
 }
 
 /**
@@ -838,6 +914,337 @@ export async function atomicWriteJson<T>(
         message:
           error instanceof Error ? error.message : "Failed to serialize JSON",
         field: "data",
+      })
+    );
+  }
+}
+
+// ============================================================================
+// Shared (Reader) Locking
+// ============================================================================
+
+/**
+ * Internal type for exclusive lock file content.
+ */
+interface ExclusiveLockData {
+  type: "exclusive";
+  pid: number;
+  timestamp: number;
+}
+
+/**
+ * Internal type for shared lock reader entry.
+ */
+interface SharedLockReader {
+  id: string;
+  pid: number;
+  timestamp: number;
+}
+
+/**
+ * Internal type for shared lock file content.
+ */
+interface SharedLockData {
+  type: "shared";
+  readers: SharedLockReader[];
+}
+
+/**
+ * Union type for lock file content.
+ */
+type LockData = ExclusiveLockData | SharedLockData;
+
+/**
+ * Acquires a shared (reader) lock on a file.
+ *
+ * Multiple readers can hold shared locks simultaneously. Shared locks are
+ * blocked by exclusive locks. Uses the same .lock file as exclusive locks
+ * with a JSON format that distinguishes lock types.
+ *
+ * Important: This is advisory locking. All processes must cooperate by using
+ * these locking APIs. The filesystem does not enforce the lock.
+ *
+ * @param path - Absolute path to the file to lock
+ * @param options - Lock options including timeout and retry interval
+ * @returns Result containing SharedFileLock on success, or ConflictError if blocked by exclusive lock
+ */
+export async function acquireSharedLock(
+  path: string,
+  options?: LockOptions
+): Promise<Result<SharedFileLock, InstanceType<typeof ConflictError>>> {
+  const lockPath = `${path}.lock`;
+  const metaLockPath = `${lockPath}.meta`;
+  const startTime = Date.now();
+  const timeout = options?.timeout ?? 0;
+  const retryInterval = options?.retryInterval ?? 50;
+
+  while (true) {
+    // Acquire meta-lock to protect read-modify-write sequence
+    const metaLockResult = await acquireLock(metaLockPath, {
+      timeout: retryInterval,
+      retryInterval: 10,
+    });
+
+    if (metaLockResult.isErr()) {
+      // Meta-lock busy - retry
+      if (timeout > 0 && Date.now() - startTime < timeout) {
+        await Bun.sleep(retryInterval);
+        continue;
+      }
+      return Result.err(
+        new ConflictError({
+          message: `Failed to acquire shared lock: ${path}`,
+        })
+      );
+    }
+
+    const metaLock = metaLockResult.value;
+
+    const lockFile = Bun.file(lockPath);
+    const exists = await lockFile.exists();
+
+    if (exists) {
+      // Read existing lock file
+      try {
+        const lockContent = await lockFile.text();
+        const lockData = JSON.parse(lockContent) as LockData;
+
+        if (lockData.type === "exclusive") {
+          // Exclusive lock exists - cannot acquire shared lock
+          await releaseLock(metaLock);
+          if (timeout > 0 && Date.now() - startTime < timeout) {
+            await Bun.sleep(retryInterval);
+            continue;
+          }
+          return Result.err(
+            new ConflictError({
+              message: `File is exclusively locked: ${path}`,
+            })
+          );
+        }
+
+        // Shared lock exists - add ourselves as a reader
+        const readerId = Bun.randomUUIDv7();
+        const newReader: SharedLockReader = {
+          id: readerId,
+          pid: process.pid,
+          timestamp: Date.now(),
+        };
+        lockData.readers.push(newReader);
+
+        // Write updated lock file
+        await fsWriteFile(lockPath, JSON.stringify(lockData));
+        await releaseLock(metaLock);
+
+        return Result.ok({
+          path,
+          lockPath,
+          pid: process.pid,
+          timestamp: newReader.timestamp,
+          lockType: "shared" as const,
+          readerId,
+        });
+      } catch {
+        // Lock file exists but couldn't be parsed - treat as exclusive
+        await releaseLock(metaLock);
+        if (timeout > 0 && Date.now() - startTime < timeout) {
+          await Bun.sleep(retryInterval);
+          continue;
+        }
+        return Result.err(
+          new ConflictError({
+            message: `File is locked: ${path}`,
+          })
+        );
+      }
+    }
+
+    // No lock file exists - create new shared lock
+    const readerId = Bun.randomUUIDv7();
+    const timestamp = Date.now();
+    const sharedLockData: SharedLockData = {
+      type: "shared",
+      readers: [
+        {
+          id: readerId,
+          pid: process.pid,
+          timestamp,
+        },
+      ],
+    };
+
+    try {
+      await fsWriteFile(lockPath, JSON.stringify(sharedLockData), {
+        flag: "wx",
+      });
+      await releaseLock(metaLock);
+
+      return Result.ok({
+        path,
+        lockPath,
+        pid: process.pid,
+        timestamp,
+        lockType: "shared" as const,
+        readerId,
+      });
+    } catch (error) {
+      await releaseLock(metaLock);
+      // File already exists (race condition) - retry
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "EEXIST" &&
+        timeout > 0 &&
+        Date.now() - startTime < timeout
+      ) {
+        await Bun.sleep(retryInterval);
+        continue;
+      }
+      return Result.err(
+        new ConflictError({
+          message: `Failed to acquire shared lock: ${path}`,
+        })
+      );
+    }
+  }
+}
+
+/**
+ * Releases a shared (reader) lock.
+ *
+ * Removes this process from the list of readers in the lock file.
+ * If this is the last reader, the lock file is deleted.
+ *
+ * @param lock - Shared lock object returned from acquireSharedLock
+ * @returns Result indicating success, or InternalError if lock file cannot be modified
+ */
+export async function releaseSharedLock(
+  lock: SharedFileLock
+): Promise<Result<void, InstanceType<typeof InternalError>>> {
+  const metaLockPath = `${lock.lockPath}.meta`;
+
+  // Acquire meta-lock to protect read-modify-write sequence
+  const metaLockResult = await acquireLock(metaLockPath, {
+    timeout: 5000,
+    retryInterval: 10,
+  });
+
+  if (metaLockResult.isErr()) {
+    return Result.err(
+      new InternalError({
+        message: "Failed to acquire meta-lock for shared lock release",
+      })
+    );
+  }
+
+  const metaLock = metaLockResult.value;
+
+  try {
+    const lockFile = Bun.file(lock.lockPath);
+    const exists = await lockFile.exists();
+
+    if (!exists) {
+      // Lock file already gone - consider it released
+      await releaseLock(metaLock);
+      return Result.ok(undefined);
+    }
+
+    const lockContent = await lockFile.text();
+    const lockData = JSON.parse(lockContent) as LockData;
+
+    if (lockData.type !== "shared") {
+      // Not a shared lock - this shouldn't happen
+      await releaseLock(metaLock);
+      return Result.err(
+        new InternalError({
+          message: "Lock file is not a shared lock",
+        })
+      );
+    }
+
+    // Remove this reader from the list (match by unique readerId)
+    lockData.readers = lockData.readers.filter(
+      (reader) => reader.id !== lock.readerId
+    );
+
+    if (lockData.readers.length === 0) {
+      // Last reader - delete lock file
+      await unlink(lock.lockPath);
+    } else {
+      // Other readers remain - update lock file
+      await fsWriteFile(lock.lockPath, JSON.stringify(lockData));
+    }
+
+    await releaseLock(metaLock);
+    return Result.ok(undefined);
+  } catch (error) {
+    await releaseLock(metaLock);
+    return Result.err(
+      new InternalError({
+        message:
+          error instanceof Error
+            ? error.message
+            : "Failed to release shared lock",
+      })
+    );
+  }
+}
+
+/**
+ * Executes a callback while holding a shared (reader) lock on a file.
+ *
+ * Lock is automatically released after callback completes, whether it
+ * succeeds or throws an error. This is the recommended way to use shared locks.
+ *
+ * Multiple readers can hold shared locks simultaneously. Use this for
+ * read-only operations that should not block other readers.
+ *
+ * @typeParam T - Return type of the callback
+ * @param path - Absolute path to the file to lock
+ * @param callback - Async callback to execute while holding lock
+ * @param options - Lock options including timeout and retry interval
+ * @returns Result containing callback return value, ConflictError if blocked, or InternalError on failure
+ */
+export async function withSharedLock<T>(
+  path: string,
+  callback: () => Promise<T>,
+  options?: LockOptions
+): Promise<
+  Result<
+    T,
+    InstanceType<typeof ConflictError> | InstanceType<typeof InternalError>
+  >
+> {
+  const lockResult = await acquireSharedLock(path, options);
+
+  if (lockResult.isErr()) {
+    return lockResult;
+  }
+
+  const lock = lockResult.value;
+
+  try {
+    const result = await callback();
+    const releaseResult = await releaseSharedLock(lock);
+    // Surface release failures to caller
+    if (releaseResult.isErr()) {
+      return releaseResult;
+    }
+    return Result.ok(result);
+  } catch (error) {
+    // Always attempt to release the lock, even on error
+    const releaseResult = await releaseSharedLock(lock);
+    // If release also fails, include that in the error
+    if (releaseResult.isErr()) {
+      return Result.err(
+        new InternalError({
+          message: `Callback failed: ${error instanceof Error ? error.message : "Unknown error"}; lock release also failed: ${releaseResult.error.message}`,
+        })
+      );
+    }
+    return Result.err(
+      new InternalError({
+        message: error instanceof Error ? error.message : "Callback failed",
       })
     );
   }


### PR DESCRIPTION
## Summary

Adds `withSharedLock()` for read-only operations that can run concurrently.

- Multiple readers can hold shared locks simultaneously
- Shared locks are blocked by exclusive locks (from `withLock`)
- Returns `Result<T, E>` for consistent error handling

```typescript
// Multiple reads can happen concurrently
const result = await withSharedLock(lockPath, async () => {
  return readData();
});
```

Closes #59

## Test plan

- [x] Unit tests for shared lock behavior
- [x] Concurrent reader tests
- [x] Exclusive lock blocking tests
- [x] TypeScript compilation passes