### PR TITLE
chore: update bun.lock for Bun 1.3.7 compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
         "@outfitter/state": ">=0.1.0-rc.1",
         "@outfitter/testing": ">=0.1.0-rc.1",
         "@outfitter/types": ">=0.1.0-rc.1",
+        "@outfitter/ui": ">=0.1.0-rc.1",
       },
       "optionalPeers": [
         "@outfitter/agents",
@@ -196,6 +197,7 @@
         "@outfitter/state",
         "@outfitter/testing",
         "@outfitter/types",
+        "@outfitter/ui",
       ],
     },
     "packages/state": {
@@ -940,9 +942,13 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@outfitter/stack/@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
     "outfitter/@clack/prompts": ["@clack/prompts@0.10.1", "", { "dependencies": { "@clack/core": "0.4.2", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "@outfitter/stack/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "outfitter/@clack/prompts/@clack/core": ["@clack/core@0.4.2", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg=="],
 


### PR DESCRIPTION
## Summary

Updates `bun.lock` to resolve CI failures caused by lockfile drift between Bun 1.3.6 (local) and 1.3.7 (CI).

## Test plan

- [x] `bun install --frozen-lockfile` passes locally
- [x] CI build and test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)