### PR TITLE
chore: release 0.1.0-rc.2

### DIFF
--- a/.changeset/cli-utilities.md
+++ b/.changeset/cli-utilities.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/cli": patch
+---
+
+Add text utilities (pluralize, slugify), format utilities (formatDuration, formatBytes), parseDateRange, and registerRenderer for custom shape renderers

--- a/.changeset/contracts-error-codes.md
+++ b/.changeset/contracts-error-codes.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/contracts": patch
+---
+
+Add ERROR_CODES constant with granular numeric error codes organized by category

--- a/.changeset/file-ops-shared-lock.md
+++ b/.changeset/file-ops-shared-lock.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/file-ops": patch
+---
+
+Add withSharedLock for reader-writer locking with meta-lock protection against race conditions

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,26 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "outfitter": "0.1.0-rc.1",
+    "@outfitter/agents": "0.1.0-rc.1",
+    "@outfitter/cli": "0.1.0-rc.1",
+    "@outfitter/config": "0.1.0-rc.1",
+    "@outfitter/contracts": "0.1.0-rc.1",
+    "@outfitter/daemon": "0.1.0-rc.1",
+    "@outfitter/file-ops": "0.1.0-rc.1",
+    "@outfitter/index": "0.1.0-rc.1",
+    "@outfitter/logging": "0.1.0-rc.1",
+    "@outfitter/mcp": "0.1.0-rc.1",
+    "@outfitter/stack": "0.1.0-rc.1",
+    "@outfitter/state": "0.1.0-rc.1",
+    "@outfitter/testing": "0.1.0-rc.1",
+    "@outfitter/types": "0.1.0-rc.1"
+  },
+  "changesets": [
+    "cli-utilities",
+    "contracts-error-codes",
+    "file-ops-shared-lock",
+    "types-utilities"
+  ]
+}

--- a/.changeset/types-utilities.md
+++ b/.changeset/types-utilities.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/types": patch
+---
+
+Add Prettify<T> utility type and collection utilities (sortBy, dedupe, chunk)

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @outfitter/agents
+
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/agents",
   "description": "Default agent documentation and scaffolding for AI-ready projects",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Add text utilities (pluralize, slugify), format utilities (formatDuration, formatBytes), parseDateRange, and registerRenderer for custom shape renderers
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/types@0.1.0-rc.2
+  - @outfitter/config@0.1.0-rc.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/cli",
   "description": "Typed CLI runtime with terminal detection, rendering, output contracts, and input parsing",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/types@0.1.0-rc.2
+
 All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/config",
   "description": "XDG-compliant config loading with schema validation for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @outfitter/contracts
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Add ERROR_CODES constant with granular numeric error codes organized by category
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/contracts",
   "description": "Result/Error patterns, error taxonomy, and handler contracts for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/file-ops@0.1.0-rc.2
+  - @outfitter/logging@0.1.0-rc.2
+
 ## [0.1.0] - 2026-01-23
 
 ### Added

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/daemon",
   "description": "Daemon lifecycle, IPC, and health checks for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/file-ops/CHANGELOG.md
+++ b/packages/file-ops/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Add withSharedLock for reader-writer locking with meta-lock protection against race conditions
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/types@0.1.0-rc.2
+
 All notable changes to `@outfitter/file-ops` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/packages/file-ops/package.json
+++ b/packages/file-ops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/file-ops",
   "description": "Workspace detection, secure path handling, and file locking for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/index/CHANGELOG.md
+++ b/packages/index/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @outfitter/index
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/file-ops@0.1.0-rc.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/index",
   "description": "SQLite FTS5 full-text search indexing for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+
 All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/logging",
   "description": "Structured logging via logtape with redaction support for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @outfitter/mcp
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/logging@0.1.0-rc.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/mcp",
   "description": "MCP server framework with typed tools for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/state/CHANGELOG.md
+++ b/packages/state/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/types@0.1.0-rc.2
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/state",
   "description": "Pagination cursor persistence and state management for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+  - @outfitter/mcp@0.1.0-rc.2
+
 ## [0.1.0] - 2026-01-23
 
 ### Added

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/testing",
   "description": "Test harnesses, fixtures, and utilities for Outfitter packages",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @outfitter/types
 
+## 0.1.0-rc.2
+
+### Patch Changes
+
+- Add Prettify<T> utility type and collection utilities (sortBy, dedupe, chunk)
+- Updated dependencies
+  - @outfitter/contracts@0.1.0-rc.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outfitter/types",
   "description": "Branded types, type guards, and type utilities for Outfitter",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Version bump to `0.1.0-rc.2` for all packages.

### New Features

**@outfitter/types**
- `Prettify<T>` utility type
- `sortBy`, `dedupe`, `chunk` collection utilities

**@outfitter/contracts**
- `ERROR_CODES` constant with granular numeric error codes by category

**@outfitter/cli**
- `pluralize`, `slugify` text utilities
- `formatDuration`, `formatBytes` format utilities
- `parseDateRange` for date range parsing
- `registerRenderer` for custom shape renderers

**@outfitter/file-ops**
- `withSharedLock` for reader-writer locking with race condition protection

## Test plan

- [x] All tests pass
- [x] Build succeeds
- [x] Changesets created and versioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)