### PR TITLE
ci: switch to npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: write
       pull-requests: write
@@ -41,5 +42,4 @@ jobs:
           publish: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Add `environment: npm-publish` to release workflow for OIDC trusted publishing
- Remove `NPM_TOKEN` secret usage in favor of GitHub Actions OIDC

## Test plan
- [ ] Merge and verify release workflow publishes to npm successfully

🤖 Generated with [Claude Code](https://claude.ai/code)