### PR TITLE
ci: add Node.js setup for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,15 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      - name: Setup Node (for npm OIDC publish)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- Add `actions/setup-node@v4` with Node.js 22 and npm registry URL
- Upgrade npm to latest (v11.5.1+) for OIDC trusted publishing support
- Bun doesn't support npm OIDC yet, so we need npm CLI for publishing

## Context
npm OIDC trusted publishing requires npm v11.5.1+. The previous attempt failed because only Bun was set up, which doesn't support OIDC authentication for publishing.

## Test plan
- [ ] Merge and verify release workflow publishes to npm successfully via OIDC

🤖 Generated with [Claude Code](https://claude.ai/code)