### PR TITLE
chore(scripts): improve upgrade-bun.sh to handle types and engines

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -67,12 +67,12 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.6",
+    "@types/bun": "^1.3.7",
     "@types/node": "^25.0.10",
     "typescript": "^5.9.3"
   },
   "engines": {
-    "bun": ">=1.3.6"
+    "bun": ">=1.3.7"
   },
   "keywords": [
     "outfitter",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "zod": "^4.3.5",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.6",
+        "@types/bun": "^1.3.7",
         "@types/node": "^25.0.10",
         "typescript": "^5.9.3",
       },
@@ -954,6 +954,8 @@
 
     "outfitter/@clack/prompts": ["@clack/prompts@0.10.1", "", { "dependencies": { "@clack/core": "0.4.2", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw=="],
 
+    "outfitter/@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "@outfitter/cli/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
@@ -967,6 +969,8 @@
     "@outfitter/types/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "outfitter/@clack/prompts/@clack/core": ["@clack/core@0.4.2", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg=="],
+
+    "outfitter/@types/bun/bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "packageManager": "bun@1.3.6",
   "engines": {
     "node": ">=24.0.0",
-    "bun": ">=1.3.6"
+    "bun": ">=1.3.7"
   },
   "trustedDependencies": [
     "@biomejs/biome"


### PR DESCRIPTION
## Summary

Enhance the Bun upgrade script to update `@types/bun` and `engines.bun` fields in package.json files, not just `.bun-version` and `bun.lock`.

## Changes

- Update `engines.bun` (`"bun": ">=x.y.z"`) across all package.json files
- Update pinned `@types/bun` versions (leaves `"latest"` alone)
- Sync remaining 1.3.6 references to 1.3.7
- Support both macOS and Linux sed syntax

## Why

Previously, upgrading Bun required manually updating type definitions and engine constraints. This caused version drift (e.g., `.bun-version` at 1.3.7 while `engines.bun` stayed at 1.3.6).

## Test Plan

- [x] Verified sed patterns work on macOS
- [x] Script properly identifies files with pinned versions vs "latest"

---

🤖 Generated with [Claude Code](https://claude.ai/code)