### PR TITLE
feat(cli): add box-drawing character system

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,22 +15,10 @@
         "default": "./dist/output.js"
       }
     },
-    "./render": {
+    "./render/text": {
       "import": {
-        "types": "./dist/render/index.d.ts",
-        "default": "./dist/render/index.js"
-      }
-    },
-    "./render/format": {
-      "import": {
-        "types": "./dist/render/format.d.ts",
-        "default": "./dist/render/format.js"
-      }
-    },
-    "./render/shapes": {
-      "import": {
-        "types": "./dist/render/shapes.d.ts",
-        "default": "./dist/render/shapes.js"
+        "types": "./dist/render/text.d.ts",
+        "default": "./dist/render/text.js"
       }
     },
     "./render/markdown": {
@@ -39,10 +27,34 @@
         "default": "./dist/render/markdown.js"
       }
     },
+    "./render/format": {
+      "import": {
+        "types": "./dist/render/format.d.ts",
+        "default": "./dist/render/format.js"
+      }
+    },
+    "./render/borders": {
+      "import": {
+        "types": "./dist/render/borders.d.ts",
+        "default": "./dist/render/borders.js"
+      }
+    },
+    "./render": {
+      "import": {
+        "types": "./dist/render/index.d.ts",
+        "default": "./dist/render/index.js"
+      }
+    },
     "./render/list": {
       "import": {
         "types": "./dist/render/list.d.ts",
         "default": "./dist/render/list.js"
+      }
+    },
+    "./render/shapes": {
+      "import": {
+        "types": "./dist/render/shapes.d.ts",
+        "default": "./dist/render/shapes.js"
       }
     },
     "./render/tree": {
@@ -55,6 +67,18 @@
       "import": {
         "types": "./dist/terminal/index.d.ts",
         "default": "./dist/terminal/index.js"
+      }
+    },
+    "./terminal/detection": {
+      "import": {
+        "types": "./dist/terminal/detection.d.ts",
+        "default": "./dist/terminal/detection.js"
+      }
+    },
+    "./render/colors": {
+      "import": {
+        "types": "./dist/render/colors.d.ts",
+        "default": "./dist/render/colors.js"
       }
     },
     "./render/format-relative": {
@@ -87,36 +111,6 @@
         "default": "./dist/render/table.js"
       }
     },
-    "./render/text": {
-      "import": {
-        "types": "./dist/render/text.d.ts",
-        "default": "./dist/render/text.js"
-      }
-    },
-    "./render/colors": {
-      "import": {
-        "types": "./dist/render/colors.d.ts",
-        "default": "./dist/render/colors.js"
-      }
-    },
-    "./terminal/detection": {
-      "import": {
-        "types": "./dist/terminal/detection.d.ts",
-        "default": "./dist/terminal/detection.js"
-      }
-    },
-    "./types": {
-      "import": {
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
-      }
-    },
-    ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
     "./pagination": {
       "import": {
         "types": "./dist/pagination.d.ts",
@@ -129,10 +123,22 @@
         "default": "./dist/input.js"
       }
     },
+    "./types": {
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      }
+    },
     "./actions": {
       "import": {
         "types": "./dist/actions.d.ts",
         "default": "./dist/actions.js"
+      }
+    },
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     },
     "./command": {

--- a/packages/cli/src/__tests__/borders.test.ts
+++ b/packages/cli/src/__tests__/borders.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for box-drawing border utilities
+ *
+ * Tests cover:
+ * - Border character sets (5 tests)
+ * - getBorderCharacters() (2 tests)
+ * - drawHorizontalLine() (5 tests)
+ *
+ * Total: 12 tests
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  BORDERS,
+  type BorderCharacters,
+  type BorderStyle,
+  drawHorizontalLine,
+  getBorderCharacters,
+} from "../render/borders.js";
+
+// ============================================================================
+// Border Character Sets Tests
+// ============================================================================
+
+describe("Border Character Sets", () => {
+  it("defines single border style with all characters", () => {
+    const single = BORDERS.single;
+
+    expect(single.topLeft).toBe("┌");
+    expect(single.topRight).toBe("┐");
+    expect(single.bottomLeft).toBe("└");
+    expect(single.bottomRight).toBe("┘");
+    expect(single.horizontal).toBe("─");
+    expect(single.vertical).toBe("│");
+    expect(single.topT).toBe("┬");
+    expect(single.bottomT).toBe("┴");
+    expect(single.leftT).toBe("├");
+    expect(single.rightT).toBe("┤");
+    expect(single.cross).toBe("┼");
+  });
+
+  it("defines double border style with all characters", () => {
+    const double = BORDERS.double;
+
+    expect(double.topLeft).toBe("╔");
+    expect(double.topRight).toBe("╗");
+    expect(double.bottomLeft).toBe("╚");
+    expect(double.bottomRight).toBe("╝");
+    expect(double.horizontal).toBe("═");
+    expect(double.vertical).toBe("║");
+    expect(double.topT).toBe("╦");
+    expect(double.bottomT).toBe("╩");
+    expect(double.leftT).toBe("╠");
+    expect(double.rightT).toBe("╣");
+    expect(double.cross).toBe("╬");
+  });
+
+  it("defines rounded border style with rounded corners", () => {
+    const rounded = BORDERS.rounded;
+
+    expect(rounded.topLeft).toBe("╭");
+    expect(rounded.topRight).toBe("╮");
+    expect(rounded.bottomLeft).toBe("╰");
+    expect(rounded.bottomRight).toBe("╯");
+    // Rounded uses single-line characters for edges
+    expect(rounded.horizontal).toBe("─");
+    expect(rounded.vertical).toBe("│");
+  });
+
+  it("defines heavy border style with thick characters", () => {
+    const heavy = BORDERS.heavy;
+
+    expect(heavy.topLeft).toBe("┏");
+    expect(heavy.topRight).toBe("┓");
+    expect(heavy.bottomLeft).toBe("┗");
+    expect(heavy.bottomRight).toBe("┛");
+    expect(heavy.horizontal).toBe("━");
+    expect(heavy.vertical).toBe("┃");
+    expect(heavy.topT).toBe("┳");
+    expect(heavy.bottomT).toBe("┻");
+    expect(heavy.leftT).toBe("┣");
+    expect(heavy.rightT).toBe("┫");
+    expect(heavy.cross).toBe("╋");
+  });
+
+  it("defines none border style with empty strings", () => {
+    const none = BORDERS.none;
+
+    expect(none.topLeft).toBe("");
+    expect(none.topRight).toBe("");
+    expect(none.bottomLeft).toBe("");
+    expect(none.bottomRight).toBe("");
+    expect(none.horizontal).toBe("");
+    expect(none.vertical).toBe("");
+    expect(none.topT).toBe("");
+    expect(none.bottomT).toBe("");
+    expect(none.leftT).toBe("");
+    expect(none.rightT).toBe("");
+    expect(none.cross).toBe("");
+  });
+});
+
+// ============================================================================
+// getBorderCharacters() Tests
+// ============================================================================
+
+describe("getBorderCharacters()", () => {
+  it("returns correct character set for each style", () => {
+    const styles: BorderStyle[] = [
+      "single",
+      "double",
+      "rounded",
+      "heavy",
+      "none",
+    ];
+
+    for (const style of styles) {
+      const chars = getBorderCharacters(style);
+      expect(chars).toBe(BORDERS[style]);
+    }
+  });
+
+  it("returns object with all required properties", () => {
+    const chars = getBorderCharacters("single");
+
+    // Verify all properties exist
+    const requiredKeys: (keyof BorderCharacters)[] = [
+      "topLeft",
+      "topRight",
+      "bottomLeft",
+      "bottomRight",
+      "horizontal",
+      "vertical",
+      "topT",
+      "bottomT",
+      "leftT",
+      "rightT",
+      "cross",
+    ];
+
+    for (const key of requiredKeys) {
+      expect(chars[key]).toBeDefined();
+      expect(typeof chars[key]).toBe("string");
+    }
+  });
+});
+
+// ============================================================================
+// drawHorizontalLine() Tests
+// ============================================================================
+
+describe("drawHorizontalLine()", () => {
+  it("draws top line without columns", () => {
+    const chars = getBorderCharacters("single");
+    const line = drawHorizontalLine(10, chars, "top");
+
+    expect(line).toBe("┌──────────┐");
+  });
+
+  it("draws middle line without columns", () => {
+    const chars = getBorderCharacters("single");
+    const line = drawHorizontalLine(10, chars, "middle");
+
+    expect(line).toBe("├──────────┤");
+  });
+
+  it("draws bottom line without columns", () => {
+    const chars = getBorderCharacters("single");
+    const line = drawHorizontalLine(10, chars, "bottom");
+
+    expect(line).toBe("└──────────┘");
+  });
+
+  it("draws line with column intersections", () => {
+    const chars = getBorderCharacters("single");
+    // columnWidths [5, 7] = 12 + 1 intersection = 13 inner chars
+    // width 14 means last column is padded to make 14 inner chars total
+    const line = drawHorizontalLine(14, chars, "top", [5, 7]);
+
+    // 5 dashes + T + 8 dashes (7+1 to reach width 14) = ┌─────┬────────┐
+    expect(line).toBe("┌─────┬────────┐");
+  });
+
+  it("draws middle line with column intersections", () => {
+    const chars = getBorderCharacters("single");
+    // columnWidths [5, 7] = 12 + 1 intersection = 13 inner chars
+    // width 14 means last column is padded to make 14 inner chars total
+    const line = drawHorizontalLine(14, chars, "middle", [5, 7]);
+
+    // 5 dashes + intersection + 8 dashes (7+1 to reach width 14) = ├─────┼────────┤
+    expect(line).toBe("├─────┼────────┤");
+  });
+
+  it("handles zero width gracefully", () => {
+    const chars = getBorderCharacters("single");
+    const line = drawHorizontalLine(0, chars, "top");
+
+    expect(line).toBe("┌┐");
+  });
+
+  it("handles single column width", () => {
+    const chars = getBorderCharacters("single");
+    const line = drawHorizontalLine(5, chars, "top", [5]);
+
+    expect(line).toBe("┌─────┐");
+  });
+
+  it("works with different border styles", () => {
+    const doubleChars = getBorderCharacters("double");
+    const line = drawHorizontalLine(10, doubleChars, "top");
+
+    expect(line).toBe("╔══════════╗");
+  });
+
+  it("returns empty for none style", () => {
+    const noneChars = getBorderCharacters("none");
+    const line = drawHorizontalLine(10, noneChars, "top");
+
+    expect(line).toBe("");
+  });
+});

--- a/packages/cli/src/render/borders.ts
+++ b/packages/cli/src/render/borders.ts
@@ -1,0 +1,258 @@
+/**
+ * Box-drawing border utilities.
+ *
+ * Provides border character sets and line drawing functions for tables, boxes, and panels.
+ *
+ * @packageDocumentation
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Available border style presets.
+ *
+ * - `single`: Standard Unicode single-line borders (┌─┐)
+ * - `double`: Double-line borders (╔═╗)
+ * - `rounded`: Rounded corners with single lines (╭─╮)
+ * - `heavy`: Thick/heavy borders (┏━┓)
+ * - `ascii`: ASCII-only fallback (+, -, |)
+ * - `none`: No borders (empty strings)
+ */
+export type BorderStyle =
+  | "single"
+  | "double"
+  | "rounded"
+  | "heavy"
+  | "ascii"
+  | "none";
+
+/**
+ * Complete set of box-drawing characters for a border style.
+ *
+ * Includes corners, edges, and intersection characters for building
+ * tables, boxes, and other bordered elements.
+ */
+export interface BorderCharacters {
+  /** Top-left corner (e.g., ┌ ╔ ╭ ┏) */
+  topLeft: string;
+  /** Top-right corner (e.g., ┐ ╗ ╮ ┓) */
+  topRight: string;
+  /** Bottom-left corner (e.g., └ ╚ ╰ ┗) */
+  bottomLeft: string;
+  /** Bottom-right corner (e.g., ┘ ╝ ╯ ┛) */
+  bottomRight: string;
+  /** Horizontal line (e.g., ─ ═ ━) */
+  horizontal: string;
+  /** Vertical line (e.g., │ ║ ┃) */
+  vertical: string;
+  /** Top T-intersection for column separators (e.g., ┬ ╦ ┳) */
+  topT: string;
+  /** Bottom T-intersection for column separators (e.g., ┴ ╩ ┻) */
+  bottomT: string;
+  /** Left T-intersection for row separators (e.g., ├ ╠ ┣) */
+  leftT: string;
+  /** Right T-intersection for row separators (e.g., ┤ ╣ ┫) */
+  rightT: string;
+  /** Cross intersection for table cells (e.g., ┼ ╬ ╋) */
+  cross: string;
+}
+
+// ============================================================================
+// Border Character Sets
+// ============================================================================
+
+/**
+ * Preset border character sets for each style.
+ *
+ * @example
+ * ```typescript
+ * import { BORDERS } from "@outfitter/cli";
+ *
+ * const single = BORDERS.single;
+ * console.log(`${single.topLeft}${single.horizontal.repeat(10)}${single.topRight}`);
+ * // Output: ┌──────────┐
+ * ```
+ */
+export const BORDERS: Record<BorderStyle, BorderCharacters> = {
+  single: {
+    topLeft: "┌",
+    topRight: "┐",
+    bottomLeft: "└",
+    bottomRight: "┘",
+    horizontal: "─",
+    vertical: "│",
+    topT: "┬",
+    bottomT: "┴",
+    leftT: "├",
+    rightT: "┤",
+    cross: "┼",
+  },
+  double: {
+    topLeft: "╔",
+    topRight: "╗",
+    bottomLeft: "╚",
+    bottomRight: "╝",
+    horizontal: "═",
+    vertical: "║",
+    topT: "╦",
+    bottomT: "╩",
+    leftT: "╠",
+    rightT: "╣",
+    cross: "╬",
+  },
+  rounded: {
+    topLeft: "╭",
+    topRight: "╮",
+    bottomLeft: "╰",
+    bottomRight: "╯",
+    horizontal: "─",
+    vertical: "│",
+    topT: "┬",
+    bottomT: "┴",
+    leftT: "├",
+    rightT: "┤",
+    cross: "┼",
+  },
+  heavy: {
+    topLeft: "┏",
+    topRight: "┓",
+    bottomLeft: "┗",
+    bottomRight: "┛",
+    horizontal: "━",
+    vertical: "┃",
+    topT: "┳",
+    bottomT: "┻",
+    leftT: "┣",
+    rightT: "┫",
+    cross: "╋",
+  },
+  ascii: {
+    topLeft: "+",
+    topRight: "+",
+    bottomLeft: "+",
+    bottomRight: "+",
+    horizontal: "-",
+    vertical: "|",
+    topT: "+",
+    bottomT: "+",
+    leftT: "+",
+    rightT: "+",
+    cross: "+",
+  },
+  none: {
+    topLeft: "",
+    topRight: "",
+    bottomLeft: "",
+    bottomRight: "",
+    horizontal: "",
+    vertical: "",
+    topT: "",
+    bottomT: "",
+    leftT: "",
+    rightT: "",
+    cross: "",
+  },
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+/**
+ * Returns the border character set for the given style.
+ *
+ * @param style - The border style preset
+ * @returns The complete set of border characters
+ *
+ * @example
+ * ```typescript
+ * const chars = getBorderCharacters("rounded");
+ * console.log(chars.topLeft); // ╭
+ * console.log(chars.topRight); // ╮
+ * ```
+ */
+export function getBorderCharacters(style: BorderStyle): BorderCharacters {
+  return BORDERS[style];
+}
+
+/**
+ * Position of a horizontal line within a bordered element.
+ */
+export type LinePosition = "top" | "middle" | "bottom";
+
+/**
+ * Draws a horizontal line with the appropriate corner/intersection characters.
+ *
+ * Used for building table borders and box edges. Handles column intersections
+ * when column widths are provided.
+ *
+ * @param width - Total width of the line content (excluding corners)
+ * @param chars - Border character set to use
+ * @param position - Position of line: "top", "middle", or "bottom"
+ * @param columnWidths - Optional array of column widths for intersection placement
+ * @returns The formatted horizontal line string
+ *
+ * @example
+ * ```typescript
+ * const chars = getBorderCharacters("single");
+ *
+ * // Simple line (no columns)
+ * drawHorizontalLine(10, chars, "top");
+ * // Returns: ┌──────────┐
+ *
+ * // Line with column intersections
+ * drawHorizontalLine(14, chars, "middle", [5, 7]);
+ * // Returns: ├─────┼───────┤
+ * ```
+ */
+export function drawHorizontalLine(
+  width: number,
+  chars: BorderCharacters,
+  position: LinePosition,
+  columnWidths?: number[]
+): string {
+  // Handle "none" style - return empty string
+  if (!chars.horizontal) {
+    return "";
+  }
+
+  // Character mappings for each position
+  const positionChars = {
+    top: { left: chars.topLeft, right: chars.topRight, cross: chars.topT },
+    middle: { left: chars.leftT, right: chars.rightT, cross: chars.cross },
+    bottom: {
+      left: chars.bottomLeft,
+      right: chars.bottomRight,
+      cross: chars.bottomT,
+    },
+  } as const;
+
+  const { left, right, cross: intersection } = positionChars[position];
+
+  // No columns or single column - draw simple line
+  if (!columnWidths || columnWidths.length <= 1) {
+    return `${left}${chars.horizontal.repeat(width)}${right}`;
+  }
+
+  // Build line with column intersections
+  // Calculate actual width: sum of columns + (n-1) intersections
+  const columnsWidth = columnWidths.reduce((sum, w) => sum + w, 0);
+  const intersectionsWidth = columnWidths.length - 1;
+  const actualWidth = columnsWidth + intersectionsWidth;
+
+  // If columnWidths don't match expected width, adjust last column
+  const adjustedWidths = [...columnWidths];
+  if (actualWidth !== width && adjustedWidths.length > 0) {
+    const lastIndex = adjustedWidths.length - 1;
+    const lastWidth = adjustedWidths[lastIndex] ?? 0;
+    adjustedWidths[lastIndex] = Math.max(0, lastWidth + (width - actualWidth));
+  }
+
+  const segments = adjustedWidths.map((colWidth) =>
+    chars.horizontal.repeat(colWidth)
+  );
+
+  return `${left}${segments.join(intersection)}${right}`;
+}

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -8,6 +8,15 @@
 
 // biome-ignore lint/performance/noBarrelFile: intentional re-exports for subpath API
 export {
+  // Box-drawing borders
+  BORDERS,
+  type BorderCharacters,
+  type BorderStyle,
+  drawHorizontalLine,
+  getBorderCharacters,
+  type LinePosition,
+} from "./borders.js";
+export {
   ANSI,
   applyColor,
   type ColorName,


### PR DESCRIPTION
## Summary

Adds a foundational box-drawing system with Unicode border characters for CLI output primitives.

- Define `BorderStyle` type with 5 styles: `single`, `double`, `rounded`, `heavy`, `none`
- Export `BORDERS` constant with complete character sets for each style
- Add `getBorderCharacters()` helper for style lookup
- Add `drawHorizontalLine()` utility for separators

## Usage

```typescript
import { BORDERS, getBorderCharacters } from "@outfitter/cli/borders";

const chars = getBorderCharacters("rounded");
// chars.topLeft → "╭", chars.horizontal → "─", etc.
```

## Test Plan

- [x] Unit tests for all border styles
- [x] Tests for character retrieval functions