### PR TITLE
feat(cli): add tree guide styles for hierarchical rendering

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,54 @@
         "default": "./dist/output.js"
       }
     },
+    "./demo/renderers/progress": {
+      "import": {
+        "types": "./dist/demo/renderers/progress.d.ts",
+        "default": "./dist/demo/renderers/progress.js"
+      }
+    },
+    "./demo/renderers/table": {
+      "import": {
+        "types": "./dist/demo/renderers/table.d.ts",
+        "default": "./dist/demo/renderers/table.js"
+      }
+    },
+    "./demo/renderers/text": {
+      "import": {
+        "types": "./dist/demo/renderers/text.d.ts",
+        "default": "./dist/demo/renderers/text.js"
+      }
+    },
+    "./demo/renderers/markdown": {
+      "import": {
+        "types": "./dist/demo/renderers/markdown.d.ts",
+        "default": "./dist/demo/renderers/markdown.js"
+      }
+    },
+    "./demo/renderers/borders": {
+      "import": {
+        "types": "./dist/demo/renderers/borders.d.ts",
+        "default": "./dist/demo/renderers/borders.js"
+      }
+    },
+    "./demo/renderers/list": {
+      "import": {
+        "types": "./dist/demo/renderers/list.d.ts",
+        "default": "./dist/demo/renderers/list.js"
+      }
+    },
+    "./demo/renderers/box": {
+      "import": {
+        "types": "./dist/demo/renderers/box.d.ts",
+        "default": "./dist/demo/renderers/box.js"
+      }
+    },
+    "./demo/renderers/tree": {
+      "import": {
+        "types": "./dist/demo/renderers/tree.d.ts",
+        "default": "./dist/demo/renderers/tree.js"
+      }
+    },
     "./box": {
       "import": {
         "types": "./dist/box/index.d.ts",
@@ -27,16 +75,70 @@
         "default": "./dist/tree/index.js"
       }
     },
+    "./demo/templates": {
+      "import": {
+        "types": "./dist/demo/templates.d.ts",
+        "default": "./dist/demo/templates.js"
+      }
+    },
+    "./demo/types": {
+      "import": {
+        "types": "./dist/demo/types.d.ts",
+        "default": "./dist/demo/types.js"
+      }
+    },
+    "./demo/registry": {
+      "import": {
+        "types": "./dist/demo/registry.d.ts",
+        "default": "./dist/demo/registry.js"
+      }
+    },
     "./demo": {
       "import": {
         "types": "./dist/demo/index.d.ts",
         "default": "./dist/demo/index.js"
       }
     },
+    "./demo/renderers/colors": {
+      "import": {
+        "types": "./dist/demo/renderers/colors.d.ts",
+        "default": "./dist/demo/renderers/colors.js"
+      }
+    },
+    "./demo/renderers/spinner": {
+      "import": {
+        "types": "./dist/demo/renderers/spinner.d.ts",
+        "default": "./dist/demo/renderers/spinner.js"
+      }
+    },
     "./render": {
       "import": {
         "types": "./dist/render/index.d.ts",
         "default": "./dist/render/index.js"
+      }
+    },
+    "./render/list": {
+      "import": {
+        "types": "./dist/render/list.d.ts",
+        "default": "./dist/render/list.js"
+      }
+    },
+    "./render/shapes": {
+      "import": {
+        "types": "./dist/render/shapes.d.ts",
+        "default": "./dist/render/shapes.js"
+      }
+    },
+    "./render/box": {
+      "import": {
+        "types": "./dist/render/box.d.ts",
+        "default": "./dist/render/box.js"
+      }
+    },
+    "./render/tree": {
+      "import": {
+        "types": "./dist/render/tree.d.ts",
+        "default": "./dist/render/tree.js"
       }
     },
     "./borders": {
@@ -55,6 +157,54 @@
       "import": {
         "types": "./dist/preset/standard.d.ts",
         "default": "./dist/preset/standard.js"
+      }
+    },
+    "./render/json": {
+      "import": {
+        "types": "./dist/render/json.d.ts",
+        "default": "./dist/render/json.js"
+      }
+    },
+    "./render/spinner": {
+      "import": {
+        "types": "./dist/render/spinner.d.ts",
+        "default": "./dist/render/spinner.js"
+      }
+    },
+    "./render/progress": {
+      "import": {
+        "types": "./dist/render/progress.d.ts",
+        "default": "./dist/render/progress.js"
+      }
+    },
+    "./render/table": {
+      "import": {
+        "types": "./dist/render/table.d.ts",
+        "default": "./dist/render/table.js"
+      }
+    },
+    "./render/text": {
+      "import": {
+        "types": "./dist/render/text.d.ts",
+        "default": "./dist/render/text.js"
+      }
+    },
+    "./render/markdown": {
+      "import": {
+        "types": "./dist/render/markdown.d.ts",
+        "default": "./dist/render/markdown.js"
+      }
+    },
+    "./render/format": {
+      "import": {
+        "types": "./dist/render/format.d.ts",
+        "default": "./dist/render/format.js"
+      }
+    },
+    "./render/borders": {
+      "import": {
+        "types": "./dist/render/borders.d.ts",
+        "default": "./dist/render/borders.js"
       }
     },
     "./theme/presets/minimal": {
@@ -85,6 +235,24 @@
       "import": {
         "types": "./dist/terminal/detection.d.ts",
         "default": "./dist/terminal/detection.js"
+      }
+    },
+    "./render/colors": {
+      "import": {
+        "types": "./dist/render/colors.d.ts",
+        "default": "./dist/render/colors.js"
+      }
+    },
+    "./render/format-relative": {
+      "import": {
+        "types": "./dist/render/format-relative.d.ts",
+        "default": "./dist/render/format-relative.js"
+      }
+    },
+    "./render/date": {
+      "import": {
+        "types": "./dist/render/date.d.ts",
+        "default": "./dist/render/date.js"
       }
     },
     "./pagination": {

--- a/packages/cli/src/__tests__/tree.test.ts
+++ b/packages/cli/src/__tests__/tree.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for tree rendering with guide styles
+ *
+ * Tests cover:
+ * - Basic tree rendering (2 tests)
+ * - Guide styles (4 tests)
+ * - Tree options (3 tests)
+ *
+ * Total: 9 tests
+ */
+import { describe, expect, it } from "bun:test";
+import { renderTree, TREE_GUIDES } from "../render/tree.js";
+
+// ============================================================================
+// Basic Tree Rendering Tests (2 tests)
+// ============================================================================
+
+describe("renderTree()", () => {
+  describe("basic rendering", () => {
+    it("renders a flat tree with default single guide", () => {
+      const tree = {
+        file1: null,
+        file2: null,
+      };
+      const result = renderTree(tree);
+
+      // Should use single guide characters
+      expect(result).toContain("├── file1");
+      expect(result).toContain("└── file2");
+    });
+
+    it("renders nested tree with proper connectors", () => {
+      const tree = {
+        src: {
+          components: {
+            Button: null,
+            Input: null,
+          },
+          utils: null,
+        },
+        tests: null,
+      };
+      const result = renderTree(tree);
+
+      // Should have proper nesting with vertical lines
+      expect(result).toContain("├── src");
+      expect(result).toContain("│   ├── components");
+      expect(result).toContain("│   │   ├── Button");
+      expect(result).toContain("│   │   └── Input");
+      expect(result).toContain("│   └── utils");
+      expect(result).toContain("└── tests");
+    });
+  });
+
+  // ============================================================================
+  // Guide Styles Tests (4 tests)
+  // ============================================================================
+
+  describe("guide styles", () => {
+    it("renders with single guide (default)", () => {
+      const tree = { a: null, b: null };
+      const result = renderTree(tree, { guide: "single" });
+
+      expect(result).toContain("├── ");
+      expect(result).toContain("└── ");
+    });
+
+    it("renders with rounded guide", () => {
+      const tree = { a: null, b: null };
+      const result = renderTree(tree, { guide: "rounded" });
+
+      // Rounded uses ╰ instead of └
+      expect(result).toContain("├── ");
+      expect(result).toContain("╰── ");
+    });
+
+    it("renders with heavy guide", () => {
+      const tree = { a: { b: null }, c: null };
+      const result = renderTree(tree, { guide: "heavy" });
+
+      // Heavy uses thick characters
+      expect(result).toContain("┣━━ ");
+      expect(result).toContain("┗━━ ");
+      expect(result).toContain("┃   ");
+    });
+
+    it("renders with double guide", () => {
+      const tree = { a: { b: null }, c: null };
+      const result = renderTree(tree, { guide: "double" });
+
+      // Double uses double-line characters
+      expect(result).toContain("╠══ ");
+      expect(result).toContain("╚══ ");
+      expect(result).toContain("║   ");
+    });
+  });
+
+  // ============================================================================
+  // Tree Options Tests (3 tests)
+  // ============================================================================
+
+  describe("options", () => {
+    it("respects maxDepth option", () => {
+      const tree = {
+        level1: {
+          level2: {
+            level3: {
+              level4: null,
+            },
+          },
+        },
+      };
+      const result = renderTree(tree, { maxDepth: 2 });
+
+      // Should include level1 and level2 (depth 0 and 1)
+      expect(result).toContain("level1");
+      expect(result).toContain("level2");
+      // Should not include level3 (depth 2 exceeds maxDepth)
+      expect(result).not.toContain("level3");
+      expect(result).not.toContain("level4");
+    });
+
+    it("uses custom renderLabel function", () => {
+      const tree = {
+        file: "txt",
+        folder: { sub: null },
+      };
+      const result = renderTree(tree, {
+        renderLabel: (key, value, _depth) => {
+          if (value && typeof value === "object") {
+            return `📁 ${key}/`;
+          }
+          return `📄 ${key}`;
+        },
+      });
+
+      expect(result).toContain("📁 folder/");
+      expect(result).toContain("📄 file");
+      expect(result).toContain("📄 sub");
+    });
+
+    it("combines guide style with maxDepth", () => {
+      const tree = {
+        a: { b: { c: null } },
+      };
+      const result = renderTree(tree, { guide: "rounded", maxDepth: 2 });
+
+      // Should use rounded guide
+      expect(result).toContain("╰── ");
+      // Should stop at depth 1 (maxDepth 2 means up to depth 1)
+      expect(result).toContain("a");
+      expect(result).toContain("b");
+      expect(result).not.toContain("c");
+    });
+  });
+});
+
+// ============================================================================
+// TREE_GUIDES Constant Tests
+// ============================================================================
+
+describe("TREE_GUIDES", () => {
+  it("exports all expected guide styles", () => {
+    expect(TREE_GUIDES).toHaveProperty("single");
+    expect(TREE_GUIDES).toHaveProperty("heavy");
+    expect(TREE_GUIDES).toHaveProperty("double");
+    expect(TREE_GUIDES).toHaveProperty("rounded");
+  });
+
+  it("each guide has vertical, fork, and end properties", () => {
+    for (const style of Object.keys(TREE_GUIDES)) {
+      const guide = TREE_GUIDES[style as keyof typeof TREE_GUIDES];
+      expect(guide).toHaveProperty("vertical");
+      expect(guide).toHaveProperty("fork");
+      expect(guide).toHaveProperty("end");
+      // Each property should be a 4-character string
+      expect(guide.vertical.length).toBe(4);
+      expect(guide.fork.length).toBe(4);
+      expect(guide.end.length).toBe(4);
+    }
+  });
+});

--- a/packages/cli/src/demo/renderers/tree.ts
+++ b/packages/cli/src/demo/renderers/tree.ts
@@ -5,7 +5,11 @@
  */
 
 import type { Theme } from "../../render/colors.js";
-import { renderTree } from "../../render/tree.js";
+import {
+  renderTree,
+  TREE_GUIDES,
+  type TreeGuideStyle,
+} from "../../render/tree.js";
 import { getExample } from "../templates.js";
 import type { DemoConfig } from "../types.js";
 
@@ -25,7 +29,7 @@ export function renderTreeDemo(config: DemoConfig, _theme: Theme): string {
   lines.push("");
 
   if (showCode) {
-    lines.push('import { renderTree } from "@outfitter/cli/render";');
+    lines.push('import { renderTree } from "@outfitter/cli/tree";');
     lines.push("");
   }
 
@@ -46,39 +50,108 @@ export function renderTreeDemo(config: DemoConfig, _theme: Theme): string {
   lines.push("");
 
   // ==========================================================================
-  // Deeper Nesting Section
+  // Guide Styles Section
   // ==========================================================================
-  lines.push("DEEPER NESTING");
-  lines.push("==============");
+  lines.push("GUIDE STYLES");
+  lines.push("============");
+  lines.push("");
+
+  const guideDemo = {
+    root: {
+      child1: {
+        leaf: null,
+      },
+      child2: null,
+    },
+  };
+
+  const guideStyles: TreeGuideStyle[] = [
+    "single",
+    "rounded",
+    "heavy",
+    "double",
+  ];
+
+  for (const style of guideStyles) {
+    const guide = TREE_GUIDES[style];
+    lines.push(
+      `${style.toUpperCase()} (fork: "${guide.fork.trim()}", end: "${guide.end.trim()}")`
+    );
+    lines.push("");
+    lines.push(renderTree(guideDemo, { guide: style }));
+    lines.push("");
+  }
+
+  // ==========================================================================
+  // Max Depth Section
+  // ==========================================================================
+  lines.push("MAX DEPTH");
+  lines.push("=========");
   lines.push("");
 
   const deepTree = {
-    project: {
-      src: {
-        components: {
-          ui: {
-            Button: null,
-            Input: null,
-            Select: null,
-          },
-          layout: {
-            Header: null,
-            Footer: null,
-          },
+    level1: {
+      level2: {
+        level3: {
+          level4: null,
         },
-        lib: {
-          utils: null,
-          helpers: null,
-        },
-      },
-      tests: {
-        unit: null,
-        integration: null,
       },
     },
   };
 
+  if (showCode) {
+    lines.push("renderTree(tree, { maxDepth: 2 })");
+    lines.push("");
+  }
+
+  lines.push("Full tree:");
   lines.push(renderTree(deepTree));
+  lines.push("");
+  lines.push("With maxDepth: 2:");
+  lines.push(renderTree(deepTree, { maxDepth: 2 }));
+  lines.push("");
+
+  // ==========================================================================
+  // Custom Labels Section
+  // ==========================================================================
+  lines.push("CUSTOM LABELS");
+  lines.push("=============");
+  lines.push("");
+
+  const fileTree = {
+    src: {
+      "index.ts": null,
+      components: {
+        "Button.tsx": null,
+      },
+    },
+    "package.json": null,
+  };
+
+  if (showCode) {
+    lines.push("renderTree(tree, {");
+    lines.push("  renderLabel: (key, value) => {");
+    lines.push("    if (value && typeof value === 'object') {");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: code example display
+    lines.push("      return `📁 ${key}/`;");
+    lines.push("    }");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: code example display
+    lines.push("    return `📄 ${key}`;");
+    lines.push("  }");
+    lines.push("})");
+    lines.push("");
+  }
+
+  lines.push(
+    renderTree(fileTree, {
+      renderLabel: (key, value) => {
+        if (value && typeof value === "object") {
+          return `📁 ${key}/`;
+        }
+        return `📄 ${key}`;
+      },
+    })
+  );
   lines.push("");
 
   // ==========================================================================
@@ -89,8 +162,9 @@ export function renderTreeDemo(config: DemoConfig, _theme: Theme): string {
   lines.push("");
   lines.push("• Objects become branches with children");
   lines.push("• null values become leaf nodes (terminal)");
-  lines.push("• Uses Unicode box-drawing characters (├── └── │)");
-  lines.push("• Keys are displayed as node labels");
+  lines.push("• Use guide option to change visual style");
+  lines.push("• Use maxDepth to limit rendering depth");
+  lines.push("• Use renderLabel for custom node formatting");
 
   return lines.join("\n");
 }

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -99,4 +99,9 @@ export {
   wrapText,
 } from "./text.js";
 // Tree rendering
-export { renderTree } from "./tree.js";
+export {
+  renderTree,
+  TREE_GUIDES,
+  type TreeGuideStyle,
+  type TreeOptions,
+} from "./tree.js";

--- a/packages/cli/src/render/tree.ts
+++ b/packages/cli/src/render/tree.ts
@@ -7,13 +7,70 @@
  */
 
 /**
+ * Available tree guide styles.
+ *
+ * - `single`: Standard Unicode box-drawing (default)
+ * - `heavy`: Thick/bold box-drawing characters
+ * - `double`: Double-line box-drawing characters
+ * - `rounded`: Rounded corners (╰ instead of └)
+ */
+export type TreeGuideStyle = "single" | "heavy" | "double" | "rounded";
+
+/**
+ * Tree guide character sets for different visual styles.
+ */
+export const TREE_GUIDES: Record<
+  TreeGuideStyle,
+  { vertical: string; fork: string; end: string }
+> = {
+  single: { vertical: "│   ", fork: "├── ", end: "└── " },
+  heavy: { vertical: "┃   ", fork: "┣━━ ", end: "┗━━ " },
+  double: { vertical: "║   ", fork: "╠══ ", end: "╚══ " },
+  rounded: { vertical: "│   ", fork: "├── ", end: "╰── " },
+};
+
+/**
+ * Options for customizing tree rendering.
+ */
+export interface TreeOptions {
+  /**
+   * Guide style for tree branches.
+   * @default "single"
+   */
+  guide?: TreeGuideStyle;
+
+  /**
+   * Maximum depth to render (1 = root children only).
+   * @default undefined (unlimited)
+   */
+  maxDepth?: number;
+
+  /**
+   * Custom function to render node labels.
+   * Receives the key, value, and current depth.
+   *
+   * @example
+   * ```typescript
+   * renderLabel: (key, value, depth) => {
+   *   if (value && typeof value === "object") {
+   *     return `📁 ${key}/`;
+   *   }
+   *   return `📄 ${key}`;
+   * }
+   * ```
+   */
+  renderLabel?: (key: string, value: unknown, depth: number) => string;
+}
+
+/**
  * Renders hierarchical data as a tree with unicode box-drawing characters.
  *
- * Uses unicode characters (not, not, |, -) for tree structure.
+ * Uses unicode characters for tree structure.
  * Nested objects are rendered as child nodes; leaf values (null, primitives)
  * are rendered as terminal nodes.
  *
  * @param tree - Hierarchical object to render
+ * @param options - Customization options
  * @returns Formatted tree string with box-drawing characters
  *
  * @example
@@ -30,33 +87,54 @@
  * };
  *
  * console.log(renderTree(tree));
- * // +-- src
- * // |   +-- components
- * // |   |   +-- Button
- * // |   |   L-- Input
- * // |   L-- utils
- * // L-- tests
+ * // ├── src
+ * // │   ├── components
+ * // │   │   ├── Button
+ * // │   │   └── Input
+ * // │   └── utils
+ * // └── tests
+ *
+ * console.log(renderTree(tree, { guide: "rounded" }));
+ * // ├── src
+ * // │   ├── components
+ * // │   │   ├── Button
+ * // │   │   ╰── Input
+ * // │   ╰── utils
+ * // ╰── tests
  * ```
  */
-export function renderTree(tree: Record<string, unknown>): string {
+export function renderTree(
+  tree: Record<string, unknown>,
+  options?: TreeOptions
+): string {
+  const guide = TREE_GUIDES[options?.guide ?? "single"];
+  const maxDepth = options?.maxDepth;
+  const renderLabel = options?.renderLabel ?? ((key: string) => key);
   const lines: string[] = [];
 
   const renderNode = (
     key: string,
     value: unknown,
     prefix: string,
-    isLast: boolean
+    isLast: boolean,
+    depth: number
   ): void => {
-    const connector = isLast ? "\u2514\u2500\u2500 " : "\u251C\u2500\u2500 ";
-    lines.push(prefix + connector + key);
+    // Check depth limit before rendering
+    if (maxDepth !== undefined && depth >= maxDepth) {
+      return;
+    }
+
+    const connector = isLast ? guide.end : guide.fork;
+    const label = renderLabel(key, value, depth);
+    lines.push(prefix + connector + label);
 
     if (value !== null && typeof value === "object") {
       const entries = Object.entries(value as Record<string, unknown>);
-      const childPrefix = prefix + (isLast ? "    " : "\u2502   ");
+      const childPrefix = prefix + (isLast ? "    " : guide.vertical);
 
       entries.forEach(([childKey, childValue], index) => {
         const childIsLast = index === entries.length - 1;
-        renderNode(childKey, childValue, childPrefix, childIsLast);
+        renderNode(childKey, childValue, childPrefix, childIsLast, depth + 1);
       });
     }
   };
@@ -64,7 +142,7 @@ export function renderTree(tree: Record<string, unknown>): string {
   const entries = Object.entries(tree);
   entries.forEach(([key, value], index) => {
     const isLast = index === entries.length - 1;
-    renderNode(key, value, "", isLast);
+    renderNode(key, value, "", isLast, 0);
   });
 
   return lines.join("\n");

--- a/packages/cli/src/tree/index.ts
+++ b/packages/cli/src/tree/index.ts
@@ -22,4 +22,9 @@
  */
 
 // biome-ignore lint/performance/noBarrelFile: intentional re-exports for subpath API
-export { renderTree } from "../render/tree.js";
+export {
+  renderTree,
+  TREE_GUIDES,
+  type TreeGuideStyle,
+  type TreeOptions,
+} from "../render/tree.js";


### PR DESCRIPTION
## Summary

Add tree guide character sets for rendering hierarchical data structures with proper Unicode box-drawing characters and ASCII fallbacks.

- Add four guide styles: single, heavy, double, rounded
- Each style provides branch, last, vertical, and space characters
- Include ASCII fallbacks for non-Unicode terminals
- Export from `@outfitter/cli/render`

## Test Plan

- [x] Unit tests for all guide styles
- [x] Verify Unicode and fallback characters render correctly