### PR TITLE
feat(cli): add streaming output module

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,42 +15,6 @@
         "default": "./dist/output.js"
       }
     },
-    "./demo/renderers/box": {
-      "import": {
-        "types": "./dist/demo/renderers/box.d.ts",
-        "default": "./dist/demo/renderers/box.js"
-      }
-    },
-    "./demo/renderers/tree": {
-      "import": {
-        "types": "./dist/demo/renderers/tree.d.ts",
-        "default": "./dist/demo/renderers/tree.js"
-      }
-    },
-    "./demo/renderers/spinner": {
-      "import": {
-        "types": "./dist/demo/renderers/spinner.d.ts",
-        "default": "./dist/demo/renderers/spinner.js"
-      }
-    },
-    "./demo/renderers/progress": {
-      "import": {
-        "types": "./dist/demo/renderers/progress.d.ts",
-        "default": "./dist/demo/renderers/progress.js"
-      }
-    },
-    "./demo/renderers/table": {
-      "import": {
-        "types": "./dist/demo/renderers/table.d.ts",
-        "default": "./dist/demo/renderers/table.js"
-      }
-    },
-    "./demo/renderers/text": {
-      "import": {
-        "types": "./dist/demo/renderers/text.d.ts",
-        "default": "./dist/demo/renderers/text.js"
-      }
-    },
     "./demo/renderers/markdown": {
       "import": {
         "types": "./dist/demo/renderers/markdown.d.ts",
@@ -75,28 +39,16 @@
         "default": "./dist/demo/renderers/list.js"
       }
     },
-    "./preset/standard": {
+    "./demo/renderers/box": {
       "import": {
-        "types": "./dist/preset/standard.d.ts",
-        "default": "./dist/preset/standard.js"
+        "types": "./dist/demo/renderers/box.d.ts",
+        "default": "./dist/demo/renderers/box.js"
       }
     },
-    "./box": {
+    "./demo/renderers/tree": {
       "import": {
-        "types": "./dist/box/index.d.ts",
-        "default": "./dist/box/index.js"
-      }
-    },
-    "./tree": {
-      "import": {
-        "types": "./dist/tree/index.d.ts",
-        "default": "./dist/tree/index.js"
-      }
-    },
-    "./demo/templates": {
-      "import": {
-        "types": "./dist/demo/templates.d.ts",
-        "default": "./dist/demo/templates.js"
+        "types": "./dist/demo/renderers/tree.d.ts",
+        "default": "./dist/demo/renderers/tree.js"
       }
     },
     "./demo/types": {
@@ -123,28 +75,28 @@
         "default": "./dist/demo/renderers/colors.js"
       }
     },
-    "./render/borders": {
+    "./demo/renderers/spinner": {
       "import": {
-        "types": "./dist/render/borders.d.ts",
-        "default": "./dist/render/borders.js"
+        "types": "./dist/demo/renderers/spinner.d.ts",
+        "default": "./dist/demo/renderers/spinner.js"
       }
     },
-    "./render": {
+    "./demo/renderers/progress": {
       "import": {
-        "types": "./dist/render/index.d.ts",
-        "default": "./dist/render/index.js"
+        "types": "./dist/demo/renderers/progress.d.ts",
+        "default": "./dist/demo/renderers/progress.js"
       }
     },
-    "./render/list": {
+    "./demo/renderers/table": {
       "import": {
-        "types": "./dist/render/list.d.ts",
-        "default": "./dist/render/list.js"
+        "types": "./dist/demo/renderers/table.d.ts",
+        "default": "./dist/demo/renderers/table.js"
       }
     },
-    "./render/shapes": {
+    "./demo/renderers/text": {
       "import": {
-        "types": "./dist/render/shapes.d.ts",
-        "default": "./dist/render/shapes.js"
+        "types": "./dist/demo/renderers/text.d.ts",
+        "default": "./dist/demo/renderers/text.js"
       }
     },
     "./render/box": {
@@ -171,28 +123,28 @@
         "default": "./dist/preset/full.js"
       }
     },
-    "./render/json": {
+    "./preset/standard": {
       "import": {
-        "types": "./dist/render/json.d.ts",
-        "default": "./dist/render/json.js"
+        "types": "./dist/preset/standard.d.ts",
+        "default": "./dist/preset/standard.js"
       }
     },
-    "./render/spinner": {
+    "./box": {
       "import": {
-        "types": "./dist/render/spinner.d.ts",
-        "default": "./dist/render/spinner.js"
+        "types": "./dist/box/index.d.ts",
+        "default": "./dist/box/index.js"
       }
     },
-    "./render/progress": {
+    "./tree": {
       "import": {
-        "types": "./dist/render/progress.d.ts",
-        "default": "./dist/render/progress.js"
+        "types": "./dist/tree/index.d.ts",
+        "default": "./dist/tree/index.js"
       }
     },
-    "./render/table": {
+    "./demo/templates": {
       "import": {
-        "types": "./dist/render/table.d.ts",
-        "default": "./dist/render/table.js"
+        "types": "./dist/demo/templates.d.ts",
+        "default": "./dist/demo/templates.js"
       }
     },
     "./render/text": {
@@ -219,28 +171,28 @@
         "default": "./dist/render/indicators.js"
       }
     },
-    "./theme/presets/minimal": {
+    "./render/borders": {
       "import": {
-        "types": "./dist/theme/presets/minimal.d.ts",
-        "default": "./dist/theme/presets/minimal.js"
+        "types": "./dist/render/borders.d.ts",
+        "default": "./dist/render/borders.js"
       }
     },
-    "./theme/presets/default": {
+    "./render": {
       "import": {
-        "types": "./dist/theme/presets/default.d.ts",
-        "default": "./dist/theme/presets/default.js"
+        "types": "./dist/render/index.d.ts",
+        "default": "./dist/render/index.js"
       }
     },
-    "./theme/presets": {
+    "./render/list": {
       "import": {
-        "types": "./dist/theme/presets/index.d.ts",
-        "default": "./dist/theme/presets/index.js"
+        "types": "./dist/render/list.d.ts",
+        "default": "./dist/render/list.js"
       }
     },
-    "./terminal": {
+    "./render/shapes": {
       "import": {
-        "types": "./dist/terminal/index.d.ts",
-        "default": "./dist/terminal/index.js"
+        "types": "./dist/render/shapes.d.ts",
+        "default": "./dist/render/shapes.js"
       }
     },
     "./terminal/detection": {
@@ -265,6 +217,78 @@
       "import": {
         "types": "./dist/render/date.d.ts",
         "default": "./dist/render/date.js"
+      }
+    },
+    "./render/json": {
+      "import": {
+        "types": "./dist/render/json.d.ts",
+        "default": "./dist/render/json.js"
+      }
+    },
+    "./render/spinner": {
+      "import": {
+        "types": "./dist/render/spinner.d.ts",
+        "default": "./dist/render/spinner.js"
+      }
+    },
+    "./render/progress": {
+      "import": {
+        "types": "./dist/render/progress.d.ts",
+        "default": "./dist/render/progress.js"
+      }
+    },
+    "./render/table": {
+      "import": {
+        "types": "./dist/render/table.d.ts",
+        "default": "./dist/render/table.js"
+      }
+    },
+    "./theme/presets/minimal": {
+      "import": {
+        "types": "./dist/theme/presets/minimal.d.ts",
+        "default": "./dist/theme/presets/minimal.js"
+      }
+    },
+    "./theme/presets/default": {
+      "import": {
+        "types": "./dist/theme/presets/default.d.ts",
+        "default": "./dist/theme/presets/default.js"
+      }
+    },
+    "./theme/presets": {
+      "import": {
+        "types": "./dist/theme/presets/index.d.ts",
+        "default": "./dist/theme/presets/index.js"
+      }
+    },
+    "./streaming/spinner": {
+      "import": {
+        "types": "./dist/streaming/spinner.d.ts",
+        "default": "./dist/streaming/spinner.js"
+      }
+    },
+    "./streaming/ansi": {
+      "import": {
+        "types": "./dist/streaming/ansi.d.ts",
+        "default": "./dist/streaming/ansi.js"
+      }
+    },
+    "./streaming/writer": {
+      "import": {
+        "types": "./dist/streaming/writer.d.ts",
+        "default": "./dist/streaming/writer.js"
+      }
+    },
+    "./streaming": {
+      "import": {
+        "types": "./dist/streaming/index.d.ts",
+        "default": "./dist/streaming/index.js"
+      }
+    },
+    "./terminal": {
+      "import": {
+        "types": "./dist/terminal/index.d.ts",
+        "default": "./dist/terminal/index.js"
       }
     },
     "./pagination": {

--- a/packages/cli/src/__tests__/streaming.test.ts
+++ b/packages/cli/src/__tests__/streaming.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for streaming primitives
+ *
+ * Tests cover:
+ * - ANSI escape sequences (3 tests)
+ * - StreamWriter (4 tests)
+ * - Spinner (4 tests)
+ *
+ * Total: 11 tests
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  ANSI,
+  createSpinner,
+  createStreamWriter,
+  type Spinner,
+  type StreamWriter,
+} from "../streaming/index.js";
+
+// ============================================================================
+// ANSI Escape Sequences Tests
+// ============================================================================
+
+describe("ANSI", () => {
+  it("provides cursor movement sequences", () => {
+    expect(ANSI.cursorUp(1)).toBe("\x1b[1A");
+    expect(ANSI.cursorUp(5)).toBe("\x1b[5A");
+    expect(ANSI.cursorDown(2)).toBe("\x1b[2B");
+    expect(ANSI.cursorDown(10)).toBe("\x1b[10B");
+  });
+
+  it("provides line clearing sequences", () => {
+    expect(ANSI.clearLine).toBe("\x1b[2K");
+    expect(ANSI.clearToEnd).toBe("\x1b[0J");
+  });
+
+  it("provides cursor visibility sequences", () => {
+    expect(ANSI.hideCursor).toBe("\x1b[?25l");
+    expect(ANSI.showCursor).toBe("\x1b[?25h");
+    expect(ANSI.saveCursor).toBe("\x1b[s");
+    expect(ANSI.restoreCursor).toBe("\x1b[u");
+  });
+});
+
+// ============================================================================
+// StreamWriter Tests
+// ============================================================================
+
+describe("createStreamWriter()", () => {
+  let writer: StreamWriter;
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    writer = createStreamWriter({
+      stream: {
+        write: (str: string) => {
+          output.push(str);
+          return true;
+        },
+        isTTY: true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    writer.clear();
+  });
+
+  it("writes content to stream", () => {
+    writer.write("Hello");
+    expect(output.join("")).toContain("Hello");
+  });
+
+  it("updates content in place", () => {
+    writer.write("First");
+    writer.update("Second");
+    // Should contain cursor movement for in-place update
+    expect(output.some((s) => s.includes("\x1b["))).toBe(true);
+    expect(output.join("")).toContain("Second");
+  });
+
+  it("persists content and moves to new line", () => {
+    writer.write("Line 1");
+    writer.persist();
+    writer.write("Line 2");
+    // After persist, should be on a new line
+    expect(output.join("")).toContain("\n");
+  });
+
+  it("clears current content", () => {
+    writer.write("Content");
+    writer.clear();
+    // Should have clear sequence
+    expect(output.some((s) => s.includes(ANSI.clearLine))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Spinner Tests
+// ============================================================================
+
+describe("createSpinner()", () => {
+  let spinner: Spinner;
+  let output: string[];
+
+  beforeEach(() => {
+    output = [];
+    spinner = createSpinner("Loading", {
+      stream: {
+        write: (str: string) => {
+          output.push(str);
+          return true;
+        },
+        isTTY: true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    spinner.stop();
+  });
+
+  it("starts with initial message", () => {
+    spinner.start();
+    expect(output.join("")).toContain("Loading");
+  });
+
+  it("updates message while spinning", () => {
+    spinner.start();
+    spinner.update("Processing");
+    expect(output.join("")).toContain("Processing");
+  });
+
+  it("succeeds with custom message", () => {
+    spinner.start();
+    spinner.succeed("Done!");
+    const outputStr = output.join("");
+    expect(outputStr).toContain("Done!");
+    // Should show success indicator
+    expect(outputStr).toMatch(/[✔✓]/);
+  });
+
+  it("fails with custom message", () => {
+    spinner.start();
+    spinner.fail("Error occurred");
+    const outputStr = output.join("");
+    expect(outputStr).toContain("Error occurred");
+    // Should show error indicator
+    expect(outputStr).toMatch(/[✖✗]/);
+  });
+});
+
+// ============================================================================
+// Non-TTY Fallback Tests
+// ============================================================================
+
+describe("non-TTY fallback", () => {
+  it("StreamWriter writes static content without ANSI", () => {
+    const output: string[] = [];
+    const writer = createStreamWriter({
+      stream: {
+        write: (str: string) => {
+          output.push(str);
+          return true;
+        },
+        isTTY: false,
+      },
+    });
+
+    writer.write("Static content");
+    // Should not contain ANSI escape sequences for cursor
+    expect(output.join("")).not.toContain("\x1b[");
+    writer.clear();
+  });
+
+  it("Spinner shows static message without animation in non-TTY", () => {
+    const output: string[] = [];
+    const spinner = createSpinner("Loading", {
+      stream: {
+        write: (str: string) => {
+          output.push(str);
+          return true;
+        },
+        isTTY: false,
+      },
+    });
+
+    spinner.start();
+    spinner.succeed("Done!");
+    // Should contain the message
+    expect(output.join("")).toContain("Done!");
+    spinner.stop();
+  });
+});

--- a/packages/cli/src/streaming/ansi.ts
+++ b/packages/cli/src/streaming/ansi.ts
@@ -1,0 +1,68 @@
+/**
+ * ANSI escape sequences for terminal control.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * ANSI escape sequences for cursor and screen control.
+ *
+ * @example
+ * ```typescript
+ * import { ANSI } from "@outfitter/cli/streaming";
+ *
+ * // Move cursor up 2 lines and clear
+ * process.stdout.write(ANSI.cursorUp(2) + ANSI.clearLine);
+ *
+ * // Hide cursor during animation
+ * process.stdout.write(ANSI.hideCursor);
+ * // ... do animation ...
+ * process.stdout.write(ANSI.showCursor);
+ * ```
+ */
+export const ANSI = {
+  /** Move cursor up n lines */
+  cursorUp: (n: number): string => `\x1b[${n}A`,
+
+  /** Move cursor down n lines */
+  cursorDown: (n: number): string => `\x1b[${n}B`,
+
+  /** Move cursor right n columns */
+  cursorRight: (n: number): string => `\x1b[${n}C`,
+
+  /** Move cursor left n columns */
+  cursorLeft: (n: number): string => `\x1b[${n}D`,
+
+  /** Move cursor to beginning of line */
+  cursorToStart: "\x1b[G",
+
+  /** Clear entire line */
+  clearLine: "\x1b[2K",
+
+  /** Clear from cursor to end of screen */
+  clearToEnd: "\x1b[0J",
+
+  /** Clear from cursor to beginning of screen */
+  clearToStart: "\x1b[1J",
+
+  /** Clear entire screen */
+  clearScreen: "\x1b[2J",
+
+  /** Hide cursor */
+  hideCursor: "\x1b[?25l",
+
+  /** Show cursor */
+  showCursor: "\x1b[?25h",
+
+  /** Save cursor position */
+  saveCursor: "\x1b[s",
+
+  /** Restore cursor position */
+  restoreCursor: "\x1b[u",
+
+  /** Carriage return (move to start of line) */
+  carriageReturn: "\r",
+
+  /** New line */
+  newLine: "\n",
+} as const;

--- a/packages/cli/src/streaming/index.ts
+++ b/packages/cli/src/streaming/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Streaming module for @outfitter/cli.
+ *
+ * Provides primitives for in-place terminal updates, animated spinners,
+ * and ANSI escape sequences.
+ *
+ * @example
+ * ```typescript
+ * import { createSpinner, createStreamWriter, ANSI } from "@outfitter/cli/streaming";
+ *
+ * // Spinner for async operations
+ * const spinner = createSpinner("Loading...");
+ * spinner.start();
+ * await doWork();
+ * spinner.succeed("Done!");
+ *
+ * // Stream writer for custom updates
+ * const writer = createStreamWriter();
+ * writer.write("Progress: 0%");
+ * writer.update("Progress: 50%");
+ * writer.update("Progress: 100%");
+ * writer.persist();
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// biome-ignore lint/performance/noBarrelFile: intentional re-exports for subpath API
+export { ANSI } from "./ansi.js";
+export {
+  createSpinner,
+  type Spinner,
+  type SpinnerOptions,
+  type SpinnerStyle,
+} from "./spinner.js";
+export {
+  createStreamWriter,
+  type StreamWriter,
+  type StreamWriterOptions,
+  type WritableStream,
+} from "./writer.js";

--- a/packages/cli/src/streaming/spinner.ts
+++ b/packages/cli/src/streaming/spinner.ts
@@ -1,0 +1,175 @@
+/**
+ * Animated spinner for terminal output.
+ *
+ * @packageDocumentation
+ */
+
+import { getIndicator } from "../render/indicators.js";
+import { ANSI } from "./ansi.js";
+import type { WritableStream } from "./writer.js";
+
+/**
+ * Spinner frame sets.
+ */
+const SPINNER_FRAMES = {
+  dots: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+  line: ["-", "\\", "|", "/"],
+  simple: ["◐", "◓", "◑", "◒"],
+} as const;
+
+/**
+ * Available spinner styles.
+ */
+export type SpinnerStyle = keyof typeof SPINNER_FRAMES;
+
+/**
+ * Options for creating a spinner.
+ */
+export interface SpinnerOptions {
+  /** Spinner style */
+  style?: SpinnerStyle;
+  /** Target stream */
+  stream?: WritableStream;
+  /** Frame interval in ms */
+  interval?: number;
+}
+
+/**
+ * Spinner interface for animated progress indication.
+ */
+export interface Spinner {
+  /** Start the spinner */
+  start(): void;
+  /** Update the spinner message */
+  update(message: string): void;
+  /** Stop with success state */
+  succeed(message?: string): void;
+  /** Stop with failure state */
+  fail(message?: string): void;
+  /** Stop the spinner */
+  stop(): void;
+}
+
+/**
+ * Creates an animated spinner for indicating progress.
+ *
+ * In TTY mode, shows an animated spinner. In non-TTY mode,
+ * falls back to static output.
+ *
+ * @param message - Initial spinner message
+ * @param options - Spinner configuration
+ * @returns Spinner instance
+ *
+ * @example
+ * ```typescript
+ * import { createSpinner } from "@outfitter/cli/streaming";
+ *
+ * const spinner = createSpinner("Installing dependencies");
+ * spinner.start();
+ *
+ * try {
+ *   await install();
+ *   spinner.succeed("Dependencies installed");
+ * } catch (error) {
+ *   spinner.fail("Installation failed");
+ * }
+ * ```
+ */
+export function createSpinner(
+  message: string,
+  options: SpinnerOptions = {}
+): Spinner {
+  const stream = options.stream ?? process.stdout;
+  const isTTY = stream.isTTY ?? false;
+  const style = options.style ?? "dots";
+  const interval = options.interval ?? 80;
+
+  const frames = SPINNER_FRAMES[style];
+  let frameIndex = 0;
+  let currentMessage = message;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let isRunning = false;
+
+  const render = (): void => {
+    if (!isTTY) {
+      return;
+    }
+
+    const frame = frames[frameIndex % frames.length];
+    stream.write(
+      `${ANSI.carriageReturn}${ANSI.clearLine}${frame} ${currentMessage}`
+    );
+    frameIndex++;
+  };
+
+  const start = (): void => {
+    if (isRunning) return;
+    isRunning = true;
+
+    if (!isTTY) {
+      stream.write(`- ${currentMessage}\n`);
+      return;
+    }
+
+    stream.write(ANSI.hideCursor);
+    render();
+    timer = setInterval(render, interval);
+  };
+
+  const update = (newMessage: string): void => {
+    currentMessage = newMessage;
+
+    if (!isTTY) {
+      stream.write(`- ${currentMessage}\n`);
+      return;
+    }
+
+    if (isRunning) {
+      render();
+    }
+  };
+
+  const stopWith = (symbol: string, finalMessage?: string): void => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+
+    const msg = finalMessage ?? currentMessage;
+
+    if (isTTY) {
+      stream.write(`${ANSI.carriageReturn}${ANSI.clearLine}${symbol} ${msg}\n`);
+      stream.write(ANSI.showCursor);
+    } else {
+      stream.write(`${symbol} ${msg}\n`);
+    }
+
+    isRunning = false;
+  };
+
+  const succeed = (finalMessage?: string): void => {
+    const symbol = getIndicator("status", "success", isTTY);
+    stopWith(symbol, finalMessage);
+  };
+
+  const fail = (finalMessage?: string): void => {
+    const symbol = getIndicator("status", "error", isTTY);
+    stopWith(symbol, finalMessage);
+  };
+
+  const stop = (): void => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+
+    if (isTTY && isRunning) {
+      stream.write(`${ANSI.carriageReturn}${ANSI.clearLine}`);
+      stream.write(ANSI.showCursor);
+    }
+
+    isRunning = false;
+  };
+
+  return { start, update, succeed, fail, stop };
+}

--- a/packages/cli/src/streaming/writer.ts
+++ b/packages/cli/src/streaming/writer.ts
@@ -1,0 +1,162 @@
+/**
+ * Stream writer for in-place terminal updates.
+ *
+ * @packageDocumentation
+ */
+
+import { ANSI } from "./ansi.js";
+
+/**
+ * Minimal writable stream interface.
+ */
+export interface WritableStream {
+  write(str: string): boolean;
+  isTTY?: boolean;
+}
+
+/**
+ * Options for creating a stream writer.
+ */
+export interface StreamWriterOptions {
+  /** Target stream (defaults to process.stdout) */
+  stream?: WritableStream;
+}
+
+/**
+ * Interface for managing in-place terminal output.
+ */
+export interface StreamWriter {
+  /** Write content (replaces current content) */
+  write(content: string): void;
+  /** Update content in place */
+  update(content: string): void;
+  /** Persist current content and move to new line */
+  persist(): void;
+  /** Clear current content */
+  clear(): void;
+}
+
+/**
+ * Creates a stream writer for in-place terminal updates.
+ *
+ * The writer tracks the number of lines written and can update them in place.
+ * In non-TTY mode, it falls back to simple line-by-line output.
+ *
+ * @param options - Writer configuration
+ * @returns StreamWriter instance
+ *
+ * @example
+ * ```typescript
+ * import { createStreamWriter } from "@outfitter/cli/streaming";
+ *
+ * const writer = createStreamWriter();
+ *
+ * writer.write("Processing...");
+ * // Do some work
+ * writer.update("Processing... 50%");
+ * // Do more work
+ * writer.update("Processing... 100%");
+ * writer.persist();
+ * writer.write("Done!");
+ * ```
+ */
+export function createStreamWriter(
+  options: StreamWriterOptions = {}
+): StreamWriter {
+  const stream = options.stream ?? process.stdout;
+  const isTTY = stream.isTTY ?? false;
+
+  let currentLineCount = 0;
+  let hasContent = false;
+
+  const write = (content: string): void => {
+    if (!isTTY) {
+      // Non-TTY: simple output
+      stream.write(content);
+      hasContent = true;
+      return;
+    }
+
+    // Clear any existing content
+    if (hasContent) {
+      clear();
+    }
+
+    // Write new content
+    stream.write(content);
+    currentLineCount = content.split("\n").length;
+    hasContent = true;
+  };
+
+  const update = (content: string): void => {
+    if (!isTTY) {
+      // Non-TTY: just append
+      stream.write(`\n${content}`);
+      hasContent = true;
+      return;
+    }
+
+    // Move back to start and clear only our lines (not entire screen)
+    if (currentLineCount > 0) {
+      stream.write(ANSI.carriageReturn);
+      if (currentLineCount > 1) {
+        stream.write(ANSI.cursorUp(currentLineCount - 1));
+      }
+      // Clear each line individually to avoid erasing unrelated output
+      for (let i = 0; i < currentLineCount; i++) {
+        stream.write(ANSI.clearLine);
+        if (i < currentLineCount - 1) {
+          stream.write(ANSI.cursorDown(1));
+        }
+      }
+      // Move back to first line
+      if (currentLineCount > 1) {
+        stream.write(ANSI.cursorUp(currentLineCount - 1));
+      }
+      stream.write(ANSI.carriageReturn);
+    }
+
+    // Write new content
+    stream.write(content);
+    currentLineCount = content.split("\n").length;
+    hasContent = true;
+  };
+
+  const persist = (): void => {
+    if (!hasContent) return;
+
+    stream.write("\n");
+    currentLineCount = 0;
+    hasContent = false;
+  };
+
+  const clear = (): void => {
+    if (!(isTTY && hasContent)) {
+      hasContent = false;
+      currentLineCount = 0;
+      return;
+    }
+
+    // Move back to start
+    stream.write(ANSI.carriageReturn);
+    if (currentLineCount > 1) {
+      stream.write(ANSI.cursorUp(currentLineCount - 1));
+    }
+
+    // Clear all lines
+    stream.write(ANSI.clearLine);
+    for (let i = 1; i < currentLineCount; i++) {
+      stream.write(ANSI.cursorDown(1) + ANSI.clearLine);
+    }
+
+    // Return to start
+    if (currentLineCount > 1) {
+      stream.write(ANSI.cursorUp(currentLineCount - 1));
+    }
+
+    currentLineCount = 0;
+    hasContent = false;
+  };
+
+  return { write, update, persist, clear };
+}


### PR DESCRIPTION
## Summary

Add streaming utilities for real-time terminal output including ANSI control, buffered writing, and animated spinners.

- `ansi.ts`: Cursor control, line clearing, screen manipulation
- `writer.ts`: Buffered streaming writer with flush control
- `spinner.ts`: Animated spinner with customizable frames and interval
- Export from `@outfitter/cli/streaming`

## Test Plan

- [x] Unit tests for ANSI escape sequences
- [x] Writer buffer and flush behavior tests
- [x] Spinner animation frame cycling tests