### PR TITLE
feat(cli): add Result-wrapped prompt module

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,100 +15,10 @@
         "default": "./dist/output.js"
       }
     },
-    "./demo/renderers/markdown": {
-      "import": {
-        "types": "./dist/demo/renderers/markdown.d.ts",
-        "default": "./dist/demo/renderers/markdown.js"
-      }
-    },
-    "./demo/renderers/indicators": {
-      "import": {
-        "types": "./dist/demo/renderers/indicators.d.ts",
-        "default": "./dist/demo/renderers/indicators.js"
-      }
-    },
-    "./demo/renderers/borders": {
-      "import": {
-        "types": "./dist/demo/renderers/borders.d.ts",
-        "default": "./dist/demo/renderers/borders.js"
-      }
-    },
-    "./demo/renderers/list": {
-      "import": {
-        "types": "./dist/demo/renderers/list.d.ts",
-        "default": "./dist/demo/renderers/list.js"
-      }
-    },
-    "./demo/renderers/box": {
-      "import": {
-        "types": "./dist/demo/renderers/box.d.ts",
-        "default": "./dist/demo/renderers/box.js"
-      }
-    },
-    "./demo/renderers/tree": {
-      "import": {
-        "types": "./dist/demo/renderers/tree.d.ts",
-        "default": "./dist/demo/renderers/tree.js"
-      }
-    },
-    "./demo/types": {
-      "import": {
-        "types": "./dist/demo/types.d.ts",
-        "default": "./dist/demo/types.js"
-      }
-    },
-    "./demo/registry": {
-      "import": {
-        "types": "./dist/demo/registry.d.ts",
-        "default": "./dist/demo/registry.js"
-      }
-    },
     "./demo": {
       "import": {
         "types": "./dist/demo/index.d.ts",
         "default": "./dist/demo/index.js"
-      }
-    },
-    "./demo/renderers/colors": {
-      "import": {
-        "types": "./dist/demo/renderers/colors.d.ts",
-        "default": "./dist/demo/renderers/colors.js"
-      }
-    },
-    "./demo/renderers/spinner": {
-      "import": {
-        "types": "./dist/demo/renderers/spinner.d.ts",
-        "default": "./dist/demo/renderers/spinner.js"
-      }
-    },
-    "./demo/renderers/progress": {
-      "import": {
-        "types": "./dist/demo/renderers/progress.d.ts",
-        "default": "./dist/demo/renderers/progress.js"
-      }
-    },
-    "./demo/renderers/table": {
-      "import": {
-        "types": "./dist/demo/renderers/table.d.ts",
-        "default": "./dist/demo/renderers/table.js"
-      }
-    },
-    "./demo/renderers/text": {
-      "import": {
-        "types": "./dist/demo/renderers/text.d.ts",
-        "default": "./dist/demo/renderers/text.js"
-      }
-    },
-    "./render/box": {
-      "import": {
-        "types": "./dist/render/box.d.ts",
-        "default": "./dist/render/box.js"
-      }
-    },
-    "./render/tree": {
-      "import": {
-        "types": "./dist/render/tree.d.ts",
-        "default": "./dist/render/tree.js"
       }
     },
     "./borders": {
@@ -141,124 +51,22 @@
         "default": "./dist/tree/index.js"
       }
     },
-    "./demo/templates": {
-      "import": {
-        "types": "./dist/demo/templates.d.ts",
-        "default": "./dist/demo/templates.js"
-      }
-    },
-    "./render/text": {
-      "import": {
-        "types": "./dist/render/text.d.ts",
-        "default": "./dist/render/text.js"
-      }
-    },
-    "./render/markdown": {
-      "import": {
-        "types": "./dist/render/markdown.d.ts",
-        "default": "./dist/render/markdown.js"
-      }
-    },
-    "./render/format": {
-      "import": {
-        "types": "./dist/render/format.d.ts",
-        "default": "./dist/render/format.js"
-      }
-    },
-    "./render/indicators": {
-      "import": {
-        "types": "./dist/render/indicators.d.ts",
-        "default": "./dist/render/indicators.js"
-      }
-    },
-    "./render/borders": {
-      "import": {
-        "types": "./dist/render/borders.d.ts",
-        "default": "./dist/render/borders.js"
-      }
-    },
     "./render": {
       "import": {
         "types": "./dist/render/index.d.ts",
         "default": "./dist/render/index.js"
       }
     },
-    "./render/list": {
+    "./prompt/validators": {
       "import": {
-        "types": "./dist/render/list.d.ts",
-        "default": "./dist/render/list.js"
+        "types": "./dist/prompt/validators.d.ts",
+        "default": "./dist/prompt/validators.js"
       }
     },
-    "./render/shapes": {
+    "./prompt": {
       "import": {
-        "types": "./dist/render/shapes.d.ts",
-        "default": "./dist/render/shapes.js"
-      }
-    },
-    "./terminal/detection": {
-      "import": {
-        "types": "./dist/terminal/detection.d.ts",
-        "default": "./dist/terminal/detection.js"
-      }
-    },
-    "./render/colors": {
-      "import": {
-        "types": "./dist/render/colors.d.ts",
-        "default": "./dist/render/colors.js"
-      }
-    },
-    "./render/format-relative": {
-      "import": {
-        "types": "./dist/render/format-relative.d.ts",
-        "default": "./dist/render/format-relative.js"
-      }
-    },
-    "./render/date": {
-      "import": {
-        "types": "./dist/render/date.d.ts",
-        "default": "./dist/render/date.js"
-      }
-    },
-    "./render/json": {
-      "import": {
-        "types": "./dist/render/json.d.ts",
-        "default": "./dist/render/json.js"
-      }
-    },
-    "./render/spinner": {
-      "import": {
-        "types": "./dist/render/spinner.d.ts",
-        "default": "./dist/render/spinner.js"
-      }
-    },
-    "./render/progress": {
-      "import": {
-        "types": "./dist/render/progress.d.ts",
-        "default": "./dist/render/progress.js"
-      }
-    },
-    "./render/table": {
-      "import": {
-        "types": "./dist/render/table.d.ts",
-        "default": "./dist/render/table.js"
-      }
-    },
-    "./theme/presets/minimal": {
-      "import": {
-        "types": "./dist/theme/presets/minimal.d.ts",
-        "default": "./dist/theme/presets/minimal.js"
-      }
-    },
-    "./theme/presets/default": {
-      "import": {
-        "types": "./dist/theme/presets/default.d.ts",
-        "default": "./dist/theme/presets/default.js"
-      }
-    },
-    "./theme/presets": {
-      "import": {
-        "types": "./dist/theme/presets/index.d.ts",
-        "default": "./dist/theme/presets/index.js"
+        "types": "./dist/prompt/index.d.ts",
+        "default": "./dist/prompt/index.js"
       }
     },
     "./streaming/spinner": {
@@ -285,10 +93,100 @@
         "default": "./dist/streaming/index.js"
       }
     },
-    "./terminal": {
+    "./theme/presets/rounded": {
       "import": {
-        "types": "./dist/terminal/index.d.ts",
-        "default": "./dist/terminal/index.js"
+        "types": "./dist/theme/presets/rounded.d.ts",
+        "default": "./dist/theme/presets/rounded.js"
+      }
+    },
+    "./theme/presets/bold": {
+      "import": {
+        "types": "./dist/theme/presets/bold.d.ts",
+        "default": "./dist/theme/presets/bold.js"
+      }
+    },
+    "./theme/presets/minimal": {
+      "import": {
+        "types": "./dist/theme/presets/minimal.d.ts",
+        "default": "./dist/theme/presets/minimal.js"
+      }
+    },
+    "./theme/presets/default": {
+      "import": {
+        "types": "./dist/theme/presets/default.d.ts",
+        "default": "./dist/theme/presets/default.js"
+      }
+    },
+    "./theme/presets": {
+      "import": {
+        "types": "./dist/theme/presets/index.d.ts",
+        "default": "./dist/theme/presets/index.js"
+      }
+    },
+    "./prompt/confirm": {
+      "import": {
+        "types": "./dist/prompt/confirm.d.ts",
+        "default": "./dist/prompt/confirm.js"
+      }
+    },
+    "./prompt/select": {
+      "import": {
+        "types": "./dist/prompt/select.d.ts",
+        "default": "./dist/prompt/select.js"
+      }
+    },
+    "./prompt/group": {
+      "import": {
+        "types": "./dist/prompt/group.d.ts",
+        "default": "./dist/prompt/group.js"
+      }
+    },
+    "./list": {
+      "import": {
+        "types": "./dist/list/index.d.ts",
+        "default": "./dist/list/index.js"
+      }
+    },
+    "./colors": {
+      "import": {
+        "types": "./dist/colors/index.d.ts",
+        "default": "./dist/colors/index.js"
+      }
+    },
+    "./table": {
+      "import": {
+        "types": "./dist/table/index.d.ts",
+        "default": "./dist/table/index.js"
+      }
+    },
+    "./theme/context": {
+      "import": {
+        "types": "./dist/theme/context.d.ts",
+        "default": "./dist/theme/context.js"
+      }
+    },
+    "./theme/types": {
+      "import": {
+        "types": "./dist/theme/types.d.ts",
+        "default": "./dist/theme/types.js"
+      }
+    },
+    "./theme": {
+      "import": {
+        "types": "./dist/theme/index.d.ts",
+        "default": "./dist/theme/index.js"
+      }
+    },
+    "./theme/create": {
+      "import": {
+        "types": "./dist/theme/create.d.ts",
+        "default": "./dist/theme/create.js"
+      }
+    },
+    "./theme/resolve": {
+      "import": {
+        "types": "./dist/theme/resolve.d.ts",
+        "default": "./dist/theme/resolve.js"
       }
     },
     "./pagination": {

--- a/packages/cli/src/__tests__/prompt.test.ts
+++ b/packages/cli/src/__tests__/prompt.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for prompt utilities
+ *
+ * Tests cover:
+ * - Validators (5 tests)
+ * - Type exports (1 test)
+ *
+ * Total: 6 tests
+ */
+import { describe, expect, it } from "bun:test";
+import { validators } from "../prompt/validators.js";
+
+// ============================================================================
+// Validator Tests
+// ============================================================================
+
+describe("validators", () => {
+  describe("required()", () => {
+    it("fails on empty string", () => {
+      const validate = validators.required();
+      const result = validate("");
+      expect(result).toBe("Required");
+    });
+
+    it("passes on non-empty string", () => {
+      const validate = validators.required();
+      const result = validate("hello");
+      expect(result).toBeUndefined();
+    });
+
+    it("uses custom error message", () => {
+      const validate = validators.required("Please enter a value");
+      const result = validate("");
+      expect(result).toBe("Please enter a value");
+    });
+  });
+
+  describe("minLength()", () => {
+    it("fails when too short", () => {
+      const validate = validators.minLength(5);
+      const result = validate("abc");
+      expect(result).toBe("Minimum 5 characters");
+    });
+
+    it("passes when long enough", () => {
+      const validate = validators.minLength(5);
+      const result = validate("hello");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("maxLength()", () => {
+    it("fails when too long", () => {
+      const validate = validators.maxLength(5);
+      const result = validate("hello world");
+      expect(result).toBe("Maximum 5 characters");
+    });
+
+    it("passes when short enough", () => {
+      const validate = validators.maxLength(5);
+      const result = validate("hi");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("pattern()", () => {
+    it("fails when pattern does not match", () => {
+      const validate = validators.pattern(/^\d+$/, "Numbers only");
+      const result = validate("abc");
+      expect(result).toBe("Numbers only");
+    });
+
+    it("passes when pattern matches", () => {
+      const validate = validators.pattern(/^\d+$/, "Numbers only");
+      const result = validate("123");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("email()", () => {
+    it("fails on invalid email", () => {
+      const validate = validators.email();
+      const result = validate("not-an-email");
+      expect(result).toBe("Invalid email");
+    });
+
+    it("passes on valid email", () => {
+      const validate = validators.email();
+      const result = validate("test@example.com");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("compose()", () => {
+    it("runs validators in order and returns first error", () => {
+      const validate = validators.compose(
+        validators.required(),
+        validators.minLength(5)
+      );
+      const result = validate("");
+      expect(result).toBe("Required");
+    });
+
+    it("passes when all validators pass", () => {
+      const validate = validators.compose(
+        validators.required(),
+        validators.minLength(3),
+        validators.maxLength(10)
+      );
+      const result = validate("hello");
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/prompt/confirm.ts
+++ b/packages/cli/src/prompt/confirm.ts
@@ -1,0 +1,53 @@
+/**
+ * Confirmation prompt wrapper.
+ *
+ * @packageDocumentation
+ */
+
+import { confirm, isCancel } from "@clack/prompts";
+import { Result } from "better-result";
+import {
+  type ConfirmPromptOptions,
+  createCancelledError,
+  type PromptResult,
+} from "./types.js";
+
+/**
+ * Prompts for yes/no confirmation with Result wrapping.
+ *
+ * @param options - Confirm prompt options
+ * @returns Ok with boolean or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptConfirm } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptConfirm({
+ *   message: "Are you sure you want to continue?",
+ *   initialValue: false,
+ * });
+ *
+ * if (result.isOk() && result.value) {
+ *   console.log("Continuing...");
+ * }
+ * ```
+ */
+export async function promptConfirm(
+  options: ConfirmPromptOptions
+): PromptResult<boolean> {
+  // Build options object, excluding undefined values for exactOptionalPropertyTypes
+  const confirmOptions: Parameters<typeof confirm>[0] = {
+    message: options.message,
+  };
+  if (options.initialValue !== undefined) {
+    confirmOptions.initialValue = options.initialValue;
+  }
+
+  const result = await confirm(confirmOptions);
+
+  if (isCancel(result)) {
+    return Result.err(createCancelledError());
+  }
+
+  return Result.ok(result);
+}

--- a/packages/cli/src/prompt/group.ts
+++ b/packages/cli/src/prompt/group.ts
@@ -1,0 +1,61 @@
+/**
+ * Grouped prompts for wizard-style workflows.
+ *
+ * @packageDocumentation
+ */
+
+import type { Result } from "better-result";
+import { Result as R } from "better-result";
+import type { CancelledError, PromptResult } from "./types.js";
+import { createCancelledError } from "./types.js";
+
+/**
+ * A step in a prompt group.
+ */
+export type PromptStep<T> = () => PromptResult<T>;
+
+/**
+ * Collects multiple prompts into a single result object.
+ *
+ * If any prompt is cancelled, the entire group fails with CancelledError.
+ *
+ * @param steps - Object of named prompt steps
+ * @returns Ok with collected values or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptGroup, promptText, promptSelect } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptGroup({
+ *   name: () => promptText({ message: "Name:" }),
+ *   role: () => promptSelect({
+ *     message: "Role:",
+ *     options: [
+ *       { value: "admin", label: "Admin" },
+ *       { value: "user", label: "User" },
+ *     ],
+ *   }),
+ * });
+ *
+ * if (result.isOk()) {
+ *   console.log(`Creating ${result.value.role}: ${result.value.name}`);
+ * }
+ * ```
+ */
+export async function promptGroup<T extends Record<string, unknown>>(
+  steps: { [K in keyof T]: PromptStep<T[K]> }
+): Promise<Result<T, CancelledError>> {
+  const result: Partial<T> = {};
+
+  for (const [key, step] of Object.entries(steps)) {
+    const stepResult = await (step as PromptStep<unknown>)();
+
+    if (stepResult.isErr()) {
+      return R.err(createCancelledError(stepResult.error.message));
+    }
+
+    result[key as keyof T] = stepResult.value as T[keyof T];
+  }
+
+  return R.ok(result as T);
+}

--- a/packages/cli/src/prompt/index.ts
+++ b/packages/cli/src/prompt/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Prompt module for @outfitter/cli.
+ *
+ * Provides Result-wrapped prompts using Clack, with validators and
+ * group utilities for wizard-style workflows.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   promptText,
+ *   promptSelect,
+ *   promptConfirm,
+ *   promptGroup,
+ *   validators,
+ * } from "@outfitter/cli/prompt";
+ *
+ * // Single prompt
+ * const name = await promptText({
+ *   message: "Name:",
+ *   validate: validators.required(),
+ * });
+ *
+ * // Grouped prompts
+ * const config = await promptGroup({
+ *   name: () => promptText({ message: "Name:" }),
+ *   debug: () => promptConfirm({ message: "Debug mode?" }),
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// biome-ignore lint/performance/noBarrelFile: intentional re-exports for subpath API
+export { promptConfirm } from "./confirm.js";
+export { type PromptStep, promptGroup } from "./group.js";
+export { promptMultiSelect, promptSelect } from "./select.js";
+export { promptPassword, promptText } from "./text.js";
+export {
+  type CancelledError,
+  type ConfirmPromptOptions,
+  createCancelledError,
+  type MultiSelectPromptOptions,
+  type PasswordPromptOptions,
+  type PromptResult,
+  type SelectPromptOptions,
+  type TextPromptOptions,
+} from "./types.js";
+export { type Validator, validators } from "./validators.js";

--- a/packages/cli/src/prompt/select.ts
+++ b/packages/cli/src/prompt/select.ts
@@ -1,0 +1,127 @@
+/**
+ * Select and multi-select prompt wrappers.
+ *
+ * @packageDocumentation
+ */
+
+import { isCancel, multiselect, select } from "@clack/prompts";
+import { Result } from "better-result";
+import {
+  createCancelledError,
+  type MultiSelectPromptOptions,
+  type PromptResult,
+  type SelectPromptOptions,
+} from "./types.js";
+
+/**
+ * Prompts for single selection with Result wrapping.
+ *
+ * @param options - Select prompt options
+ * @returns Ok with selected value or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptSelect } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptSelect({
+ *   message: "Pick a color:",
+ *   options: [
+ *     { value: "red", label: "Red", hint: "A warm color" },
+ *     { value: "blue", label: "Blue", hint: "A cool color" },
+ *   ],
+ * });
+ *
+ * if (result.isOk()) {
+ *   console.log(`You picked: ${result.value}`);
+ * }
+ * ```
+ */
+export async function promptSelect<T>(
+  options: SelectPromptOptions<T>
+): PromptResult<T> {
+  // Map options to ensure correct type for Clack
+  const clackOptions = options.options.map((opt) => {
+    const mapped: { value: T; label: string; hint?: string } = {
+      value: opt.value,
+      label: opt.label,
+    };
+    if (opt.hint !== undefined) {
+      mapped.hint = opt.hint;
+    }
+    return mapped;
+  });
+
+  // Build select options, excluding undefined values for exactOptionalPropertyTypes
+  const selectOptions: Parameters<typeof select>[0] = {
+    message: options.message,
+    options: clackOptions as Parameters<typeof select>[0]["options"],
+  };
+  if (options.initialValue !== undefined) {
+    selectOptions.initialValue = options.initialValue;
+  }
+
+  const result = await select(selectOptions);
+
+  if (isCancel(result)) {
+    return Result.err(createCancelledError());
+  }
+
+  return Result.ok(result as T);
+}
+
+/**
+ * Prompts for multiple selections with Result wrapping.
+ *
+ * @param options - Multi-select prompt options
+ * @returns Ok with array of selected values or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptMultiSelect } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptMultiSelect({
+ *   message: "Select toppings:",
+ *   options: [
+ *     { value: "cheese", label: "Cheese" },
+ *     { value: "pepperoni", label: "Pepperoni" },
+ *     { value: "mushrooms", label: "Mushrooms" },
+ *   ],
+ *   required: true,
+ * });
+ * ```
+ */
+export async function promptMultiSelect<T>(
+  options: MultiSelectPromptOptions<T>
+): PromptResult<T[]> {
+  // Map options to ensure correct type for Clack
+  const clackOptions = options.options.map((opt) => {
+    const mapped: { value: T; label: string; hint?: string } = {
+      value: opt.value,
+      label: opt.label,
+    };
+    if (opt.hint !== undefined) {
+      mapped.hint = opt.hint;
+    }
+    return mapped;
+  });
+
+  // Build multiselect options, excluding undefined values for exactOptionalPropertyTypes
+  const multiselectOptions: Parameters<typeof multiselect>[0] = {
+    message: options.message,
+    options: clackOptions as Parameters<typeof multiselect>[0]["options"],
+  };
+  if (options.initialValues !== undefined) {
+    multiselectOptions.initialValues = options.initialValues;
+  }
+  if (options.required !== undefined) {
+    multiselectOptions.required = options.required;
+  }
+
+  const result = await multiselect(multiselectOptions);
+
+  if (isCancel(result)) {
+    return Result.err(createCancelledError());
+  }
+
+  return Result.ok(result as T[]);
+}

--- a/packages/cli/src/prompt/text.ts
+++ b/packages/cli/src/prompt/text.ts
@@ -1,0 +1,98 @@
+/**
+ * Text and password prompt wrappers.
+ *
+ * @packageDocumentation
+ */
+
+import { isCancel, password, text } from "@clack/prompts";
+import { Result } from "better-result";
+import {
+  createCancelledError,
+  type PasswordPromptOptions,
+  type PromptResult,
+  type TextPromptOptions,
+} from "./types.js";
+
+/**
+ * Prompts for text input with Result wrapping.
+ *
+ * @param options - Text prompt options
+ * @returns Ok with value or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptText } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptText({
+ *   message: "What is your name?",
+ *   placeholder: "Enter your name",
+ *   validate: (v) => v.length > 0 || "Name is required",
+ * });
+ *
+ * if (result.isOk()) {
+ *   console.log(`Hello, ${result.value}!`);
+ * }
+ * ```
+ */
+export async function promptText(
+  options: TextPromptOptions
+): PromptResult<string> {
+  // Build options object, excluding undefined values for exactOptionalPropertyTypes
+  const textOptions: Parameters<typeof text>[0] = {
+    message: options.message,
+  };
+  if (options.placeholder !== undefined) {
+    textOptions.placeholder = options.placeholder;
+  }
+  if (options.defaultValue !== undefined) {
+    textOptions.defaultValue = options.defaultValue;
+  }
+  if (options.validate !== undefined) {
+    textOptions.validate = options.validate;
+  }
+
+  const result = await text(textOptions);
+
+  if (isCancel(result)) {
+    return Result.err(createCancelledError());
+  }
+
+  return Result.ok(result);
+}
+
+/**
+ * Prompts for password input with Result wrapping.
+ *
+ * @param options - Password prompt options
+ * @returns Ok with value or Err with CancelledError
+ *
+ * @example
+ * ```typescript
+ * import { promptPassword } from "@outfitter/cli/prompt";
+ *
+ * const result = await promptPassword({
+ *   message: "Enter your password:",
+ *   validate: (v) => v.length >= 8 || "Password too short",
+ * });
+ * ```
+ */
+export async function promptPassword(
+  options: PasswordPromptOptions
+): PromptResult<string> {
+  // Build options object, excluding undefined values for exactOptionalPropertyTypes
+  const passwordOptions: Parameters<typeof password>[0] = {
+    message: options.message,
+    mask: options.mask ?? "•",
+  };
+  if (options.validate !== undefined) {
+    passwordOptions.validate = options.validate;
+  }
+
+  const result = await password(passwordOptions);
+
+  if (isCancel(result)) {
+    return Result.err(createCancelledError());
+  }
+
+  return Result.ok(result);
+}

--- a/packages/cli/src/prompt/types.ts
+++ b/packages/cli/src/prompt/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Prompt types and interfaces.
+ *
+ * @packageDocumentation
+ */
+
+import type { Result } from "better-result";
+import type { Validator } from "./validators.js";
+
+/**
+ * Error returned when user cancels a prompt.
+ */
+export interface CancelledError {
+  type: "cancelled";
+  message: string;
+}
+
+/**
+ * Creates a cancelled error.
+ */
+export function createCancelledError(
+  message = "User cancelled"
+): CancelledError {
+  return { type: "cancelled", message };
+}
+
+/**
+ * Options for text prompts.
+ */
+export interface TextPromptOptions {
+  /** Prompt message to display */
+  message: string;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Default value */
+  defaultValue?: string;
+  /** Validation function */
+  validate?: Validator;
+}
+
+/**
+ * Options for password prompts.
+ */
+export interface PasswordPromptOptions {
+  /** Prompt message to display */
+  message: string;
+  /** Validation function */
+  validate?: Validator;
+  /** Mask character (default: •) */
+  mask?: string;
+}
+
+/**
+ * Options for select prompts.
+ */
+export interface SelectPromptOptions<T> {
+  /** Prompt message to display */
+  message: string;
+  /** Available options */
+  options: Array<{
+    value: T;
+    label: string;
+    hint?: string;
+  }>;
+  /** Initial selected index */
+  initialValue?: T;
+}
+
+/**
+ * Options for multi-select prompts.
+ */
+export interface MultiSelectPromptOptions<T> {
+  /** Prompt message to display */
+  message: string;
+  /** Available options */
+  options: Array<{
+    value: T;
+    label: string;
+    hint?: string;
+  }>;
+  /** Initially selected values */
+  initialValues?: T[];
+  /** Require at least one selection */
+  required?: boolean;
+}
+
+/**
+ * Options for confirm prompts.
+ */
+export interface ConfirmPromptOptions {
+  /** Prompt message to display */
+  message: string;
+  /** Initial value */
+  initialValue?: boolean;
+}
+
+/**
+ * Type alias for prompt results.
+ */
+export type PromptResult<T> = Promise<Result<T, CancelledError>>;

--- a/packages/cli/src/prompt/validators.ts
+++ b/packages/cli/src/prompt/validators.ts
@@ -1,0 +1,105 @@
+/**
+ * Validator factories for prompt input validation.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * A validator function that returns an error message or undefined.
+ */
+export type Validator = (value: string) => string | undefined;
+
+/**
+ * Collection of validator factory functions.
+ *
+ * @example
+ * ```typescript
+ * import { validators } from "@outfitter/cli/prompt";
+ *
+ * const validate = validators.compose(
+ *   validators.required(),
+ *   validators.minLength(3),
+ *   validators.email()
+ * );
+ *
+ * const error = validate("ab");
+ * // "Minimum 3 characters"
+ * ```
+ */
+export const validators = {
+  /**
+   * Requires a non-empty value.
+   *
+   * @param message - Custom error message
+   * @returns Validator function
+   */
+  required:
+    (message = "Required"): Validator =>
+    (value: string) =>
+      value.length > 0 ? undefined : message,
+
+  /**
+   * Requires minimum character length.
+   *
+   * @param length - Minimum length
+   * @param message - Custom error message
+   * @returns Validator function
+   */
+  minLength:
+    (length: number, message?: string): Validator =>
+    (value: string) =>
+      value.length >= length
+        ? undefined
+        : (message ?? `Minimum ${length} characters`),
+
+  /**
+   * Requires maximum character length.
+   *
+   * @param length - Maximum length
+   * @param message - Custom error message
+   * @returns Validator function
+   */
+  maxLength:
+    (length: number, message?: string): Validator =>
+    (value: string) =>
+      value.length <= length
+        ? undefined
+        : (message ?? `Maximum ${length} characters`),
+
+  /**
+   * Requires value to match a regex pattern.
+   *
+   * @param regex - Pattern to match
+   * @param message - Error message when pattern doesn't match
+   * @returns Validator function
+   */
+  pattern:
+    (regex: RegExp, message: string): Validator =>
+    (value: string) =>
+      regex.test(value) ? undefined : message,
+
+  /**
+   * Validates email format.
+   *
+   * @param message - Custom error message
+   * @returns Validator function
+   */
+  email: (message = "Invalid email"): Validator =>
+    validators.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, message),
+
+  /**
+   * Composes multiple validators, returning the first error.
+   *
+   * @param fns - Validators to compose
+   * @returns Combined validator function
+   */
+  compose:
+    (...fns: Validator[]): Validator =>
+    (value: string) => {
+      for (const fn of fns) {
+        const error = fn(value);
+        if (error) return error;
+      }
+      return undefined;
+    },
+};


### PR DESCRIPTION
## Summary

Add interactive prompt utilities that wrap Clack prompts with Result types for type-safe error handling.

- `promptText` / `promptPassword`: Text input with validation
- `promptConfirm`: Yes/no confirmation
- `promptSelect` / `promptMultiSelect`: Selection prompts
- `promptGroup`: Compose multiple prompts into a single flow
- All prompts return `Result<T, PromptError>` for explicit error handling
- Graceful cancellation handling

## Test Plan

- [x] Unit tests for all prompt types
- [x] Cancellation returns appropriate error
- [x] Validation errors propagate correctly