### PR TITLE
feat(cli): add heading and separator render utilities

### DIFF
--- a/packages/cli/src/__tests__/sections.test.ts
+++ b/packages/cli/src/__tests__/sections.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for heading and separator render utilities
+ *
+ * Tests cover:
+ * - renderHeading (8 tests)
+ * - renderSeparator (5 tests)
+ *
+ * Total: 13 tests
+ */
+import { describe, expect, it } from "bun:test";
+import { renderHeading } from "../render/heading.js";
+import { renderSeparator } from "../render/separator.js";
+
+// ============================================================================
+// Heading Tests
+// ============================================================================
+
+describe("renderHeading", () => {
+  describe("default behavior", () => {
+    it("renders heading with equals separator matching text width (uppercase)", () => {
+      const result = renderHeading("Colors");
+      expect(result).toBe("COLORS\n======");
+    });
+
+    it("renders multi-word heading in uppercase", () => {
+      const result = renderHeading("Theme Colors");
+      expect(result).toBe("THEME COLORS\n============");
+    });
+  });
+
+  describe("separator styles", () => {
+    it("renders with dash separator", () => {
+      const result = renderHeading("Status", { separator: "-" });
+      expect(result).toBe("STATUS\n------");
+    });
+
+    it("renders with box drawing thin separator", () => {
+      const result = renderHeading("Status", { separator: "─" });
+      expect(result).toBe("STATUS\n──────");
+    });
+
+    it("renders with box drawing heavy separator", () => {
+      const result = renderHeading("Status", { separator: "━" });
+      expect(result).toBe("STATUS\n━━━━━━");
+    });
+
+    it("renders with box drawing double separator", () => {
+      const result = renderHeading("Status", { separator: "═" });
+      expect(result).toBe("STATUS\n══════");
+    });
+  });
+
+  describe("width modes", () => {
+    it("renders with text width (default)", () => {
+      const result = renderHeading("Hi", { width: "text" });
+      expect(result).toBe("HI\n==");
+    });
+
+    it("renders with fixed width", () => {
+      const result = renderHeading("Hi", { width: 10 });
+      expect(result).toBe("HI\n==========");
+    });
+  });
+
+  describe("case transformations", () => {
+    it("renders in lowercase", () => {
+      const result = renderHeading("Theme Colors", { case: "lower" });
+      expect(result).toBe("theme colors\n============");
+    });
+
+    it("renders in title case", () => {
+      const result = renderHeading("theme colors", { case: "title" });
+      expect(result).toBe("Theme Colors\n============");
+    });
+
+    it("renders with no case transformation", () => {
+      const result = renderHeading("Theme Colors", { case: "none" });
+      expect(result).toBe("Theme Colors\n============");
+    });
+  });
+});
+
+// ============================================================================
+// Separator Tests
+// ============================================================================
+
+describe("renderSeparator", () => {
+  describe("default behavior", () => {
+    it("renders thin separator with default width", () => {
+      const result = renderSeparator();
+      // Default width is 40
+      expect(result).toBe("─".repeat(40));
+    });
+  });
+
+  describe("styles", () => {
+    it("renders heavy separator", () => {
+      const result = renderSeparator({ style: "━", width: 10 });
+      expect(result).toBe("━━━━━━━━━━");
+    });
+
+    it("renders double separator", () => {
+      const result = renderSeparator({ style: "═", width: 10 });
+      expect(result).toBe("══════════");
+    });
+
+    it("renders dash-space separator", () => {
+      const result = renderSeparator({ style: "- ", width: 10 });
+      expect(result).toBe("- - - - - ");
+    });
+
+    it("renders dot-space separator", () => {
+      const result = renderSeparator({ style: "· ", width: 10 });
+      expect(result).toBe("· · · · · ");
+    });
+  });
+
+  describe("width modes", () => {
+    it("renders with fixed width", () => {
+      const result = renderSeparator({ width: 20 });
+      expect(result).toBe("─".repeat(20));
+    });
+  });
+});

--- a/packages/cli/src/render/heading.ts
+++ b/packages/cli/src/render/heading.ts
@@ -1,0 +1,170 @@
+/**
+ * Heading render utility for section headers.
+ *
+ * @packageDocumentation
+ */
+
+import { getTerminalWidth } from "./layout.js";
+/**
+ * Separator style for headings.
+ */
+export type SeparatorStyle = "=" | "-" | "─" | "━" | "═";
+
+/**
+ * Width mode for headings.
+ * - "text" - match the text width
+ * - "full" - full terminal width
+ * - number - fixed width
+ */
+export type WidthMode = "text" | "full" | number;
+
+/**
+ * Case transformation for heading text.
+ */
+export type CaseMode = "upper" | "lower" | "title" | "none";
+
+/**
+ * Options for rendering a heading.
+ */
+export interface HeadingOptions {
+  /** Separator character/style (default: "=") */
+  separator?: SeparatorStyle;
+  /** Width mode (default: "text") */
+  width?: WidthMode;
+  /** Case transformation (default: "upper") */
+  case?: CaseMode;
+}
+
+/** ANSI escape sequence pattern */
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Transforms text to title case, preserving ANSI escape codes.
+ */
+function toTitleCase(text: string): string {
+  return text.replace(
+    /\w\S*/g,
+    (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+  );
+}
+
+/**
+ * Applies case transformation to text while preserving ANSI escape codes.
+ * ANSI sequences are extracted, transformation applied to visible text only,
+ * then sequences are restored to their original positions.
+ */
+function applyCase(text: string, caseMode: CaseMode): string {
+  if (caseMode === "none") {
+    return text;
+  }
+
+  // Check if text contains ANSI codes
+  const hasAnsi = ANSI_PATTERN.test(text);
+  ANSI_PATTERN.lastIndex = 0; // Reset regex state
+
+  if (!hasAnsi) {
+    // No ANSI codes, apply transformation directly
+    switch (caseMode) {
+      case "upper":
+        return text.toUpperCase();
+      case "lower":
+        return text.toLowerCase();
+      case "title":
+        return toTitleCase(text);
+      default: {
+        const _exhaustive: never = caseMode;
+        return _exhaustive;
+      }
+    }
+  }
+
+  // Extract ANSI sequences and their positions
+  const sequences: Array<{ index: number; seq: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = ANSI_PATTERN.exec(text)) !== null) {
+    sequences.push({ index: match.index, seq: match[0] });
+  }
+
+  // Strip ANSI codes and apply transformation
+  const stripped = Bun.stripANSI(text);
+  let transformed: string;
+  switch (caseMode) {
+    case "upper":
+      transformed = stripped.toUpperCase();
+      break;
+    case "lower":
+      transformed = stripped.toLowerCase();
+      break;
+    case "title":
+      transformed = toTitleCase(stripped);
+      break;
+    default: {
+      const _exhaustive: never = caseMode;
+      return _exhaustive;
+    }
+  }
+
+  // Reinsert ANSI sequences at original positions
+  let result = transformed;
+  let offset = 0;
+  for (const { index, seq } of sequences) {
+    const insertPos = index + offset;
+    result = result.slice(0, insertPos) + seq + result.slice(insertPos);
+    offset += seq.length;
+  }
+
+  return result;
+}
+
+/**
+ * Calculates the display width of text.
+ * Uses Bun's stringWidth for accurate width calculation with ANSI and Unicode.
+ */
+function getTextWidth(text: string): number {
+  return Bun.stringWidth(text);
+}
+
+/**
+ * Renders a section heading with a separator line below.
+ *
+ * @param text - The heading text
+ * @param options - Rendering options
+ * @returns Formatted heading string
+ *
+ * @example
+ * ```typescript
+ * import { renderHeading } from "@outfitter/cli/render";
+ *
+ * console.log(renderHeading("Theme Colors"));
+ * // THEME COLORS
+ * // ============
+ *
+ * console.log(renderHeading("Status", { separator: "─", case: "none" }));
+ * // Status
+ * // ──────
+ * ```
+ */
+export function renderHeading(text: string, options?: HeadingOptions): string {
+  const separator = options?.separator ?? "=";
+  const widthMode = options?.width ?? "text";
+  const caseMode = options?.case ?? "upper";
+
+  // Apply case transformation
+  const transformedText = applyCase(text, caseMode);
+
+  // Calculate width
+  let width: number;
+  if (widthMode === "text") {
+    width = getTextWidth(transformedText);
+  } else if (widthMode === "full") {
+    // Use terminal width helper for consistency
+    width = getTerminalWidth();
+  } else {
+    width = widthMode;
+  }
+
+  // Build separator line
+  const separatorLine = separator.repeat(width);
+
+  return `${transformedText}\n${separatorLine}`;
+}

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -40,6 +40,14 @@ export {
 export { formatBytes, formatDuration } from "./format.js";
 // Date/time formatting
 export { formatRelative } from "./format-relative.js";
+// Heading rendering
+export {
+  type CaseMode,
+  type HeadingOptions,
+  renderHeading,
+  type SeparatorStyle,
+  type WidthMode,
+} from "./heading.js";
 // Indicators
 export {
   getIndicator,
@@ -66,6 +74,12 @@ export { renderMarkdown } from "./markdown.js";
 
 // Progress rendering
 export { type ProgressOptions, renderProgress } from "./progress.js";
+// Separator rendering
+export {
+  type DividerStyle,
+  renderSeparator,
+  type SeparatorOptions,
+} from "./separator.js";
 // Shapes and unified render
 export {
   type Collection,

--- a/packages/cli/src/render/separator.ts
+++ b/packages/cli/src/render/separator.ts
@@ -1,0 +1,71 @@
+/**
+ * Separator render utility for visual dividers.
+ *
+ * @packageDocumentation
+ */
+
+import { getTerminalWidth } from "./layout.js";
+import type { WidthMode } from "./heading.js";
+
+/**
+ * Separator style for dividers.
+ * Single characters repeat to fill width.
+ * Two-character patterns (like "- ") alternate to create dashed effect.
+ */
+export type DividerStyle = "─" | "━" | "═" | "- " | "· ";
+
+/**
+ * Options for rendering a separator.
+ */
+export interface SeparatorOptions {
+  /** Separator style (default: "─") */
+  style?: DividerStyle;
+  /** Width mode (default: 40) */
+  width?: WidthMode;
+}
+
+/**
+ * Renders a horizontal separator line.
+ *
+ * @param options - Rendering options
+ * @returns Formatted separator string
+ *
+ * @example
+ * ```typescript
+ * import { renderSeparator } from "@outfitter/cli/render";
+ *
+ * console.log(renderSeparator());
+ * // ────────────────────────────────────────
+ *
+ * console.log(renderSeparator({ style: "━", width: 20 }));
+ * // ━━━━━━━━━━━━━━━━━━━━
+ *
+ * console.log(renderSeparator({ style: "- ", width: 20 }));
+ * // - - - - - - - - - -
+ * ```
+ */
+export function renderSeparator(options?: SeparatorOptions): string {
+  const style = options?.style ?? "─";
+  const widthMode = options?.width ?? 40;
+
+  // Calculate width
+  let width: number;
+  if (widthMode === "text") {
+    // For separator, "text" doesn't make sense, use default
+    width = 40;
+  } else if (widthMode === "full") {
+    // Use terminal width helper for consistency
+    width = getTerminalWidth();
+  } else {
+    width = widthMode;
+  }
+
+  // For two-character patterns, repeat to fill width
+  if (style.length === 2) {
+    const repetitions = Math.ceil(width / 2);
+    return style.repeat(repetitions).slice(0, width);
+  }
+
+  // Single character, just repeat
+  return style.repeat(width);
+}


### PR DESCRIPTION
## Summary

Add section rendering utilities for consistent visual hierarchy in CLI output.

- `renderHeading`: Section headers with customizable separator style (─, ═, ━, etc.)
- `renderSeparator`: Horizontal dividers with configurable width and style
- Case transformation options: upper, lower, title, none
- Width modes: text (match content), full (terminal width), fixed number

## Test Plan

- [x] Unit tests for heading rendering
- [x] Separator width calculation tests
- [x] Case transformation verification