### PR TITLE
feat(cli): add horizontal and vertical layout utilities

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,12 @@
         "default": "./dist/output.js"
       }
     },
+    "./tree": {
+      "import": {
+        "types": "./dist/tree/index.d.ts",
+        "default": "./dist/tree/index.js"
+      }
+    },
     "./demo": {
       "import": {
         "types": "./dist/demo/index.d.ts",
@@ -43,12 +49,6 @@
       "import": {
         "types": "./dist/box/index.d.ts",
         "default": "./dist/box/index.js"
-      }
-    },
-    "./tree": {
-      "import": {
-        "types": "./dist/tree/index.d.ts",
-        "default": "./dist/tree/index.js"
       }
     },
     "./render": {

--- a/packages/cli/src/__tests__/layout.test.ts
+++ b/packages/cli/src/__tests__/layout.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for layout render utilities
+ *
+ * Tests cover:
+ * - joinHorizontal (6 tests)
+ * - joinVertical (4 tests)
+ *
+ * Total: 10 tests
+ */
+import { describe, expect, it } from "bun:test";
+import { joinHorizontal, joinVertical } from "../render/layout.js";
+
+// ============================================================================
+// joinHorizontal Tests
+// ============================================================================
+
+describe("joinHorizontal", () => {
+  describe("basic functionality", () => {
+    it("joins two single-line blocks side by side", () => {
+      const result = joinHorizontal(["Left", "Right"]);
+      expect(result).toBe("LeftRight");
+    });
+
+    it("joins multiline blocks side by side", () => {
+      const left = "A\nB";
+      const right = "1\n2";
+      const result = joinHorizontal([left, right]);
+      expect(result).toBe("A1\nB2");
+    });
+
+    it("handles blocks of different heights (top alignment)", () => {
+      const short = "A";
+      const tall = "1\n2\n3";
+      const result = joinHorizontal([short, tall], { align: "top" });
+      expect(result).toBe("A1\n 2\n 3");
+    });
+  });
+
+  describe("gap option", () => {
+    it("adds gap between blocks", () => {
+      const result = joinHorizontal(["Left", "Right"], { gap: 2 });
+      expect(result).toBe("Left  Right");
+    });
+
+    it("adds gap between multiline blocks", () => {
+      const left = "A\nB";
+      const right = "1\n2";
+      const result = joinHorizontal([left, right], { gap: 2 });
+      expect(result).toBe("A  1\nB  2");
+    });
+  });
+
+  describe("alignment options", () => {
+    it("aligns blocks to center", () => {
+      const short = "A";
+      const tall = "1\n2\n3";
+      const result = joinHorizontal([short, tall], { align: "center" });
+      expect(result).toBe(" 1\nA2\n 3");
+    });
+
+    it("aligns blocks to bottom", () => {
+      const short = "A";
+      const tall = "1\n2\n3";
+      const result = joinHorizontal([short, tall], { align: "bottom" });
+      expect(result).toBe(" 1\n 2\nA3");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty array", () => {
+      const result = joinHorizontal([]);
+      expect(result).toBe("");
+    });
+
+    it("handles single block", () => {
+      const result = joinHorizontal(["Only"]);
+      expect(result).toBe("Only");
+    });
+  });
+});
+
+// ============================================================================
+// joinVertical Tests
+// ============================================================================
+
+describe("joinVertical", () => {
+  describe("basic functionality", () => {
+    it("stacks blocks vertically", () => {
+      const result = joinVertical(["Top", "Bottom"]);
+      expect(result).toBe("Top\nBottom");
+    });
+
+    it("stacks multiline blocks", () => {
+      const first = "A\nB";
+      const second = "1\n2";
+      const result = joinVertical([first, second]);
+      expect(result).toBe("A\nB\n1\n2");
+    });
+  });
+
+  describe("gap option", () => {
+    it("adds gap between blocks", () => {
+      const result = joinVertical(["Top", "Bottom"], { gap: 1 });
+      expect(result).toBe("Top\n\nBottom");
+    });
+
+    it("adds larger gap between blocks", () => {
+      const result = joinVertical(["Top", "Bottom"], { gap: 2 });
+      expect(result).toBe("Top\n\n\nBottom");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty array", () => {
+      const result = joinVertical([]);
+      expect(result).toBe("");
+    });
+
+    it("handles single block", () => {
+      const result = joinVertical(["Only"]);
+      expect(result).toBe("Only");
+    });
+  });
+});

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -60,6 +60,14 @@ export {
 } from "./indicators.js";
 // JSON and text rendering
 export { renderJson, renderText } from "./json.js";
+// Layout utilities
+export {
+  type Alignment,
+  type HorizontalLayoutOptions,
+  joinHorizontal,
+  joinVertical,
+  type VerticalLayoutOptions,
+} from "./layout.js";
 
 // List rendering
 export {

--- a/packages/cli/src/render/layout.ts
+++ b/packages/cli/src/render/layout.ts
@@ -1,0 +1,195 @@
+/**
+ * Layout utilities for arranging text blocks.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Vertical alignment for horizontal layout.
+ */
+export type Alignment = "top" | "center" | "bottom";
+
+/**
+ * Options for horizontal layout.
+ */
+export interface HorizontalLayoutOptions {
+  /** Gap (in characters) between blocks */
+  gap?: number;
+  /** Vertical alignment of blocks */
+  align?: Alignment;
+}
+
+/**
+ * Options for vertical layout.
+ */
+export interface VerticalLayoutOptions {
+  /** Gap (in lines) between blocks */
+  gap?: number;
+}
+
+/**
+ * Gets the display width of a string, handling ANSI codes and Unicode.
+ */
+function getWidth(text: string): number {
+  return Bun.stringWidth(text);
+}
+
+/**
+ * Splits a block into lines.
+ */
+function splitLines(block: string): string[] {
+  return block.split("\n");
+}
+
+/**
+ * Pads a string to a specific width.
+ */
+function padToWidth(text: string, width: number): string {
+  const currentWidth = getWidth(text);
+  if (currentWidth >= width) return text;
+  return text + " ".repeat(width - currentWidth);
+}
+
+/**
+ * Creates an array filled with a value.
+ */
+function createFilledArray(length: number, value: string): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < length; i++) {
+    result.push(value);
+  }
+  return result;
+}
+
+/**
+ * Joins multiple text blocks horizontally (side by side).
+ *
+ * Handles blocks of different heights by aligning them according
+ * to the `align` option. Blocks are padded to maintain alignment.
+ *
+ * @param blocks - Array of text blocks to join
+ * @param options - Layout options
+ * @returns Combined string with blocks side by side
+ *
+ * @example
+ * ```typescript
+ * import { joinHorizontal } from "@outfitter/cli/render";
+ * import { renderBox } from "@outfitter/cli/render";
+ *
+ * const left = renderBox({ content: "Left", borderStyle: "single" });
+ * const right = renderBox({ content: "Right", borderStyle: "single" });
+ *
+ * console.log(joinHorizontal([left, right], { gap: 2 }));
+ * // ┌──────┐  ┌───────┐
+ * // │ Left │  │ Right │
+ * // └──────┘  └───────┘
+ * ```
+ */
+export function joinHorizontal(
+  blocks: string[],
+  options?: HorizontalLayoutOptions
+): string {
+  if (blocks.length === 0) return "";
+  const first = blocks[0];
+  if (first === undefined) return "";
+  if (blocks.length === 1) return first;
+
+  const gap = options?.gap ?? 0;
+  const align = options?.align ?? "top";
+  const gapString = " ".repeat(gap);
+
+  // Split all blocks into lines
+  const blockLines = blocks.map(splitLines);
+
+  // Find the max height
+  const maxHeight = Math.max(...blockLines.map((lines) => lines.length));
+
+  // Find the width of each block
+  const blockWidths = blockLines.map((lines) =>
+    Math.max(...lines.map(getWidth))
+  );
+
+  // Pad each block to maxHeight based on alignment
+  const paddedBlocks = blockLines.map((lines, blockIndex) => {
+    const width = blockWidths[blockIndex] ?? 0;
+    const height = lines.length;
+    const padding = maxHeight - height;
+
+    let topPadding: number;
+    switch (align) {
+      case "top":
+        topPadding = 0;
+        break;
+      case "center":
+        topPadding = Math.floor(padding / 2);
+        break;
+      case "bottom":
+        topPadding = padding;
+        break;
+      default: {
+        const _exhaustive: never = align;
+        topPadding = _exhaustive;
+      }
+    }
+    const bottomPadding = padding - topPadding;
+
+    const emptyLine = " ".repeat(width);
+    const paddedLines = [
+      ...createFilledArray(topPadding, emptyLine),
+      ...lines.map((line) => padToWidth(line, width)),
+      ...createFilledArray(bottomPadding, emptyLine),
+    ];
+
+    return paddedLines;
+  });
+
+  // Join lines horizontally
+  const resultLines: string[] = [];
+  for (let i = 0; i < maxHeight; i++) {
+    const lineSegments = paddedBlocks.map((block) => block[i] ?? "");
+    resultLines.push(lineSegments.join(gapString));
+  }
+
+  return resultLines.join("\n");
+}
+
+/**
+ * Joins multiple text blocks vertically (stacked).
+ *
+ * @param blocks - Array of text blocks to stack
+ * @param options - Layout options
+ * @returns Combined string with blocks stacked
+ *
+ * @example
+ * ```typescript
+ * import { joinVertical, renderHeading, renderSeparator } from "@outfitter/cli/render";
+ *
+ * const heading = renderHeading("Section Title");
+ * const separator = renderSeparator({ width: 20 });
+ * const content = "Some content here.";
+ *
+ * console.log(joinVertical([heading, separator, content], { gap: 1 }));
+ * // SECTION TITLE
+ * // =============
+ * //
+ * // ────────────────────
+ * //
+ * // Some content here.
+ * ```
+ */
+export function joinVertical(
+  blocks: string[],
+  options?: VerticalLayoutOptions
+): string {
+  if (blocks.length === 0) return "";
+  const first = blocks[0];
+  if (first === undefined) return "";
+  if (blocks.length === 1) return first;
+
+  const gap = options?.gap ?? 0;
+
+  // Create gap string (empty lines)
+  const gapLines = gap > 0 ? "\n".repeat(gap) : "";
+
+  return blocks.join(`\n${gapLines}`);
+}


### PR DESCRIPTION
## Summary

Add layout composition utilities for arranging content blocks in terminal output.

- `joinHorizontal`: Place blocks side by side with optional gap and vertical alignment (top/center/bottom)
- `joinVertical`: Stack blocks vertically with configurable gap
- Handle multi-line content with proper padding
- Preserve ANSI escape sequences during layout

## Test Plan

- [x] Horizontal layout with alignment options
- [x] Vertical layout with gap control
- [x] Multi-line block handling