### PR TITLE
feat(cli): add individual border control and margin support

### DIFF
--- a/packages/cli/src/__tests__/box.test.ts
+++ b/packages/cli/src/__tests__/box.test.ts
@@ -234,6 +234,129 @@ describe("renderBox()", () => {
   });
 
   // ============================================================================
+  // Partial Borders Tests (3 tests)
+  // ============================================================================
+
+  describe("partial borders", () => {
+    it("renders box with only top and bottom borders", () => {
+      const result = renderBox("Content", {
+        borders: { top: true, bottom: true, left: false, right: false },
+      });
+      const lines = result.split("\n");
+
+      // Should have top and bottom borders
+      expect(lines[0]).toContain("─");
+      expect(lines.at(-1)).toContain("─");
+      // Content line should NOT have vertical borders
+      const contentLine = lines.find((l) => l.includes("Content"));
+      expect(contentLine).not.toContain("│");
+    });
+
+    it("renders box with only left and right borders", () => {
+      const result = renderBox("Content", {
+        borders: { top: false, bottom: false, left: true, right: true },
+      });
+      const lines = result.split("\n");
+
+      // Should have no top or bottom borders
+      expect(lines[0]).not.toContain("┌");
+      expect(lines[0]).not.toContain("─");
+      // Content lines should have vertical borders
+      const contentLine = lines.find((l) => l.includes("Content"));
+      expect(contentLine).toMatch(/│.*Content.*│/);
+    });
+
+    it("renders box with single border (top only)", () => {
+      const result = renderBox("Content", {
+        borders: { top: true, bottom: false, left: false, right: false },
+      });
+      const lines = result.split("\n");
+
+      // First line should have horizontal border
+      expect(lines[0]).toContain("─");
+      // Content line should not have vertical borders
+      const contentLine = lines.find((l) => l.includes("Content"));
+      expect(contentLine).not.toContain("│");
+      // Last line should not be a border
+      expect(lines.at(-1)).not.toContain("─");
+    });
+  });
+
+  // ============================================================================
+  // Margin Tests (3 tests)
+  // ============================================================================
+
+  describe("margin", () => {
+    it("adds margin as empty lines/spaces outside box", () => {
+      const result = renderBox("X", { margin: 1 });
+      const lines = result.split("\n");
+
+      // With margin: 1, should have empty lines before/after
+      expect(lines[0]).toBe("");
+      expect(lines.at(-1)).toBe("");
+      // Content should have space indentation
+      const boxLine = lines.find((l) => l.includes("┌"));
+      expect(boxLine).toMatch(/^\s+┌/);
+    });
+
+    it("supports individual margin per side", () => {
+      const result = renderBox("X", {
+        margin: { top: 2, bottom: 0, left: 3, right: 0 },
+      });
+      const lines = result.split("\n");
+
+      // Should have 2 empty lines at top
+      expect(lines[0]).toBe("");
+      expect(lines[1]).toBe("");
+      // Box should start at line 3 (index 2)
+      expect(lines[2]).toContain("┌");
+      // Left margin of 3 spaces
+      expect(lines[2]).toMatch(/^\s{3}┌/);
+    });
+
+    it("combines margin and padding", () => {
+      const result = renderBox("X", { margin: 1, padding: 2 });
+      const lines = result.split("\n");
+
+      // Should have margin (empty line)
+      expect(lines[0]).toBe("");
+      // Box content should have padding of 2
+      const contentLine = lines.find((l) => l.includes("X"));
+      expect(contentLine).toMatch(/│\s{2,}X\s{2,}│/);
+    });
+  });
+
+  // ============================================================================
+  // Individual Padding Tests (2 tests)
+  // ============================================================================
+
+  describe("individual padding", () => {
+    it("supports individual padding per side", () => {
+      const result = renderBox("X", {
+        padding: { top: 1, bottom: 0, left: 3, right: 1 },
+      });
+      const lines = result.split("\n");
+
+      // With top padding of 1, should have empty content line after top border
+      // Lines: top border, empty line (top padding), content, bottom border
+      expect(lines.length).toBe(4);
+      // Left padding of 3
+      const contentLine = lines.find((l) => l.includes("X"));
+      expect(contentLine).toMatch(/│\s{3}X\s{1}│/);
+    });
+
+    it("applies asymmetric vertical padding", () => {
+      const result = renderBox("X", {
+        padding: { top: 2, bottom: 1, left: 1, right: 1 },
+      });
+      const lines = result.split("\n");
+
+      // Lines: top border, 2 empty (top padding), content, 1 empty (bottom padding), bottom border
+      expect(lines.length).toBe(6);
+    });
+  });
+
+  // ============================================================================
   // Width and Alignment Tests (2 tests)
   // ============================================================================
 

--- a/packages/cli/src/demo/renderers/box.ts
+++ b/packages/cli/src/demo/renderers/box.ts
@@ -178,6 +178,98 @@ export function renderBoxDemo(config: DemoConfig, theme: Theme): string {
       width: 30,
     })
   );
+  lines.push("");
+
+  // ==========================================================================
+  // Partial Borders
+  // ==========================================================================
+  lines.push("PARTIAL BORDERS");
+  lines.push("===============");
+  lines.push("");
+
+  if (showDescriptions) {
+    lines.push(
+      theme.muted("Control which borders to render with the borders option.")
+    );
+    lines.push("");
+  }
+
+  if (showCode) {
+    lines.push('renderBox("Top and bottom only", {');
+    lines.push(
+      "  borders: { top: true, bottom: true, left: false, right: false }"
+    );
+    lines.push("})");
+    lines.push("");
+  }
+
+  lines.push(
+    renderBox("Top and bottom only", {
+      borders: { top: true, bottom: true, left: false, right: false },
+    })
+  );
+  lines.push("");
+
+  if (showCode) {
+    lines.push('renderBox("Left and right only", {');
+    lines.push(
+      "  borders: { top: false, bottom: false, left: true, right: true }"
+    );
+    lines.push("})");
+    lines.push("");
+  }
+
+  lines.push(
+    renderBox("Left and right only", {
+      borders: { top: false, bottom: false, left: true, right: true },
+    })
+  );
+  lines.push("");
+
+  // ==========================================================================
+  // Margin
+  // ==========================================================================
+  lines.push("MARGIN");
+  lines.push("======");
+  lines.push("");
+
+  if (showDescriptions) {
+    lines.push(theme.muted("Add spacing outside the box with margin."));
+    lines.push("");
+  }
+
+  if (showCode) {
+    lines.push('renderBox("With margin", { margin: { left: 4 } })');
+    lines.push("");
+  }
+
+  lines.push(renderBox("With margin", { margin: { left: 4 } }));
+  lines.push("");
+
+  // ==========================================================================
+  // Individual Padding
+  // ==========================================================================
+  lines.push("INDIVIDUAL PADDING");
+  lines.push("==================");
+  lines.push("");
+
+  if (showDescriptions) {
+    lines.push(theme.muted("Control padding per side with an object."));
+    lines.push("");
+  }
+
+  if (showCode) {
+    lines.push('renderBox("Custom padding", {');
+    lines.push("  padding: { top: 1, bottom: 1, left: 3, right: 1 }");
+    lines.push("})");
+    lines.push("");
+  }
+
+  lines.push(
+    renderBox("Custom padding", {
+      padding: { top: 1, bottom: 1, left: 3, right: 1 },
+    })
+  );
 
   return lines.join("\n");
 }

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -17,7 +17,13 @@ export {
   type LinePosition,
 } from "./borders.js";
 // Box rendering
-export { type BoxAlign, type BoxOptions, renderBox } from "./box.js";
+export {
+  type BoxAlign,
+  type BoxBorders,
+  type BoxOptions,
+  type BoxSpacing,
+  renderBox,
+} from "./box.js";
 export {
   ANSI,
   applyColor,


### PR DESCRIPTION
## Summary

Extend box rendering with fine-grained border control and spacing options.

- Individual border sides: enable/disable top, right, bottom, left independently
- Margin support: space outside the border
- Padding refinements: per-side padding control
- `NormalizedBorders` type for consistent internal representation

## Test Plan

- [x] Partial border rendering tests
- [x] Margin calculation tests
- [x] Combined margin + padding tests