### PR TITLE
feat(cli): add createBox for nested box composition

### DIFF
--- a/packages/cli/src/demo/renderers/box.ts
+++ b/packages/cli/src/demo/renderers/box.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { renderBox } from "../../render/box.js";
+import { createBox, renderBox } from "../../render/box.js";
 import type { Theme } from "../../render/colors.js";
 import { BORDER_STYLE_META, getBorderStyles } from "../registry.js";
 import { getExample } from "../templates.js";
@@ -270,6 +270,59 @@ export function renderBoxDemo(config: DemoConfig, theme: Theme): string {
       padding: { top: 1, bottom: 1, left: 3, right: 1 },
     })
   );
+  lines.push("");
+
+  // ==========================================================================
+  // Nested Boxes
+  // ==========================================================================
+  lines.push("NESTED BOXES");
+  lines.push("============");
+  lines.push("");
+
+  if (showDescriptions) {
+    lines.push(
+      theme.muted("Use createBox() to create composable boxes with metadata.")
+    );
+    lines.push("");
+  }
+
+  if (showCode) {
+    lines.push(
+      'const inner = createBox("Inner content", { border: "rounded" });'
+    );
+    lines.push(
+      'const outer = createBox(inner, { border: "double", title: "Container" });'
+    );
+    lines.push("console.log(outer.output);");
+    lines.push("");
+  }
+
+  const inner = createBox("Inner content", { border: "rounded" });
+  const outer = createBox(inner, { border: "double", title: "Container" });
+  lines.push(outer.output);
+  lines.push("");
+
+  // Deeply nested example
+  if (showDescriptions) {
+    lines.push(theme.muted("Boxes can be nested to any depth."));
+    lines.push("");
+  }
+
+  if (showCode) {
+    lines.push('const level1 = createBox("Core", { border: "single" });');
+    lines.push(
+      'const level2 = createBox(level1, { border: "rounded", title: "Middle" });'
+    );
+    lines.push(
+      'const level3 = createBox(level2, { border: "double", title: "Outer" });'
+    );
+    lines.push("");
+  }
+
+  const level1 = createBox("Core", { border: "single" });
+  const level2 = createBox(level1, { border: "rounded", title: "Middle" });
+  const level3 = createBox(level2, { border: "double", title: "Outer" });
+  lines.push(level3.output);
 
   return lines.join("\n");
 }

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -18,10 +18,13 @@ export {
 } from "./borders.js";
 // Box rendering
 export {
+  type Box,
   type BoxAlign,
   type BoxBorders,
+  type BoxContent,
   type BoxOptions,
   type BoxSpacing,
+  createBox,
   renderBox,
 } from "./box.js";
 export {


### PR DESCRIPTION
## Summary

Add `Box` type and `createBox()` function enabling composable, nestable box rendering.

- `Box` interface with `output`, `width`, `height` properties
- `createBox()` returns Box for use as content in other boxes
- Supports arbitrary nesting depth
- Width propagation for container-aware child sizing

## Test Plan

- [x] Single box creation tests
- [x] Nested box composition tests
- [x] Width inheritance verification