### PR TITLE
feat(cli): add container-relative width modes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,12 +15,6 @@
         "default": "./dist/output.js"
       }
     },
-    "./tree": {
-      "import": {
-        "types": "./dist/tree/index.d.ts",
-        "default": "./dist/tree/index.js"
-      }
-    },
     "./demo": {
       "import": {
         "types": "./dist/demo/index.d.ts",
@@ -51,10 +45,46 @@
         "default": "./dist/box/index.js"
       }
     },
+    "./tree": {
+      "import": {
+        "types": "./dist/tree/index.d.ts",
+        "default": "./dist/tree/index.js"
+      }
+    },
+    "./demo/section": {
+      "import": {
+        "types": "./dist/demo/section.d.ts",
+        "default": "./dist/demo/section.js"
+      }
+    },
     "./render": {
       "import": {
         "types": "./dist/render/index.d.ts",
         "default": "./dist/render/index.js"
+      }
+    },
+    "./terminal": {
+      "import": {
+        "types": "./dist/terminal/index.d.ts",
+        "default": "./dist/terminal/index.js"
+      }
+    },
+    "./terminal/detection": {
+      "import": {
+        "types": "./dist/terminal/detection.d.ts",
+        "default": "./dist/terminal/detection.js"
+      }
+    },
+    "./prompt/text": {
+      "import": {
+        "types": "./dist/prompt/text.d.ts",
+        "default": "./dist/prompt/text.js"
+      }
+    },
+    "./prompt/types": {
+      "import": {
+        "types": "./dist/prompt/types.d.ts",
+        "default": "./dist/prompt/types.js"
       }
     },
     "./prompt/validators": {

--- a/packages/cli/src/render/heading.ts
+++ b/packages/cli/src/render/heading.ts
@@ -5,6 +5,8 @@
  */
 
 import { getTerminalWidth } from "./layout.js";
+import type { WidthMode } from "./types.js";
+
 /**
  * Separator style for headings.
  */
@@ -12,11 +14,13 @@ export type SeparatorStyle = "=" | "-" | "─" | "━" | "═";
 
 /**
  * Width mode for headings.
- * - "text" - match the text width
- * - "full" - full terminal width
- * - number - fixed width
+ *
+ * Note: Headings only support "text", "full", and numeric widths.
+ * Use the shared WidthMode type for full container-relative support.
+ *
+ * @see WidthMode for the complete type definition
  */
-export type WidthMode = "text" | "full" | number;
+export type HeadingWidthMode = Extract<WidthMode, "text" | "full" | number>;
 
 /**
  * Case transformation for heading text.
@@ -30,7 +34,7 @@ export interface HeadingOptions {
   /** Separator character/style (default: "=") */
   separator?: SeparatorStyle;
   /** Width mode (default: "text") */
-  width?: WidthMode;
+  width?: HeadingWidthMode;
   /** Case transformation (default: "upper") */
   case?: CaseMode;
 }

--- a/packages/cli/src/render/index.ts
+++ b/packages/cli/src/render/index.ts
@@ -58,9 +58,9 @@ export { formatRelative } from "./format-relative.js";
 export {
   type CaseMode,
   type HeadingOptions,
+  type HeadingWidthMode,
   renderHeading,
   type SeparatorStyle,
-  type WidthMode,
 } from "./heading.js";
 // Indicators
 export {
@@ -77,15 +77,16 @@ export { renderJson, renderText } from "./json.js";
 // Layout utilities
 export {
   type Alignment,
+  createLayoutContext,
   getBoxOverhead,
   getContentWidth,
   getTerminalWidth,
   type HorizontalLayoutOptions,
   joinHorizontal,
   joinVertical,
+  resolveWidth,
   type VerticalLayoutOptions,
 } from "./layout.js";
-
 // List rendering
 export {
   type ListItem,
@@ -96,7 +97,6 @@ export {
 } from "./list.js";
 // Markdown rendering
 export { renderMarkdown } from "./markdown.js";
-
 // Progress rendering
 export { type ProgressOptions, renderProgress } from "./progress.js";
 // Separator rendering
@@ -154,3 +154,5 @@ export {
   type TreeGuideStyle,
   type TreeOptions,
 } from "./tree.js";
+// Shared render types
+export type { LayoutContext, WidthMode } from "./types.js";

--- a/packages/cli/src/render/separator.ts
+++ b/packages/cli/src/render/separator.ts
@@ -5,7 +5,15 @@
  */
 
 import { getTerminalWidth } from "./layout.js";
-import type { WidthMode } from "./heading.js";
+import type { WidthMode } from "./types.js";
+
+/**
+ * Width mode for separators.
+ *
+ * Separators only support "text", "full", and numeric widths.
+ * Container-relative modes require context, which separators don't use.
+ */
+type SeparatorWidthMode = Extract<WidthMode, "text" | "full" | number>;
 
 /**
  * Separator style for dividers.
@@ -21,7 +29,7 @@ export interface SeparatorOptions {
   /** Separator style (default: "─") */
   style?: DividerStyle;
   /** Width mode (default: 40) */
-  width?: WidthMode;
+  width?: SeparatorWidthMode;
 }
 
 /**

--- a/packages/cli/src/render/types.ts
+++ b/packages/cli/src/render/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared types for render utilities.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Width mode for layout calculations.
+ *
+ * - `"text"` - Fit to text content (returns 0 to indicate no width constraint)
+ * - `"full"` - Full terminal width
+ * - `"container"` - Available container width (requires LayoutContext)
+ * - `number` - Fixed character width
+ * - `"${number}%"` - Percentage of container/terminal width
+ *
+ * @example
+ * ```typescript
+ * import { resolveWidth } from "@outfitter/cli/render";
+ *
+ * resolveWidth("full");        // → terminal width (e.g., 120)
+ * resolveWidth(50);            // → 50
+ * resolveWidth("50%");         // → half of terminal width
+ * resolveWidth("container", ctx);  // → context width
+ * ```
+ */
+export type WidthMode = "text" | "full" | "container" | number | `${number}%`;
+
+/**
+ * Layout context for container-aware width calculations.
+ *
+ * Provides width information to nested components so they can size
+ * themselves relative to their container. Create contexts with
+ * `createLayoutContext()` and pass them through component hierarchies.
+ *
+ * @example
+ * ```typescript
+ * import { createLayoutContext, resolveWidth } from "@outfitter/cli/render";
+ *
+ * const outerCtx = createLayoutContext({ width: 80, padding: 1 });
+ * // outerCtx.width = 76 (80 - 4 overhead)
+ *
+ * const innerWidth = resolveWidth("50%", outerCtx);
+ * // innerWidth = 38 (50% of 76)
+ * ```
+ */
+export interface LayoutContext {
+  /** Available content width in characters */
+  readonly width: number;
+  /** Parent context for chained calculations */
+  readonly parent?: LayoutContext;
+}


### PR DESCRIPTION
## Summary

Extend width handling with container-relative values for flexible, responsive layouts.

- `WidthMode` type: "text" | "full" | "container" | number | "\${number}%"
- "text": Fit to content
- "full": Terminal width
- "container": Parent container width
- Percentage: Relative to container (e.g., "50%")
- `resolveWidth()` function to compute actual pixel width from mode

## Test Plan

- [x] All width mode resolution tests
- [x] Percentage calculation accuracy
- [x] Container inheritance tests