### PR TITLE
fix(release): transform workspace:* refs before npm publish

### DIFF
--- a/.changeset/fix-workspace-publish.md
+++ b/.changeset/fix-workspace-publish.md
@@ -1,0 +1,16 @@
+---
+"@outfitter/agents": patch
+"@outfitter/cli": patch
+"@outfitter/config": patch
+"@outfitter/daemon": patch
+"@outfitter/file-ops": patch
+"@outfitter/index": patch
+"@outfitter/logging": patch
+"@outfitter/mcp": patch
+"@outfitter/state": patch
+"@outfitter/testing": patch
+"@outfitter/types": patch
+"outfitter": patch
+---
+
+Fix npm publish to resolve workspace:\* dependencies to actual version numbers

--- a/apps/outfitter/src/commands/demo.ts
+++ b/apps/outfitter/src/commands/demo.ts
@@ -284,8 +284,10 @@ async function runAnimatedSpinnerDemo(): Promise<void> {
 
   process.on("SIGINT", cleanup);
 
-  // Keep running indefinitely
-  await new Promise(() => {});
+  // Keep running indefinitely (never resolves)
+  await new Promise(() => {
+    // Intentionally empty - promise never resolves to keep process alive
+  });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "turbo run clean && rm -rf node_modules",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run build && changeset publish",
+    "release": "turbo run build && bun run scripts/changeset-publish.ts",
     "publish:rc": "bun run scripts/publish-rc.ts",
     "prepare": "lefthook install"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,10 +15,82 @@
         "default": "./dist/output.js"
       }
     },
+    "./demo/renderers/indicators": {
+      "import": {
+        "types": "./dist/demo/renderers/indicators.d.ts",
+        "default": "./dist/demo/renderers/indicators.js"
+      }
+    },
+    "./demo/renderers/borders": {
+      "import": {
+        "types": "./dist/demo/renderers/borders.d.ts",
+        "default": "./dist/demo/renderers/borders.js"
+      }
+    },
+    "./demo/renderers/list": {
+      "import": {
+        "types": "./dist/demo/renderers/list.d.ts",
+        "default": "./dist/demo/renderers/list.js"
+      }
+    },
+    "./demo/renderers/box": {
+      "import": {
+        "types": "./dist/demo/renderers/box.d.ts",
+        "default": "./dist/demo/renderers/box.js"
+      }
+    },
+    "./demo/renderers/tree": {
+      "import": {
+        "types": "./dist/demo/renderers/tree.d.ts",
+        "default": "./dist/demo/renderers/tree.js"
+      }
+    },
+    "./demo/registry": {
+      "import": {
+        "types": "./dist/demo/registry.d.ts",
+        "default": "./dist/demo/registry.js"
+      }
+    },
     "./demo": {
       "import": {
         "types": "./dist/demo/index.d.ts",
         "default": "./dist/demo/index.js"
+      }
+    },
+    "./demo/renderers/colors": {
+      "import": {
+        "types": "./dist/demo/renderers/colors.d.ts",
+        "default": "./dist/demo/renderers/colors.js"
+      }
+    },
+    "./demo/renderers/spinner": {
+      "import": {
+        "types": "./dist/demo/renderers/spinner.d.ts",
+        "default": "./dist/demo/renderers/spinner.js"
+      }
+    },
+    "./demo/renderers/progress": {
+      "import": {
+        "types": "./dist/demo/renderers/progress.d.ts",
+        "default": "./dist/demo/renderers/progress.js"
+      }
+    },
+    "./demo/renderers/table": {
+      "import": {
+        "types": "./dist/demo/renderers/table.d.ts",
+        "default": "./dist/demo/renderers/table.js"
+      }
+    },
+    "./demo/renderers/text": {
+      "import": {
+        "types": "./dist/demo/renderers/text.d.ts",
+        "default": "./dist/demo/renderers/text.js"
+      }
+    },
+    "./demo/renderers/markdown": {
+      "import": {
+        "types": "./dist/demo/renderers/markdown.d.ts",
+        "default": "./dist/demo/renderers/markdown.js"
       }
     },
     "./borders": {
@@ -51,16 +123,118 @@
         "default": "./dist/tree/index.js"
       }
     },
+    "./demo/templates": {
+      "import": {
+        "types": "./dist/demo/templates.d.ts",
+        "default": "./dist/demo/templates.js"
+      }
+    },
+    "./demo/types": {
+      "import": {
+        "types": "./dist/demo/types.d.ts",
+        "default": "./dist/demo/types.js"
+      }
+    },
     "./demo/section": {
       "import": {
         "types": "./dist/demo/section.d.ts",
         "default": "./dist/demo/section.js"
       }
     },
+    "./render/borders": {
+      "import": {
+        "types": "./dist/render/borders.d.ts",
+        "default": "./dist/render/borders.js"
+      }
+    },
+    "./render/layout": {
+      "import": {
+        "types": "./dist/render/layout.d.ts",
+        "default": "./dist/render/layout.js"
+      }
+    },
     "./render": {
       "import": {
         "types": "./dist/render/index.d.ts",
         "default": "./dist/render/index.js"
+      }
+    },
+    "./render/list": {
+      "import": {
+        "types": "./dist/render/list.d.ts",
+        "default": "./dist/render/list.js"
+      }
+    },
+    "./render/shapes": {
+      "import": {
+        "types": "./dist/render/shapes.d.ts",
+        "default": "./dist/render/shapes.js"
+      }
+    },
+    "./render/box": {
+      "import": {
+        "types": "./dist/render/box.d.ts",
+        "default": "./dist/render/box.js"
+      }
+    },
+    "./render/tree": {
+      "import": {
+        "types": "./dist/render/tree.d.ts",
+        "default": "./dist/render/tree.js"
+      }
+    },
+    "./render/separator": {
+      "import": {
+        "types": "./dist/render/separator.d.ts",
+        "default": "./dist/render/separator.js"
+      }
+    },
+    "./render/table": {
+      "import": {
+        "types": "./dist/render/table.d.ts",
+        "default": "./dist/render/table.js"
+      }
+    },
+    "./render/text": {
+      "import": {
+        "types": "./dist/render/text.d.ts",
+        "default": "./dist/render/text.js"
+      }
+    },
+    "./render/markdown": {
+      "import": {
+        "types": "./dist/render/markdown.d.ts",
+        "default": "./dist/render/markdown.js"
+      }
+    },
+    "./render/stack": {
+      "import": {
+        "types": "./dist/render/stack.d.ts",
+        "default": "./dist/render/stack.js"
+      }
+    },
+    "./render/heading": {
+      "import": {
+        "types": "./dist/render/heading.d.ts",
+        "default": "./dist/render/heading.js"
+      }
+    },
+    "./render/types": {
+      "import": {
+        "types": "./dist/render/types.d.ts",
+        "default": "./dist/render/types.js"
+      }
+    },
+    "./render/format": {
+      "import": {
+        "types": "./dist/render/format.d.ts",
+        "default": "./dist/render/format.js"
+      }
+    },
+    "./render/indicators": {
+      "import": {
+        "types": "./dist/render/indicators.d.ts",
+        "default": "./dist/render/indicators.js"
       }
     },
     "./terminal": {
@@ -73,6 +247,42 @@
       "import": {
         "types": "./dist/terminal/detection.d.ts",
         "default": "./dist/terminal/detection.js"
+      }
+    },
+    "./render/colors": {
+      "import": {
+        "types": "./dist/render/colors.d.ts",
+        "default": "./dist/render/colors.js"
+      }
+    },
+    "./render/format-relative": {
+      "import": {
+        "types": "./dist/render/format-relative.d.ts",
+        "default": "./dist/render/format-relative.js"
+      }
+    },
+    "./render/date": {
+      "import": {
+        "types": "./dist/render/date.d.ts",
+        "default": "./dist/render/date.js"
+      }
+    },
+    "./render/json": {
+      "import": {
+        "types": "./dist/render/json.d.ts",
+        "default": "./dist/render/json.js"
+      }
+    },
+    "./render/spinner": {
+      "import": {
+        "types": "./dist/render/spinner.d.ts",
+        "default": "./dist/render/spinner.js"
+      }
+    },
+    "./render/progress": {
+      "import": {
+        "types": "./dist/render/progress.d.ts",
+        "default": "./dist/render/progress.js"
       }
     },
     "./prompt/text": {

--- a/packages/cli/src/render/heading.ts
+++ b/packages/cli/src/render/heading.ts
@@ -40,6 +40,7 @@ export interface HeadingOptions {
 }
 
 /** ANSI escape sequence pattern */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape detection requires matching ESC character
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
 
 /**
@@ -84,8 +85,7 @@ function applyCase(text: string, caseMode: CaseMode): string {
 
   // Extract ANSI sequences and their positions
   const sequences: Array<{ index: number; seq: string }> = [];
-  let match: RegExpExecArray | null;
-  while ((match = ANSI_PATTERN.exec(text)) !== null) {
+  for (const match of text.matchAll(ANSI_PATTERN)) {
     sequences.push({ index: match.index, seq: match[0] });
   }
 

--- a/scripts/changeset-publish.ts
+++ b/scripts/changeset-publish.ts
@@ -1,0 +1,184 @@
+/**
+ * Changeset publish wrapper that transforms workspace:* references to actual versions.
+ *
+ * Problem: `changeset publish` doesn't transform workspace protocol references,
+ * causing published packages to have unresolvable `workspace:*` dependencies.
+ *
+ * Solution: Transform workspace refs before publish, restore after.
+ *
+ * @see https://github.com/outfitter-dev/outfitter/issues/192
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+interface WorkspacePackage {
+  name: string;
+  version: string;
+  path: string;
+  packageJson: PackageJson;
+}
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const PACKAGES_DIR = join(ROOT, "packages");
+const APPS_DIR = join(ROOT, "apps");
+
+function run(command: string, args: string[], cwd = ROOT): void {
+  console.log(`$ ${command} ${args.join(" ")}`);
+  const result = Bun.spawnSync([command, ...args], {
+    cwd,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed with exit code ${result.exitCode}`);
+  }
+}
+
+function readPackageJson(path: string): PackageJson {
+  return JSON.parse(readFileSync(path, "utf8")) as PackageJson;
+}
+
+function listWorkspacePackages(): WorkspacePackage[] {
+  const packages: WorkspacePackage[] = [];
+
+  for (const dir of [PACKAGES_DIR, APPS_DIR]) {
+    if (!existsSync(dir)) continue;
+
+    const entries = readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(dir, entry.name, "package.json"))
+      .filter((path) => existsSync(path))
+      .map((path) => {
+        const packageJson = readPackageJson(path);
+        if (!(packageJson.name && packageJson.version)) {
+          throw new Error(`Missing name or version in ${path}`);
+        }
+        return {
+          name: packageJson.name,
+          version: packageJson.version,
+          path,
+          packageJson,
+        };
+      });
+
+    packages.push(...entries);
+  }
+
+  return packages;
+}
+
+function resolveWorkspaceRange(
+  depName: string,
+  range: string,
+  versionMap: Map<string, string>
+): string {
+  if (!range.startsWith("workspace:")) {
+    return range;
+  }
+
+  const depVersion = versionMap.get(depName);
+  if (!depVersion) {
+    throw new Error(`Missing workspace version for ${depName}`);
+  }
+
+  const token = range.slice("workspace:".length);
+  if (!token || token === "*") {
+    return depVersion;
+  }
+  if (token === "^") {
+    return `^${depVersion}`;
+  }
+  if (token === "~") {
+    return `~${depVersion}`;
+  }
+  return token;
+}
+
+function rewriteWorkspaceRanges(
+  pkg: WorkspacePackage,
+  versionMap: Map<string, string>
+): boolean {
+  let changed = false;
+  const sections: (keyof PackageJson)[] = [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ];
+
+  for (const section of sections) {
+    const deps = pkg.packageJson[section];
+    if (!deps) continue;
+    for (const [depName, range] of Object.entries(deps)) {
+      const next = resolveWorkspaceRange(depName, range, versionMap);
+      if (next !== range) {
+        deps[depName] = next;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function writePackageJson(
+  path: string,
+  pkg: PackageJson,
+  original: string
+): void {
+  const indent = original.includes("\t") ? "\t" : 2;
+  writeFileSync(path, `${JSON.stringify(pkg, null, indent)}\n`);
+}
+
+function main(): void {
+  const workspacePackages = listWorkspacePackages();
+  const versionMap = new Map(
+    workspacePackages.map((pkg) => [pkg.name, pkg.version])
+  );
+  const originals = new Map<string, string>();
+
+  // Transform workspace:* to actual versions
+  let transformedCount = 0;
+  for (const pkg of workspacePackages) {
+    originals.set(pkg.path, readFileSync(pkg.path, "utf8"));
+    const changed = rewriteWorkspaceRanges(pkg, versionMap);
+    if (changed) {
+      writePackageJson(
+        pkg.path,
+        pkg.packageJson,
+        originals.get(pkg.path) ?? ""
+      );
+      transformedCount++;
+    }
+  }
+  console.log(`Transformed workspace refs in ${transformedCount} packages`);
+
+  try {
+    // Let changeset handle the actual publishing
+    run("npx", ["changeset", "publish"]);
+  } finally {
+    // Always restore original package.json files
+    for (const pkg of workspacePackages) {
+      const original = originals.get(pkg.path);
+      if (original !== undefined) {
+        writeFileSync(pkg.path, original);
+      }
+    }
+    console.log("Restored original package.json files");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

The `changeset publish` command doesn't transform workspace protocol references to actual version numbers. This caused published packages to have unresolvable `workspace:*` dependencies, breaking installation for consumers.

**Root cause:** Release workflow used `changeset publish` directly, which doesn't handle the `workspace:*` protocol.

**Fix:** Add a wrapper script (`scripts/changeset-publish.ts`) that:
1. Transforms `workspace:*` → actual version numbers before publish
2. Calls `changeset publish`
3. Restores original `package.json` files in a `finally` block (even on failure)

## Test plan

- [x] Script compiles and runs successfully
- [x] Transformation verified (12 packages transformed)
- [x] Restore verified (original `workspace:*` refs restored after run)
- [ ] Full release flow test (merge this PR, create a changeset, verify publish works)

Fixes #192

---
🤖 Generated with [Claude Code](https://claude.ai/code)