### PR TITLE
fix(changeset): include outfitter app in releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["outfitter"]
+  "ignore": []
 }

--- a/.changeset/fix-workspace-publish.md
+++ b/.changeset/fix-workspace-publish.md
@@ -10,7 +10,6 @@
 "@outfitter/state": patch
 "@outfitter/testing": patch
 "@outfitter/types": patch
-"outfitter": patch
 ---
 
 Fix npm publish to resolve workspace:\* dependencies to actual version numbers


### PR DESCRIPTION
## Summary

Remove `outfitter` from the changeset ignore list so it gets published alongside the library packages.

This fixes the release workflow failure where changesets rejected the mixed changeset containing both ignored (`outfitter`) and non-ignored packages.

## Test plan

- [x] Local tests pass
- [ ] Release workflow succeeds after merge

---
🤖 Generated with [Claude Code](https://claude.ai/code)