### PR TITLE
feat(tooling): add biome preset with Outfitter rules

### DIFF
--- a/packages/tooling/biome.json
+++ b/packages/tooling/biome.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "root": false,
+  "javascript": {
+    "globals": ["Bun"]
+  },
+  "linter": {
+    "rules": {
+      "complexity": {
+        "useLiteralKeys": "off",
+        "noVoid": "off",
+        "noExcessiveCognitiveComplexity": "off"
+      },
+      "performance": {
+        "useTopLevelRegex": "off"
+      },
+      "style": {
+        "useBlockStatements": "off"
+      },
+      "suspicious": {
+        "noConsole": "error"
+      }
+    }
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["!**/node_modules", "!**/dist", "!**/.turbo", "!**/*.gen.ts"]
+  },
+  "overrides": [
+    {
+      "includes": ["packages/*/src/index.ts", "apps/*/src/index.ts", "**/index.ts"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.test.ts", "**/__tests__/**/*"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off",
+            "noConsole": "off"
+          },
+          "performance": {
+            "noDelete": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "apps/**/*.ts",
+        "scripts/**/*.ts",
+        "**/scripts/**/*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/tooling/src/__tests__/biome.test.ts
+++ b/packages/tooling/src/__tests__/biome.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const PACKAGE_ROOT = join(import.meta.dir, "../..");
+const BIOME_PATH = join(PACKAGE_ROOT, "biome.json");
+
+describe("biome.json preset", () => {
+  test("biome.json exists and is valid JSON", async () => {
+    const file = Bun.file(BIOME_PATH);
+    expect(await file.exists()).toBe(true);
+
+    const content = await file.json();
+    expect(content).toBeDefined();
+  });
+
+  test("has $schema for editor support", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    expect(content.$schema).toContain("biome");
+  });
+
+  test("has linter rules section", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    expect(content.linter?.rules).toBeDefined();
+  });
+
+  test("noConsole is set to error", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    expect(content.linter.rules.suspicious.noConsole).toBe("error");
+  });
+
+  test("includes Bun global", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    expect(content.javascript?.globals).toContain("Bun");
+  });
+
+  test("has VCS configuration for git", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    expect(content.vcs?.enabled).toBe(true);
+    expect(content.vcs?.clientKind).toBe("git");
+  });
+
+  test("ignores common build artifacts", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    const includes = content.files?.includes ?? [];
+    expect(includes).toContain("!**/node_modules");
+    expect(includes).toContain("!**/dist");
+  });
+
+  test("has test file overrides for noConsole", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    const overrides = content.overrides ?? [];
+    const testOverride = overrides.find((o: { includes?: string[] }) =>
+      o.includes?.some((i: string) => i.includes("test"))
+    );
+
+    expect(testOverride).toBeDefined();
+    expect(testOverride?.linter?.rules?.suspicious?.noConsole).toBe("off");
+  });
+
+  test("allows barrel files in index.ts", async () => {
+    const content = await Bun.file(BIOME_PATH).json();
+    const overrides = content.overrides ?? [];
+    const indexOverride = overrides.find((o: { includes?: string[] }) =>
+      o.includes?.some((i: string) => i.includes("index.ts"))
+    );
+
+    expect(indexOverride).toBeDefined();
+    expect(indexOverride?.linter?.rules?.performance?.noBarrelFile).toBe("off");
+  });
+});


### PR DESCRIPTION
## Summary

Biome configuration preset with Outfitter-specific overrides:

- `noConsole` error by default (except tests/apps)
- Bun global defined
- VCS integration with git
- Barrel file exceptions for `index.ts`
- Test file relaxations (noConsole, useAwait, noDelete)
- Uses `root: false` to work as shareable preset

## Test plan

- [x] Tests written first (TDD)
- [x] All 9 biome preset tests pass
- [x] No conflict with root biome.json

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Part 2 of 6 in the @outfitter/tooling stack