### PR TITLE
feat(tooling): add TypeScript presets

### DIFF
--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -6,8 +6,8 @@
   "files": [
     "dist",
     "biome.json",
-    "tsconfig.json",
-    "tsconfig.bun.json",
+    "tsconfig.preset.json",
+    "tsconfig.preset.bun.json",
     "lefthook.yml"
   ],
   "module": "./dist/index.js",

--- a/packages/tooling/src/__tests__/typescript.test.ts
+++ b/packages/tooling/src/__tests__/typescript.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const PACKAGE_ROOT = join(import.meta.dir, "../..");
+const TSCONFIG_BASE_PATH = join(PACKAGE_ROOT, "tsconfig.preset.json");
+const TSCONFIG_BUN_PATH = join(PACKAGE_ROOT, "tsconfig.preset.bun.json");
+
+describe("tsconfig.preset.json (base)", () => {
+	test("tsconfig.preset.json exists and is valid JSON", async () => {
+		const file = Bun.file(TSCONFIG_BASE_PATH);
+		expect(await file.exists()).toBe(true);
+
+		const content = await file.json();
+		expect(content).toBeDefined();
+	});
+
+	test("has $schema for editor support", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.$schema).toContain("tsconfig");
+	});
+
+	test("has strict mode enabled", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.compilerOptions?.strict).toBe(true);
+	});
+
+	test("has noUncheckedIndexedAccess for safer indexing", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.compilerOptions?.noUncheckedIndexedAccess).toBe(true);
+	});
+
+	test("has exactOptionalPropertyTypes for stricter optional props", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.compilerOptions?.exactOptionalPropertyTypes).toBe(true);
+	});
+
+	test("uses ESNext target and module", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.compilerOptions?.target).toBe("ESNext");
+		expect(content.compilerOptions?.module).toBe("ESNext");
+	});
+
+	test("uses verbatimModuleSyntax", async () => {
+		const content = await Bun.file(TSCONFIG_BASE_PATH).json();
+		expect(content.compilerOptions?.verbatimModuleSyntax).toBe(true);
+	});
+});
+
+describe("tsconfig.preset.bun.json", () => {
+	test("tsconfig.preset.bun.json exists and is valid JSON", async () => {
+		const file = Bun.file(TSCONFIG_BUN_PATH);
+		expect(await file.exists()).toBe(true);
+
+		const content = await file.json();
+		expect(content).toBeDefined();
+	});
+
+	test("extends the base tsconfig preset", async () => {
+		const content = await Bun.file(TSCONFIG_BUN_PATH).json();
+		expect(content.extends).toBe("./tsconfig.preset.json");
+	});
+
+	test("has @types/bun in types", async () => {
+		const content = await Bun.file(TSCONFIG_BUN_PATH).json();
+		expect(content.compilerOptions?.types).toContain("@types/bun");
+	});
+});

--- a/packages/tooling/tsconfig.preset.bun.json
+++ b/packages/tooling/tsconfig.preset.bun.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.preset.json",
+  "compilerOptions": {
+    "types": ["@types/bun"]
+  }
+}

--- a/packages/tooling/tsconfig.preset.json
+++ b/packages/tooling/tsconfig.preset.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    "alwaysStrict": true,
+
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
## Summary

TypeScript configuration presets for Outfitter projects:

- `tsconfig.preset.json` - Base strict config with all safety options
- `tsconfig.preset.bun.json` - Extends base with Bun types

### Strict mode includes

- `noUncheckedIndexedAccess`
- `exactOptionalPropertyTypes`
- `verbatimModuleSyntax`
- All standard strict flags

## Test plan

- [x] Tests written first (TDD)
- [x] All 10 TypeScript preset tests pass

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Part 3 of 6 in the @outfitter/tooling stack