### PR TITLE
feat(tooling): add lefthook preset

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -237,6 +237,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.7",
         "typescript": "^5.9.3",
+        "yaml": "^2.8.2",
       },
       "peerDependencies": {
         "lefthook": "^2.0.0",

--- a/packages/tooling/lefthook.yml
+++ b/packages/tooling/lefthook.yml
@@ -1,0 +1,27 @@
+# Lefthook configuration preset for Outfitter projects
+# https://github.com/evilmartians/lefthook
+#
+# Usage: In your project's .lefthook.yml, add:
+#   extends:
+#     - node_modules/@outfitter/tooling/lefthook.yml
+
+pre-commit:
+  parallel: true
+  commands:
+    ultracite:
+      glob: "*.{js,jsx,ts,tsx,json,jsonc,css}"
+      run: bun x ultracite fix {staged_files}
+      stage_fixed: true
+
+    typecheck:
+      glob: "*.{ts,tsx}"
+      run: bun run typecheck
+
+pre-push:
+  parallel: false
+  commands:
+    build:
+      run: bun run build
+
+    test:
+      run: bun run test

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -38,7 +38,8 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.7",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yaml": "^2.8.2"
   },
   "peerDependencies": {
     "ultracite": "^7.0.0",

--- a/packages/tooling/src/__tests__/lefthook.test.ts
+++ b/packages/tooling/src/__tests__/lefthook.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+const PACKAGE_ROOT = join(import.meta.dir, "../..");
+const LEFTHOOK_PATH = join(PACKAGE_ROOT, "lefthook.yml");
+
+describe("lefthook.yml preset", () => {
+	test("lefthook.yml exists and is valid YAML", async () => {
+		const file = Bun.file(LEFTHOOK_PATH);
+		expect(await file.exists()).toBe(true);
+
+		const content = await file.text();
+		const parsed = parseYaml(content);
+		expect(parsed).toBeDefined();
+	});
+
+	test("has pre-commit hooks", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		expect(parsed["pre-commit"]).toBeDefined();
+	});
+
+	test("has pre-push hooks", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		expect(parsed["pre-push"]).toBeDefined();
+	});
+
+	test("pre-commit includes ultracite/linting", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		const preCommit = parsed["pre-commit"];
+
+		// Check for lint/format command
+		const commands = preCommit?.commands ?? {};
+		const hasLinting = Object.values(commands).some(
+			(cmd: unknown) =>
+				typeof cmd === "object" &&
+				cmd !== null &&
+				"run" in cmd &&
+				typeof (cmd as { run: unknown }).run === "string" &&
+				(cmd as { run: string }).run.includes("ultracite")
+		);
+
+		expect(hasLinting).toBe(true);
+	});
+
+	test("pre-commit includes typecheck", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		const preCommit = parsed["pre-commit"];
+
+		const commands = preCommit?.commands ?? {};
+		const hasTypecheck = Object.values(commands).some(
+			(cmd: unknown) =>
+				typeof cmd === "object" &&
+				cmd !== null &&
+				"run" in cmd &&
+				typeof (cmd as { run: unknown }).run === "string" &&
+				(cmd as { run: string }).run.includes("typecheck")
+		);
+
+		expect(hasTypecheck).toBe(true);
+	});
+
+	test("pre-push includes build", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		const prePush = parsed["pre-push"];
+
+		const commands = prePush?.commands ?? {};
+		const hasBuild = Object.values(commands).some(
+			(cmd: unknown) =>
+				typeof cmd === "object" &&
+				cmd !== null &&
+				"run" in cmd &&
+				typeof (cmd as { run: unknown }).run === "string" &&
+				(cmd as { run: string }).run.includes("build")
+		);
+
+		expect(hasBuild).toBe(true);
+	});
+
+	test("pre-push includes test", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		const prePush = parsed["pre-push"];
+
+		const commands = prePush?.commands ?? {};
+		const hasTest = Object.values(commands).some(
+			(cmd: unknown) =>
+				typeof cmd === "object" &&
+				cmd !== null &&
+				"run" in cmd &&
+				typeof (cmd as { run: unknown }).run === "string" &&
+				(cmd as { run: string }).run.includes("test")
+		);
+
+		expect(hasTest).toBe(true);
+	});
+
+	test("pre-commit runs in parallel", async () => {
+		const content = await Bun.file(LEFTHOOK_PATH).text();
+		const parsed = parseYaml(content);
+		expect(parsed["pre-commit"]?.parallel).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Lefthook git hooks preset for Outfitter projects:

- **pre-commit** (parallel):
  - `ultracite fix` with `stage_fixed: true`
  - `bun run typecheck`

- **pre-push** (sequential):
  - `bun run build`
  - `bun run test`

Projects extend via:
```yaml
extends:
  - node_modules/@outfitter/tooling/lefthook.yml
```

## Test plan

- [x] Tests written first (TDD)
- [x] All 8 lefthook preset tests pass

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Part 4 of 6 in the @outfitter/tooling stack