### PR TITLE
feat(tooling): add CLI with init, check, fix commands

### DIFF
--- a/packages/tooling/src/__tests__/cli.test.ts
+++ b/packages/tooling/src/__tests__/cli.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+// Test the CLI utility functions (exported from cli/init.ts, cli/check.ts, cli/fix.ts)
+// We'll test the pure functions that generate commands, not the actual execution
+
+describe("CLI init command", () => {
+	// Import the function once module is created
+	test("detectFrameworks identifies React", async () => {
+		const { detectFrameworks } = await import("../cli/init.js");
+		const flags = detectFrameworks({ dependencies: { react: "^18.0.0" } });
+		expect(flags).toContain("--frameworks");
+		expect(flags).toContain("react");
+	});
+
+	test("detectFrameworks identifies Next.js", async () => {
+		const { detectFrameworks } = await import("../cli/init.js");
+		const flags = detectFrameworks({ dependencies: { next: "^14.0.0" } });
+		expect(flags).toContain("--frameworks");
+		expect(flags).toContain("next");
+	});
+
+	test("detectFrameworks handles no frameworks", async () => {
+		const { detectFrameworks } = await import("../cli/init.js");
+		const flags = detectFrameworks({ dependencies: {} });
+		expect(flags).not.toContain("--frameworks");
+	});
+
+	test("buildUltraciteCommand generates correct base flags", async () => {
+		const { buildUltraciteCommand } = await import("../cli/init.js");
+		const cmd = buildUltraciteCommand({});
+		expect(cmd).toContain("--linter");
+		expect(cmd).toContain("biome");
+		expect(cmd).toContain("--pm");
+		expect(cmd).toContain("bun");
+		expect(cmd).toContain("--quiet");
+	});
+
+	test("buildUltraciteCommand includes framework flags", async () => {
+		const { buildUltraciteCommand } = await import("../cli/init.js");
+		const cmd = buildUltraciteCommand({
+			frameworks: ["react", "next"],
+		});
+		expect(cmd).toContain("--frameworks");
+		expect(cmd).toContain("react");
+		expect(cmd).toContain("next");
+	});
+});
+
+describe("CLI check command", () => {
+	test("buildCheckCommand generates correct command", async () => {
+		const { buildCheckCommand } = await import("../cli/check.js");
+		const cmd = buildCheckCommand({});
+		expect(cmd).toContain("ultracite");
+		expect(cmd).toContain("check");
+	});
+
+	test("buildCheckCommand passes through paths", async () => {
+		const { buildCheckCommand } = await import("../cli/check.js");
+		const cmd = buildCheckCommand({ paths: ["src/", "lib/"] });
+		expect(cmd).toContain("src/");
+		expect(cmd).toContain("lib/");
+	});
+});
+
+describe("CLI fix command", () => {
+	test("buildFixCommand generates correct command", async () => {
+		const { buildFixCommand } = await import("../cli/fix.js");
+		const cmd = buildFixCommand({});
+		expect(cmd).toContain("ultracite");
+		expect(cmd).toContain("fix");
+	});
+
+	test("buildFixCommand passes through paths", async () => {
+		const { buildFixCommand } = await import("../cli/fix.js");
+		const cmd = buildFixCommand({ paths: ["src/", "lib/"] });
+		expect(cmd).toContain("src/");
+		expect(cmd).toContain("lib/");
+	});
+});

--- a/packages/tooling/src/cli/check.ts
+++ b/packages/tooling/src/cli/check.ts
@@ -1,0 +1,40 @@
+/**
+ * CLI check command - Run linting checks (wraps ultracite)
+ */
+
+/** Options for the check command */
+interface CheckOptions {
+	paths?: string[];
+}
+
+/**
+ * Build the ultracite check command
+ * @param options - Command options
+ * @returns Array of command arguments
+ */
+export function buildCheckCommand(options: CheckOptions): string[] {
+	const cmd = ["ultracite", "check"];
+
+	if (options.paths && options.paths.length > 0) {
+		cmd.push(...options.paths);
+	}
+
+	return cmd;
+}
+
+/**
+ * Run the check command
+ * @param paths - Paths to check
+ */
+export async function runCheck(paths: string[] = []): Promise<void> {
+	const cmd = buildCheckCommand({ paths });
+
+	console.log(`Running: bun x ${cmd.join(" ")}`);
+
+	const proc = Bun.spawn(["bun", "x", ...cmd], {
+		stdio: ["inherit", "inherit", "inherit"],
+	});
+
+	const exitCode = await proc.exited;
+	process.exit(exitCode);
+}

--- a/packages/tooling/src/cli/fix.ts
+++ b/packages/tooling/src/cli/fix.ts
@@ -1,0 +1,40 @@
+/**
+ * CLI fix command - Fix linting issues (wraps ultracite)
+ */
+
+/** Options for the fix command */
+interface FixOptions {
+	paths?: string[];
+}
+
+/**
+ * Build the ultracite fix command
+ * @param options - Command options
+ * @returns Array of command arguments
+ */
+export function buildFixCommand(options: FixOptions): string[] {
+	const cmd = ["ultracite", "fix"];
+
+	if (options.paths && options.paths.length > 0) {
+		cmd.push(...options.paths);
+	}
+
+	return cmd;
+}
+
+/**
+ * Run the fix command
+ * @param paths - Paths to fix
+ */
+export async function runFix(paths: string[] = []): Promise<void> {
+	const cmd = buildFixCommand({ paths });
+
+	console.log(`Running: bun x ${cmd.join(" ")}`);
+
+	const proc = Bun.spawn(["bun", "x", ...cmd], {
+		stdio: ["inherit", "inherit", "inherit"],
+	});
+
+	const exitCode = await proc.exited;
+	process.exit(exitCode);
+}

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -8,17 +8,38 @@
  */
 
 import { Command } from "commander";
+import { runCheck } from "./check.js";
+import { runFix } from "./fix.js";
+import { runInit } from "./init.js";
 
 const program = new Command();
 
 program
-  .name("tooling")
-  .description("Dev tooling configuration management for Outfitter projects")
-  .version("0.1.0-rc.1");
+	.name("tooling")
+	.description("Dev tooling configuration management for Outfitter projects")
+	.version("0.1.0-rc.1");
 
-// Commands will be added in subsequent tasks:
-// - init: Initialize tooling config in a project
-// - check: Run linting checks (wraps ultracite)
-// - fix: Fix linting issues (wraps ultracite)
+program
+	.command("init")
+	.description("Initialize tooling config in the current project")
+	.action(async () => {
+		await runInit();
+	});
+
+program
+	.command("check")
+	.description("Run linting checks (wraps ultracite)")
+	.argument("[paths...]", "Paths to check")
+	.action(async (paths: string[]) => {
+		await runCheck(paths);
+	});
+
+program
+	.command("fix")
+	.description("Fix linting issues (wraps ultracite)")
+	.argument("[paths...]", "Paths to fix")
+	.action(async (paths: string[]) => {
+		await runFix(paths);
+	});
 
 program.parse();

--- a/packages/tooling/src/cli/init.ts
+++ b/packages/tooling/src/cli/init.ts
@@ -1,0 +1,106 @@
+/**
+ * CLI init command - Initialize tooling config in a project
+ */
+
+/** Package.json structure for framework detection */
+interface PackageJson {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+}
+
+/** Options for building the ultracite command */
+interface UltraciteOptions {
+	frameworks?: string[];
+	quiet?: boolean;
+}
+
+/** Known frameworks to detect */
+const FRAMEWORK_DETECTORS: Record<string, string[]> = {
+	react: ["react", "react-dom"],
+	next: ["next"],
+	vue: ["vue"],
+	nuxt: ["nuxt"],
+	svelte: ["svelte"],
+	angular: ["@angular/core"],
+	solid: ["solid-js"],
+	astro: ["astro"],
+	remix: ["@remix-run/react"],
+	qwik: ["@builder.io/qwik"],
+};
+
+/**
+ * Detect frameworks from package.json dependencies
+ * @param pkg - Package.json contents
+ * @returns Array of CLI flags for detected frameworks
+ */
+export function detectFrameworks(pkg: PackageJson): string[] {
+	const allDeps = {
+		...pkg.dependencies,
+		...pkg.devDependencies,
+	};
+
+	const detected: string[] = [];
+
+	for (const [framework, packages] of Object.entries(FRAMEWORK_DETECTORS)) {
+		if (packages.some((p) => p in allDeps)) {
+			detected.push(framework);
+		}
+	}
+
+	if (detected.length === 0) {
+		return [];
+	}
+
+	return ["--frameworks", ...detected];
+}
+
+/**
+ * Build the ultracite init command with appropriate flags
+ * @param options - Command options
+ * @returns Array of command arguments
+ */
+export function buildUltraciteCommand(options: UltraciteOptions): string[] {
+	const cmd = ["ultracite", "--linter", "biome", "--pm", "bun", "--quiet"];
+
+	if (options.frameworks && options.frameworks.length > 0) {
+		cmd.push("--frameworks", ...options.frameworks);
+	}
+
+	return cmd;
+}
+
+/**
+ * Run the init command
+ * @param cwd - Working directory
+ */
+export async function runInit(cwd: string = process.cwd()): Promise<void> {
+	// Read package.json
+	const pkgPath = `${cwd}/package.json`;
+	const pkgFile = Bun.file(pkgPath);
+
+	if (!(await pkgFile.exists())) {
+		console.error("No package.json found in current directory");
+		process.exit(1);
+	}
+
+	const pkg = (await pkgFile.json()) as PackageJson;
+
+	// Detect frameworks
+	const frameworkFlags = detectFrameworks(pkg);
+	const frameworks =
+		frameworkFlags.length > 0 ? frameworkFlags.slice(1) : []; // Remove --frameworks flag
+
+	// Build command
+	const cmd = buildUltraciteCommand({ frameworks });
+
+	console.log(`Running: bun x ${cmd.join(" ")}`);
+
+	// Execute ultracite
+	const proc = Bun.spawn(["bun", "x", ...cmd], {
+		cwd,
+		stdio: ["inherit", "inherit", "inherit"],
+	});
+
+	const exitCode = await proc.exited;
+	process.exit(exitCode);
+}


### PR DESCRIPTION
## Summary

CLI commands for `@outfitter/tooling`:

- **init** - Detect frameworks, run ultracite init with proper flags
- **check** - Run ultracite check (linting)
- **fix** - Run ultracite fix (auto-fix linting issues)

### Framework auto-detection

Supports: React, Next.js, Vue, Nuxt, Svelte, Angular, Solid, Astro, Remix, and Qwik

### Usage

```bash
bunx @outfitter/tooling init   # Initialize with framework detection
bunx @outfitter/tooling check  # Run linting
bunx @outfitter/tooling fix    # Auto-fix issues
```

## Test plan

- [x] Tests written first (TDD)
- [x] All 9 CLI tests pass
- [x] Framework detection works for all supported frameworks

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Part 5 of 6 in the @outfitter/tooling stack