### PR TITLE
fix(tooling): add missing subpath exports for config files

### DIFF
--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -37,7 +37,11 @@
         "default": "./dist/cli/check.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./biome.json": "./biome.json",
+    "./tsconfig.preset.json": "./tsconfig.preset.json",
+    "./tsconfig.preset.bun.json": "./tsconfig.preset.bun.json",
+    "./lefthook.yml": "./lefthook.yml"
   },
   "bin": {
     "tooling": "./dist/cli/index.js"


### PR DESCRIPTION
Add exports for biome.json, tsconfig presets, and lefthook.yml
so they can be imported as @outfitter/tooling/biome.json etc.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>