### PR TITLE
fix(logging): auto-detect TTY for console sink colors

### DIFF
--- a/packages/logging/src/__tests__/logging.test.ts
+++ b/packages/logging/src/__tests__/logging.test.ts
@@ -826,6 +826,40 @@ describe("Sinks", () => {
     expect(stderrOutput.some((s) => s.includes("error message"))).toBe(true);
   });
 
+  it("Console sink strips ANSI codes when colors: false", () => {
+    const { createConsoleSink } = require("../index.js");
+    const consoleSink = createConsoleSink({ colors: false });
+
+    const logger = createLogger({
+      name: "test",
+      sinks: [consoleSink],
+    });
+
+    logger.info("no color message");
+
+    // Should not contain ANSI escape codes (ESC character = \u001b)
+    const output = stdoutOutput.join("");
+    expect(output).toContain("no color message");
+    expect(output).not.toContain("\u001b["); // No ANSI escape sequences
+  });
+
+  it("Console sink includes ANSI codes when colors: true", () => {
+    const { createConsoleSink } = require("../index.js");
+    const consoleSink = createConsoleSink({ colors: true });
+
+    const logger = createLogger({
+      name: "test",
+      sinks: [consoleSink],
+    });
+
+    logger.info("color message");
+
+    // Should contain ANSI escape codes for the level indicator (ESC character = \u001b)
+    const output = stdoutOutput.join("");
+    expect(output).toContain("color message");
+    expect(output).toContain("\u001b["); // Contains ANSI escape sequences
+  });
+
   it("File sink writes to specified path", async () => {
     const { createFileSink } = require("../index.js");
     const tempPath = `/tmp/test-log-${Date.now()}.log`;

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -355,6 +355,34 @@ export interface PrettyFormatterOptions {
 }
 
 /**
+ * Options for the console sink.
+ *
+ * Controls ANSI color output for terminal display. By default, colors are
+ * auto-detected based on whether stdout is a TTY.
+ *
+ * @example
+ * ```typescript
+ * // Auto-detect TTY (default)
+ * const sink = createConsoleSink();
+ *
+ * // Force colors off (for piped output, CI)
+ * const plainSink = createConsoleSink({ colors: false });
+ *
+ * // Force colors on (even in non-TTY)
+ * const colorSink = createConsoleSink({ colors: true });
+ * ```
+ */
+export interface ConsoleSinkOptions {
+  /**
+   * Enable ANSI colors in output.
+   * - `undefined` (default): Auto-detect based on stdout TTY status
+   * - `true`: Always use colors
+   * - `false`: Never use colors
+   */
+  colors?: boolean;
+}
+
+/**
  * Options for the file sink.
  *
  * Configures the file path and append behavior for file-based logging.
@@ -951,6 +979,7 @@ export function createPrettyFormatter(
  * Create a console sink that writes to stdout/stderr.
  * Info and below go to stdout, warn and above go to stderr.
  *
+ * @param options - Console sink options
  * @returns Sink configured for console output
  *
  * @example
@@ -959,10 +988,17 @@ export function createPrettyFormatter(
  *   name: "app",
  *   sinks: [createConsoleSink()],
  * });
+ *
+ * // Disable colors for CI/piped output
+ * const plainLogger = createLogger({
+ *   name: "app",
+ *   sinks: [createConsoleSink({ colors: false })],
+ * });
  * ```
  */
-export function createConsoleSink(): Sink {
-  const formatter = createPrettyFormatter({ colors: true });
+export function createConsoleSink(options?: ConsoleSinkOptions): Sink {
+  const useColors = options?.colors ?? process.stdout.isTTY ?? false;
+  const formatter = createPrettyFormatter({ colors: useColors });
 
   const sink: Sink = {
     formatter,


### PR DESCRIPTION
## Summary

Console sink now auto-detects whether stdout is a TTY and disables ANSI color codes when running in non-TTY contexts (pipes, CI).

## Changes

- Added `ConsoleSinkOptions` interface with `colors?: boolean` option
- Updated `createConsoleSink()` to accept options parameter
- Auto-detect TTY: `process.stdout.isTTY ?? false`
- Manual override available: `{ colors: true }` or `{ colors: false }`

## Usage

```typescript
// Auto-detect TTY (default) - colors in terminal, plain in pipes/CI
const sink = createConsoleSink();

// Force colors off
const plainSink = createConsoleSink({ colors: false });

// Force colors on
const colorSink = createConsoleSink({ colors: true });
```

## Test plan

- [x] Added test: Console sink strips ANSI codes when `colors: false`
- [x] Added test: Console sink includes ANSI codes when `colors: true`
- [x] All 60 logging tests pass

Fixes #202