### PR TITLE
feat(ci): auto-generate changesets from PR labels on merge

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -282,6 +282,10 @@
   color: "fbca04"
   description: Contains fixes only (patch version bump)
 
+- name: release:none
+  color: "666666"
+  description: No release needed (docs, CI, internal changes)
+
 - name: release:prep
   color: "5e6ad2"
   description: Release preparation

--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -1,0 +1,132 @@
+name: Auto Changeset
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  create-changeset:
+    # Only run if PR was merged and has a release label
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+        contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+        contains(github.event.pull_request.labels.*.name, 'release:major')
+      )
+    runs-on: ubuntu-latest
+    concurrency:
+      group: auto-changeset
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+
+          if echo "$LABELS" | grep -q "release:major"; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "release:minor"; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "release:patch"; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect affected packages
+        id: packages
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          PACKAGES=""
+
+          # Map labels to package names
+          declare -A LABEL_TO_PACKAGE=(
+            ["package/contracts"]="@outfitter/contracts"
+            ["package/types"]="@outfitter/types"
+            ["package/cli"]="@outfitter/cli"
+            ["package/config"]="@outfitter/config"
+            ["package/logging"]="@outfitter/logging"
+            ["package/file-ops"]="@outfitter/file-ops"
+            ["package/state"]="@outfitter/state"
+            ["package/index"]="@outfitter/index"
+            ["package/daemon"]="@outfitter/daemon"
+            ["package/mcp"]="@outfitter/mcp"
+            ["package/testing"]="@outfitter/testing"
+            ["package/tooling"]="@outfitter/tooling"
+            ["area/outfitter"]="outfitter"
+          )
+
+          for label in "${!LABEL_TO_PACKAGE[@]}"; do
+            if echo "$LABELS" | grep -q "\"$label\""; then
+              pkg="${LABEL_TO_PACKAGE[$label]}"
+              if [ -n "$PACKAGES" ]; then
+                PACKAGES="$PACKAGES,$pkg"
+              else
+                PACKAGES="$pkg"
+              fi
+            fi
+          done
+
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+          echo "Detected packages: $PACKAGES"
+
+      - name: Validate package labels
+        run: |
+          if [ -z "${{ steps.packages.outputs.packages }}" ]; then
+            echo "::error::PR has a release:* label but no package/* labels were detected. Add package labels to indicate which packages are affected."
+            exit 1
+          fi
+
+      - name: Generate changeset
+        run: |
+          RELEASE_TYPE="${{ steps.release-type.outputs.type }}"
+          PACKAGES="${{ steps.packages.outputs.packages }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+
+          # Generate a unique filename
+          FILENAME=".changeset/pr-${PR_NUMBER}-$(date +%s).md"
+
+          # Build the changeset content
+          echo "---" > "$FILENAME"
+
+          # Add each package with its bump type
+          IFS=',' read -ra PACKAGE_ARRAY <<< "$PACKAGES"
+          for pkg in "${PACKAGE_ARRAY[@]}"; do
+            echo "\"$pkg\": \"$RELEASE_TYPE\"" >> "$FILENAME"
+          done
+
+          echo "---" >> "$FILENAME"
+          echo "" >> "$FILENAME"
+          echo "$PR_TITLE" >> "$FILENAME"
+          echo "" >> "$FILENAME"
+          echo "PR: $PR_URL" >> "$FILENAME"
+
+          echo "Generated changeset:"
+          cat "$FILENAME"
+
+      - name: Commit changeset
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .changeset/
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
+          git push

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -1,0 +1,35 @@
+# CI/CD Documentation
+
+This directory documents the continuous integration and deployment workflows for the Outfitter monorepo.
+
+## Guides
+
+- [Releases](./releases.md) — Version management, changesets, and npm publishing
+- [Auto-Labeling](./auto-labeling.md) — How PRs are automatically categorized
+
+## Quick Reference
+
+### Release a Change
+
+1. Open a PR with your changes
+2. Wait for auto-labeling to detect affected packages
+3. Add a release label: `release:patch`, `release:minor`, or `release:major`
+4. Merge the PR
+5. A changeset is auto-generated and committed to main
+6. When ready, merge the "Version Packages" PR to publish
+
+### Skip a Release
+
+Add the `release:none` label to PRs that don't need a release (docs, CI, tests).
+
+### Workflows Overview
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `auto-label.yml` | PR open/update | Label PRs by file changes |
+| `auto-changeset.yml` | PR merge with release label | Generate changeset |
+| `changeset-labels.yml` | PR with manual changeset | Apply release label |
+| `release.yml` | Push to main | Version PR or publish |
+| `stack-labels.yml` | PR open/update | Graphite stack labels |
+| `label-sync.yml` | Push to main | Sync label definitions |
+| `ci.yml` | PR/push | Build and test |

--- a/docs/ci-cd/auto-labeling.md
+++ b/docs/ci-cd/auto-labeling.md
@@ -1,0 +1,165 @@
+# Auto-Labeling
+
+This document describes how pull requests are automatically labeled in the Outfitter monorepo.
+
+## Overview
+
+PRs are automatically labeled based on the files they change. This powers several workflows:
+- Release automation (which packages need version bumps)
+- PR triage (what areas are affected)
+- Review routing (who should review)
+
+## How It Works
+
+When a PR is opened or updated, the `auto-label.yml` workflow runs and applies labels based on file path patterns defined in `.github/labeler.yml`.
+
+## Label Categories
+
+### Package Labels
+
+PRs touching package source code get `package/*` labels:
+
+| Label | Triggered By |
+|-------|--------------|
+| `package/contracts` | `packages/contracts/**` |
+| `package/types` | `packages/types/**` |
+| `package/cli` | `packages/cli/**` |
+| `package/config` | `packages/config/**` |
+| `package/logging` | `packages/logging/**` |
+| `package/file-ops` | `packages/file-ops/**` |
+| `package/state` | `packages/state/**` |
+| `package/index` | `packages/index/**` |
+| `package/daemon` | `packages/daemon/**` |
+| `package/mcp` | `packages/mcp/**` |
+| `package/testing` | `packages/testing/**` |
+| `package/tooling` | `packages/tooling/**` |
+| `package/kit` | `packages/kit/**` |
+
+These labels are used by the auto-changeset workflow to determine which packages need version bumps.
+
+### Area Labels
+
+PRs are labeled by the area of the codebase they affect:
+
+| Label | Triggered By |
+|-------|--------------|
+| `area/outfitter` | `apps/outfitter/**` |
+| `area/agents` | `packages/agents/**` |
+| `area/plugins` | `plugins/**` |
+| `area/ci-cd` | `.github/**` |
+| `area/docs` | `docs/**`, `*.md` |
+| `area/tooling` | `scripts/**`, config files |
+
+### Type Labels
+
+Some content types are auto-detected:
+
+| Label | Triggered By |
+|-------|--------------|
+| `docs` | Documentation files (`.md`) |
+| `tests` | Test files (`*.test.ts`, `__tests__/**`) |
+| `deps` | Dependency files (`package.json`, `bun.lock`) |
+
+### Graphite Stack Labels
+
+PRs in Graphite stacks get position labels:
+
+| Label | Meaning |
+|-------|---------|
+| `stack:base` | Bottom of a stack (merges directly to main) |
+| `stack:middle` | Middle of a stack |
+| `stack:top` | Top of a stack |
+
+These are managed by `stack-labels.yml`.
+
+## Configuration
+
+Labels are defined in two places:
+
+### `.github/labels.yml`
+
+The source of truth for all labels. Defines name, color, and description. Synced to GitHub via `label-sync.yml` workflow.
+
+```yaml
+- name: package/cli
+  color: "0366d6"
+  description: "@outfitter/cli package"
+```
+
+### `.github/labeler.yml`
+
+Maps file patterns to labels for the auto-labeler action.
+
+```yaml
+package/cli:
+  - changed-files:
+      - any-glob-to-any-file: packages/cli/**
+```
+
+## Adding New Labels
+
+1. Add the label definition to `.github/labels.yml`
+2. Add the file pattern mapping to `.github/labeler.yml`
+3. The label syncs to GitHub when merged to main
+
+## Manual Labels
+
+Some labels are applied manually, not automatically:
+
+### Release Labels
+
+| Label | Purpose |
+|-------|---------|
+| `release:patch` | Bug fix release |
+| `release:minor` | Feature release |
+| `release:major` | Breaking change release |
+| `release:none` | No release needed |
+
+See [Releases](./releases.md) for details.
+
+### Priority Labels
+
+| Label | Purpose |
+|-------|---------|
+| `priority/critical` | Drop everything |
+| `priority/high` | Address soon |
+| `priority/medium` | Normal priority |
+| `priority/low` | When time permits |
+
+### Status Labels
+
+| Label | Purpose |
+|-------|---------|
+| `status/blocked` | Waiting on something |
+| `status/needs-info` | Needs clarification |
+| `status/ready` | Ready for review |
+
+## Workflows
+
+| Workflow | Purpose |
+|----------|---------|
+| `auto-label.yml` | Apply labels based on file changes |
+| `stack-labels.yml` | Apply Graphite stack position labels |
+| `changeset-labels.yml` | Apply release labels from manual changesets |
+| `label-sync.yml` | Sync label definitions to GitHub |
+
+## Troubleshooting
+
+### Labels not being applied
+
+1. Check that the workflow ran (Actions tab)
+2. Verify the file pattern in `.github/labeler.yml`
+3. Ensure the label exists in `.github/labels.yml`
+
+### Wrong labels applied
+
+The labeler uses glob patterns. Check that your patterns aren't too broad or overlapping.
+
+### Labels out of sync
+
+If labels in GitHub don't match `labels.yml`, manually trigger the label-sync workflow or wait for the next push to main that changes `labels.yml`.
+
+## Related Documentation
+
+- [Releases](./releases.md) — How release labels drive publishing
+- [GitHub Labeler Action](https://github.com/actions/labeler)

--- a/docs/ci-cd/releases.md
+++ b/docs/ci-cd/releases.md
@@ -1,0 +1,161 @@
+# Release Process
+
+This document describes how releases work in the Outfitter monorepo.
+
+## Overview
+
+We use [Changesets](https://github.com/changesets/changesets) for version management and npm publishing. The process is automated via GitHub Actions—you don't need to run any commands locally.
+
+## How It Works
+
+```
+PR with code changes
+        ↓
+Add release:minor label (or patch/major)
+        ↓
+PR merges to main
+        ↓
+auto-changeset.yml generates changeset file
+        ↓
+Changesets action opens "Version Packages" PR
+        ↓
+Merge Version PR
+        ↓
+Packages published to npm
+```
+
+## Release Labels
+
+Add one of these labels to your PR to indicate the type of change:
+
+| Label | When to Use | Version Bump |
+|-------|-------------|--------------|
+| `release:patch` | Bug fixes, minor improvements | `0.1.0` → `0.1.1` |
+| `release:minor` | New features, non-breaking changes | `0.1.0` → `0.2.0` |
+| `release:major` | Breaking changes | `0.1.0` → `1.0.0` |
+| `release:none` | Docs, CI, internal changes (no release) | No change |
+
+### Choosing the Right Label
+
+**Use `release:patch` for:**
+- Bug fixes
+- Performance improvements
+- Documentation fixes in code comments
+- Dependency updates (non-breaking)
+
+**Use `release:minor` for:**
+- New features
+- New exports or APIs
+- Deprecations (without removal)
+- Significant internal refactors
+
+**Use `release:major` for:**
+- Breaking API changes
+- Removed exports or features
+- Changed function signatures
+- Minimum Node/Bun version bumps
+
+**Use `release:none` for:**
+- Documentation changes (docs/, README)
+- CI/CD workflow changes
+- Test-only changes
+- Editor/tooling config
+
+## Automatic Changeset Generation
+
+When a PR with a `release:*` label merges to main:
+
+1. The `auto-changeset.yml` workflow runs
+2. It reads the release label to determine bump type
+3. It reads `package/*` labels to determine affected packages
+4. It generates a changeset file: `.changeset/pr-{number}-{timestamp}.md`
+5. It commits the changeset to main
+
+Example generated changeset:
+
+```markdown
+---
+"@outfitter/cli": minor
+"@outfitter/config": minor
+---
+
+feat(cli): add new command for workspace management
+
+PR: https://github.com/outfitter-dev/outfitter/pull/123
+```
+
+## Version Packages PR
+
+When changesets exist on main, the Changesets GitHub Action automatically:
+
+1. Opens a "Version Packages" PR
+2. Bumps versions in all affected `package.json` files
+3. Updates `CHANGELOG.md` for each package
+4. Consumes (deletes) the changeset files
+
+This PR stays open and accumulates changes until you're ready to release.
+
+## Publishing
+
+When the "Version Packages" PR is merged:
+
+1. The release workflow runs
+2. All packages with version bumps are built
+3. Tests run to verify everything works
+4. Packages are published to npm with OIDC provenance
+
+Published packages are available immediately:
+
+```bash
+npm install @outfitter/cli@latest
+```
+
+## Manual Changesets (Optional)
+
+You can still create changesets manually if preferred:
+
+```bash
+bun changeset
+```
+
+This opens an interactive prompt to select packages and bump types. The generated changeset file should be committed with your PR.
+
+Manual changesets are useful when:
+- You want a custom changelog message
+- You need to describe changes in detail
+- You're making coordinated changes across many packages
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `auto-changeset.yml` | PR merge with release label | Generate changeset from PR |
+| `changeset-labels.yml` | PR with `.changeset/*.md` | Apply release label from manual changeset |
+| `release.yml` | Push to main | Create Version PR or publish |
+
+## Troubleshooting
+
+### PR merged but no changeset was created
+
+Check that your PR had a `release:patch`, `release:minor`, or `release:major` label. The `release:none` label explicitly skips changeset generation.
+
+### Version Packages PR not appearing
+
+The Changesets action only creates a Version PR when changesets exist. Check that:
+- Changesets were committed to main
+- The release workflow ran successfully
+
+### Wrong packages in changeset
+
+The auto-changeset workflow uses `package/*` labels to determine affected packages. Ensure your PR was correctly labeled by the auto-labeler.
+
+### Need to release immediately
+
+If you need to release without waiting for more changes:
+1. Merge the "Version Packages" PR
+2. This triggers publishing immediately
+
+## Related Documentation
+
+- [Auto-Labeling](./auto-labeling.md) — How PRs get labeled automatically
+- [Changesets Documentation](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)


### PR DESCRIPTION
## Summary

Automates changeset generation based on PR labels, eliminating the need to manually run `bun changeset`.

## How it works

1. Add a `release:patch`, `release:minor`, or `release:major` label to your PR
2. When the PR merges to main, the workflow automatically:
   - Detects the release type from the label
   - Identifies affected packages from `package/*` labels
   - Generates a changeset file with PR title as description
   - Commits it to main

3. The existing Changesets release workflow handles the rest (Version Packages PR → npm publish)

## New label

Added `release:none` for PRs that don't need a release (docs, CI, internal changes).

## Label meanings

| Label | Effect |
|-------|--------|
| `release:patch` | Auto-generate patch changeset |
| `release:minor` | Auto-generate minor changeset |
| `release:major` | Auto-generate major changeset |
| `release:none` | Skip changeset (no release needed) |

## Documentation

Added comprehensive CI/CD documentation:
- `docs/ci-cd/README.md` — Overview and quick reference
- `docs/ci-cd/releases.md` — Full release process guide
- `docs/ci-cd/auto-labeling.md` — How auto-labeling works

## Benefits

- No more `bun changeset` command needed
- Release intent is explicit via labels
- Changeset description automatically uses PR title
- Works with existing auto-labeling for affected packages

→ In-collaboration-with: [Claude Code](https://claude.com/claude-code)