### PR TITLE
fix(kit): use correct 'docs' label in feedback skill templates

### DIFF
--- a/plugins/kit/skills/outfitter-feedback/templates/docs.json
+++ b/plugins/kit/skills/outfitter-feedback/templates/docs.json
@@ -1,6 +1,6 @@
 {
   "type": "docs",
-  "labels": ["documentation", "feedback", "source/agent"],
+  "labels": ["docs", "feedback", "source/agent"],
   "titlePrefix": "[docs]:",
   "bodyTemplate": "## Package/Area\n\n`{package}`\n\n## Description\n\n{description}\n\n## What's Missing or Unclear\n\n{gap}\n\n## Suggested Improvement\n\n{suggestion}\n\n## Context\n\n{context}\n\n---\n\n*Created via `kit:outfitter-feedback` skill*",
   "requiredFields": ["package", "description", "gap"],

--- a/plugins/kit/skills/outfitter-feedback/templates/migration-docs.json
+++ b/plugins/kit/skills/outfitter-feedback/templates/migration-docs.json
@@ -1,6 +1,6 @@
 {
   "type": "migration-docs",
-  "labels": ["documentation", "adoption", "feedback", "source/agent"],
+  "labels": ["docs", "adoption", "feedback", "source/agent"],
   "titlePrefix": "[docs]:",
   "bodyTemplate": "## Migration Area\n\n{area}\n\n## Description\n\n{description}\n\n## Documentation Gap\n\n{gap}\n\n## Suggested Content\n\n{suggestion}\n\n## Priority\n\n{priority}\n\n---\n\n*Created via `kit:outfitter-feedback` skill*",
   "requiredFields": ["area", "description", "gap"],


### PR DESCRIPTION
## Summary

- Fix `docs.json` and `migration-docs.json` templates using `documentation` label (doesn't exist) instead of `docs` (canonical label per `.github/labels.yml`)

Closes #227

## Test plan

- [x] Both template files updated: `documentation` → `docs`
- [x] No other templates reference `documentation`

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)