### PR TITLE
feat(contracts): add context field to NotFoundError and ValidationError

### DIFF
--- a/packages/contracts/src/__tests__/errors.test.ts
+++ b/packages/contracts/src/__tests__/errors.test.ts
@@ -160,6 +160,20 @@ describe("ValidationError", () => {
     expect(error.field).toBe("email");
   });
 
+  it("exposes optional context property", () => {
+    const error = new ValidationError({
+      message: "Value out of range",
+      field: "age",
+      context: { min: 0, max: 150, received: -1 },
+    });
+    expect(error.context).toEqual({ min: 0, max: 150, received: -1 });
+  });
+
+  it("context defaults to undefined when not provided", () => {
+    const error = new ValidationError({ message: "Invalid input" });
+    expect(error.context).toBeUndefined();
+  });
+
   it("exitCode() returns correct value", () => {
     const error = new ValidationError({ message: "Invalid input" });
     expect(error.exitCode()).toBe(exitCodeMap.validation);
@@ -245,6 +259,27 @@ describe("NotFoundError", () => {
     });
     expect(error.resourceType).toBe("note");
     expect(error.resourceId).toBe("abc123");
+  });
+
+  it("exposes optional context property", () => {
+    const error = new NotFoundError({
+      message: "Heading not found",
+      resourceType: "heading",
+      resourceId: "h:Intro",
+      context: { availableHeadings: ["Introduction", "Getting Started"] },
+    });
+    expect(error.context).toEqual({
+      availableHeadings: ["Introduction", "Getting Started"],
+    });
+  });
+
+  it("context defaults to undefined when not provided", () => {
+    const error = new NotFoundError({
+      message: "note not found",
+      resourceType: "note",
+      resourceId: "abc123",
+    });
+    expect(error.context).toBeUndefined();
   });
 
   it("exitCode() returns correct value", () => {

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -167,10 +167,12 @@ const ValidationErrorBase: TaggedErrorClass<
   {
     message: string;
     field?: string;
+    context?: Record<string, unknown>;
   }
 > = TaggedError("ValidationError")<{
   message: string;
   field?: string;
+  context?: Record<string, unknown>;
 }>();
 
 const AssertionErrorBase: TaggedErrorClass<
@@ -188,11 +190,13 @@ const NotFoundErrorBase: TaggedErrorClass<
     message: string;
     resourceType: string;
     resourceId: string;
+    context?: Record<string, unknown>;
   }
 > = TaggedError("NotFoundError")<{
   message: string;
   resourceType: string;
   resourceId: string;
+  context?: Record<string, unknown>;
 }>();
 
 const ConflictErrorBase: TaggedErrorClass<
@@ -289,6 +293,11 @@ const CancelledErrorBase: TaggedErrorClass<
  * @example
  * ```typescript
  * new ValidationError({ message: "Email format invalid", field: "email" });
+ * new ValidationError({
+ *   message: "Value out of range",
+ *   field: "age",
+ *   context: { min: 0, max: 150, received: -1 },
+ * });
  * ```
  */
 export class ValidationError extends ValidationErrorBase {
@@ -346,6 +355,12 @@ export class AssertionError extends AssertionErrorBase {
  * @example
  * ```typescript
  * new NotFoundError({ message: "note not found: abc123", resourceType: "note", resourceId: "abc123" });
+ * new NotFoundError({
+ *   message: "Heading not found",
+ *   resourceType: "heading",
+ *   resourceId: "h:Intro",
+ *   context: { availableHeadings: ["Introduction", "Getting Started"] },
+ * });
  * ```
  */
 export class NotFoundError extends NotFoundErrorBase {


### PR DESCRIPTION
## Summary

- Add optional `context?: Record<string, unknown>` to `NotFoundError` and `ValidationError`
- Matches the pattern already used by `ConflictError`, `PermissionError`, `NetworkError`, and `InternalError`
- Enables attaching structured domain metadata for rich error rendering in transport layers

Closes #219

## Test plan

- [x] `NotFoundError` accepts and exposes context
- [x] `ValidationError` accepts and exposes context
- [x] Context defaults to undefined when not provided (backwards compatible)
- [x] 300 contracts tests pass, 0 failures

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)