### PR TITLE
feat(contracts): add static create() factory methods to all error classes

### DIFF
--- a/packages/contracts/src/__tests__/errors.test.ts
+++ b/packages/contracts/src/__tests__/errors.test.ts
@@ -522,6 +522,97 @@ describe("CancelledError", () => {
 });
 
 // ============================================================================
+// Static Factory Method Tests
+// ============================================================================
+
+describe("static create() methods", () => {
+  it("ValidationError.create() sets field and generates message", () => {
+    const error = ValidationError.create("email", "format invalid");
+    expect(error.message).toBe("email: format invalid");
+    expect(error.field).toBe("email");
+    expect(error._tag).toBe("ValidationError");
+    expect(error.category).toBe("validation");
+  });
+
+  it("ValidationError.create() accepts optional context", () => {
+    const error = ValidationError.create("age", "out of range", {
+      min: 0,
+      max: 150,
+    });
+    expect(error.context).toEqual({ min: 0, max: 150 });
+  });
+
+  it("NotFoundError.create() generates message from type and id", () => {
+    const error = NotFoundError.create("PR", "outfitter#123");
+    expect(error.message).toBe("PR not found: outfitter#123");
+    expect(error.resourceType).toBe("PR");
+    expect(error.resourceId).toBe("outfitter#123");
+  });
+
+  it("NotFoundError.create() accepts optional context", () => {
+    const error = NotFoundError.create("heading", "h:Intro", {
+      available: ["Introduction"],
+    });
+    expect(error.context).toEqual({ available: ["Introduction"] });
+  });
+
+  it("ConflictError.create() builds from message", () => {
+    const error = ConflictError.create("Resource was modified");
+    expect(error.message).toBe("Resource was modified");
+    expect(error.category).toBe("conflict");
+  });
+
+  it("TimeoutError.create() generates message from operation and ms", () => {
+    const error = TimeoutError.create("database query", 5000);
+    expect(error.message).toBe("database query timed out after 5000ms");
+    expect(error.operation).toBe("database query");
+    expect(error.timeoutMs).toBe(5000);
+  });
+
+  it("RateLimitError.create() includes retryAfterSeconds", () => {
+    const error = RateLimitError.create("Rate limit exceeded", 60);
+    expect(error.message).toBe("Rate limit exceeded");
+    expect(error.retryAfterSeconds).toBe(60);
+  });
+
+  it("AuthError.create() includes reason", () => {
+    const error = AuthError.create("Token expired", "expired");
+    expect(error.message).toBe("Token expired");
+    expect(error.reason).toBe("expired");
+  });
+
+  it("CancelledError.create() builds from message", () => {
+    const error = CancelledError.create("User aborted");
+    expect(error.message).toBe("User aborted");
+    expect(error.category).toBe("cancelled");
+  });
+
+  it("NetworkError.create() includes context", () => {
+    const error = NetworkError.create("Connection refused", {
+      host: "api.example.com",
+    });
+    expect(error.message).toBe("Connection refused");
+    expect(error.context).toEqual({ host: "api.example.com" });
+  });
+
+  it("InternalError.create() includes context", () => {
+    const error = InternalError.create("Unexpected state", {
+      state: "corrupted",
+    });
+    expect(error.message).toBe("Unexpected state");
+    expect(error.context).toEqual({ state: "corrupted" });
+  });
+
+  it("PermissionError.create() includes context", () => {
+    const error = PermissionError.create("Access denied", {
+      required: "admin",
+    });
+    expect(error.message).toBe("Access denied");
+    expect(error.context).toEqual({ required: "admin" });
+  });
+});
+
+// ============================================================================
 // Helper Functions Tests
 // ============================================================================
 

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -303,6 +303,19 @@ const CancelledErrorBase: TaggedErrorClass<
 export class ValidationError extends ValidationErrorBase {
   readonly category = "validation" as const;
 
+  /** Create a ValidationError with auto-generated message from field name. */
+  static create(
+    field: string,
+    reason: string,
+    context?: Record<string, unknown>
+  ): ValidationError {
+    return new ValidationError({
+      message: `${field}: ${reason}`,
+      field,
+      ...(context != null && { context }),
+    });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -366,6 +379,20 @@ export class AssertionError extends AssertionErrorBase {
 export class NotFoundError extends NotFoundErrorBase {
   readonly category = "not_found" as const;
 
+  /** Create a NotFoundError with auto-generated message. */
+  static create(
+    resourceType: string,
+    resourceId: string,
+    context?: Record<string, unknown>
+  ): NotFoundError {
+    return new NotFoundError({
+      message: `${resourceType} not found: ${resourceId}`,
+      resourceType,
+      resourceId,
+      ...(context != null && { context }),
+    });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -385,6 +412,14 @@ export class NotFoundError extends NotFoundErrorBase {
  */
 export class ConflictError extends ConflictErrorBase {
   readonly category = "conflict" as const;
+
+  /** Create a ConflictError with optional context. */
+  static create(
+    message: string,
+    context?: Record<string, unknown>
+  ): ConflictError {
+    return new ConflictError({ message, ...(context != null && { context }) });
+  }
 
   exitCode(): number {
     return getExitCode(this.category);
@@ -406,6 +441,17 @@ export class ConflictError extends ConflictErrorBase {
 export class PermissionError extends PermissionErrorBase {
   readonly category = "permission" as const;
 
+  /** Create a PermissionError with optional context. */
+  static create(
+    message: string,
+    context?: Record<string, unknown>
+  ): PermissionError {
+    return new PermissionError({
+      message,
+      ...(context != null && { context }),
+    });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -425,6 +471,15 @@ export class PermissionError extends PermissionErrorBase {
  */
 export class TimeoutError extends TimeoutErrorBase {
   readonly category = "timeout" as const;
+
+  /** Create a TimeoutError with auto-generated message. */
+  static create(operation: string, timeoutMs: number): TimeoutError {
+    return new TimeoutError({
+      message: `${operation} timed out after ${timeoutMs}ms`,
+      operation,
+      timeoutMs,
+    });
+  }
 
   exitCode(): number {
     return getExitCode(this.category);
@@ -446,6 +501,14 @@ export class TimeoutError extends TimeoutErrorBase {
 export class RateLimitError extends RateLimitErrorBase {
   readonly category = "rate_limit" as const;
 
+  /** Create a RateLimitError with optional retry hint. */
+  static create(message: string, retryAfterSeconds?: number): RateLimitError {
+    return new RateLimitError({
+      message,
+      ...(retryAfterSeconds != null && { retryAfterSeconds }),
+    });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -465,6 +528,14 @@ export class RateLimitError extends RateLimitErrorBase {
  */
 export class NetworkError extends NetworkErrorBase {
   readonly category = "network" as const;
+
+  /** Create a NetworkError with optional context. */
+  static create(
+    message: string,
+    context?: Record<string, unknown>
+  ): NetworkError {
+    return new NetworkError({ message, ...(context != null && { context }) });
+  }
 
   exitCode(): number {
     return getExitCode(this.category);
@@ -486,6 +557,14 @@ export class NetworkError extends NetworkErrorBase {
 export class InternalError extends InternalErrorBase {
   readonly category = "internal" as const;
 
+  /** Create an InternalError with optional context. */
+  static create(
+    message: string,
+    context?: Record<string, unknown>
+  ): InternalError {
+    return new InternalError({ message, ...(context != null && { context }) });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -506,6 +585,14 @@ export class InternalError extends InternalErrorBase {
 export class AuthError extends AuthErrorBase {
   readonly category = "auth" as const;
 
+  /** Create an AuthError with optional reason. */
+  static create(
+    message: string,
+    reason?: "missing" | "invalid" | "expired"
+  ): AuthError {
+    return new AuthError({ message, ...(reason != null && { reason }) });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }
@@ -525,6 +612,11 @@ export class AuthError extends AuthErrorBase {
  */
 export class CancelledError extends CancelledErrorBase {
   readonly category = "cancelled" as const;
+
+  /** Create a CancelledError. */
+  static create(message: string): CancelledError {
+    return new CancelledError({ message });
+  }
 
   exitCode(): number {
     return getExitCode(this.category);


### PR DESCRIPTION
## Summary

Add `static create()` convenience methods to all 10 error classes, reducing boilerplate at construction sites.

High-value factories auto-generate messages from semantic fields:
- `NotFoundError.create("PR", "repo#123")` → message: `"PR not found: repo#123"`
- `ValidationError.create("email", "format invalid")` → message: `"email: format invalid"`
- `TimeoutError.create("db query", 5000)` → message: `"db query timed out after 5000ms"`

Simpler errors pass through: `AuthError.create("Token expired", "expired")`

All factories use conditional spread to satisfy `exactOptionalPropertyTypes`.

Closes #222

## Test plan

- [x] 12 tests covering all factory methods
- [x] Auto-generated messages verified for NotFoundError, ValidationError, TimeoutError
- [x] Optional params (context, reason, retryAfterSeconds) work correctly
- [x] Full typecheck passes with `exactOptionalPropertyTypes`

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)