### PR TITLE
feat(contracts): add AmbiguousError for disambiguation scenarios

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -85,6 +85,7 @@ export {
 } from "./envelope.js";
 // Errors
 export {
+  AmbiguousError,
   type AnyKitError,
   AssertionError,
   AuthError,


### PR DESCRIPTION
## Summary

New error class for "multiple matches found, user must disambiguate." Common in search, command lookup, fuzzy matching, and resolution systems.

- **Category**: `validation` (HTTP 400, exit code 1)
- **Fields**: `candidates: string[]` + optional `context`
- **Factory**: `AmbiguousError.create("heading", ["Introduction", "Intro to APIs"])`
- **Error code**: `ERROR_CODES.validation.AMBIGUOUS_MATCH` (1005)

Added to `AnyKitError` union and package exports.

Closes #220

## Test plan

- [x] 8 tests: _tag, category, candidates, context, exit/status codes, factory
- [x] ERROR_CODES.validation.AMBIGUOUS_MATCH = 1005 verified
- [x] Exported from package index

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)