### PR TITLE
feat(contracts): add expect() Result boundary helper

### DIFF
--- a/.changeset/bright-errors-shine.md
+++ b/.changeset/bright-errors-shine.md
@@ -1,0 +1,10 @@
+---
+"@outfitter/contracts": minor
+---
+
+Add error ergonomics and Result boundary helper
+
+- Add optional `context` field to `NotFoundError` and `ValidationError` for attaching structured metadata
+- Add `static create()` factory methods to all 10 error classes for concise construction
+- Add `AmbiguousError` class (category: `validation`, code: `AMBIGUOUS_MATCH`) for disambiguation scenarios with a `candidates` field
+- Add `expect()` Result utility that unwraps Ok or throws with a contextual error message

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -148,7 +148,13 @@ export {
   withTimeout,
 } from "./resilience.js";
 // Result utilities (extensions to better-result)
-export { combine2, combine3, orElse, unwrapOrElse } from "./result/index.js";
+export {
+  combine2,
+  combine3,
+  expect,
+  orElse,
+  unwrapOrElse,
+} from "./result/index.js";
 // Serialization utilities
 export {
   deserializeError,

--- a/packages/contracts/src/result/index.ts
+++ b/packages/contracts/src/result/index.ts
@@ -7,4 +7,10 @@
  */
 
 // biome-ignore lint/performance/noBarrelFile: intentional re-export for API surface
-export { combine2, combine3, orElse, unwrapOrElse } from "./utilities.js";
+export {
+  combine2,
+  combine3,
+  expect,
+  orElse,
+  unwrapOrElse,
+} from "./utilities.js";

--- a/packages/contracts/src/result/utilities.test.ts
+++ b/packages/contracts/src/result/utilities.test.ts
@@ -3,7 +3,13 @@
  */
 import { describe, expect, it, vi } from "bun:test";
 import { Result } from "better-result";
-import { combine2, combine3, orElse, unwrapOrElse } from "./utilities.js";
+import {
+  combine2,
+  combine3,
+  expect as expectResult,
+  orElse,
+  unwrapOrElse,
+} from "./utilities.js";
 
 describe("unwrapOrElse", () => {
   it("returns value on Ok", () => {
@@ -166,5 +172,30 @@ describe("combine3", () => {
     if (result.isErr()) {
       expect(result.error).toBe("first error");
     }
+  });
+});
+
+describe("expect", () => {
+  it("returns value on Ok", () => {
+    const result = Result.ok(42);
+    const value = expectResult(result, "should not fail");
+
+    expect(value).toBe(42);
+  });
+
+  it("throws with contextual message on Err", () => {
+    const result = Result.err("connection refused");
+
+    expect(() => expectResult(result, "Failed to connect")).toThrow(
+      "Failed to connect: connection refused"
+    );
+  });
+
+  it("includes stringified error in thrown message", () => {
+    const result = Result.err({ code: 404 });
+
+    expect(() => expectResult(result, "Lookup failed")).toThrow(
+      "Lookup failed: [object Object]"
+    );
   });
 });

--- a/packages/contracts/src/result/utilities.ts
+++ b/packages/contracts/src/result/utilities.ts
@@ -124,3 +124,26 @@ export const combine3 = <T1, T2, T3, E>(
   if (r3.isErr()) return r3 as unknown as Result<[T1, T2, T3], E>;
   return Result.ok([r1.value, r2.value, r3.value]);
 };
+
+/**
+ * Extract value from Ok, or throw with a contextual error message.
+ *
+ * Like `unwrap()` but with a caller-provided message for better
+ * debugging context. Use at system boundaries (CLI adapters, MCP
+ * handlers) where you need the value and want a clear error.
+ *
+ * @param result - The Result to unwrap
+ * @param message - Context message prepended to the error
+ * @returns The success value
+ * @throws Error with contextual message if Result is Err
+ *
+ * @example
+ * ```typescript
+ * const config = expect(loadConfig(), "Failed to load config");
+ * // On Err, throws: "Failed to load config: <error details>"
+ * ```
+ */
+export const expect = <T, E>(result: Result<T, E>, message: string): T => {
+  if (result.isOk()) return result.value;
+  throw new Error(`${message}: ${String(result.error)}`);
+};


### PR DESCRIPTION
## Summary

Add \`expect(result, message)\` — unwraps Ok or throws with a contextual error message. Fills the gap between \`unwrap()\` (no context) and manual \`if (result.isErr()) throw\` guards.

\`\`\`typescript
const config = expect(loadConfig(), "Failed to load config");
// On Err, throws: "Failed to load config: <error details>"
\`\`\`

\`better-result\` already provides \`unwrap()\`, \`unwrapOr()\`, \`map()\`, \`andThen()\`, \`match()\`, \`tap()\`, \`mapError()\` as instance methods. This PR adds the missing "unwrap with context" pattern as a standalone utility, consistent with existing \`unwrapOrElse\` and \`orElse\`.

Closes #223

## Test plan

- [x] Returns value on Ok
- [x] Throws with "\`message: error\`" format on Err
- [x] Stringifies non-string errors
- [x] Exported from package index

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)