### PR TITLE
feat(cli): add ANSI.inverse escape code to colors module

### DIFF
--- a/.changeset/quick-inverse-glow.md
+++ b/.changeset/quick-inverse-glow.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/cli": patch
+---
+
+Add `ANSI.inverse` escape code (`\x1b[7m`) to the colors module, completing the set of common text decoration codes alongside bold, dim, italic, and underline. Also adds `inverse` to Theme and Tokens interfaces.

--- a/packages/cli/src/__tests__/colors.test.ts
+++ b/packages/cli/src/__tests__/colors.test.ts
@@ -185,7 +185,7 @@ describe("Color Tokens", () => {
   // ============================================================================
 
   describe("utility methods", () => {
-    it("has utility methods (bold, italic, underline, dim)", () => {
+    it("has utility methods (bold, italic, underline, dim, inverse)", () => {
       const theme = createTheme();
 
       // Utility methods
@@ -193,17 +193,20 @@ describe("Color Tokens", () => {
       expect(theme.italic).toBeDefined();
       expect(theme.underline).toBeDefined();
       expect(theme.dim).toBeDefined();
+      expect(theme.inverse).toBeDefined();
 
       // Each should return a string with text preserved
       const boldText = theme.bold("strong");
       const italicText = theme.italic("emphasis");
       const underlineText = theme.underline("underlined");
       const dimText = theme.dim("faded");
+      const inverseText = theme.inverse("inverted");
 
       expect(boldText).toContain("strong");
       expect(italicText).toContain("emphasis");
       expect(underlineText).toContain("underlined");
       expect(dimText).toContain("faded");
+      expect(inverseText).toContain("inverted");
     });
 
     it("utility methods compose with semantic colors", () => {
@@ -250,6 +253,7 @@ describe("Color Tokens", () => {
       expect(tokens.italic).toBe("");
       expect(tokens.underline).toBe("");
       expect(tokens.dim).toBe("");
+      expect(tokens.inverse).toBe("");
     });
   });
 
@@ -266,6 +270,7 @@ describe("Color Tokens", () => {
       expect(ANSI.brightYellow).toBe("\x1b[93m");
       expect(ANSI.brightGreen).toBe("\x1b[92m");
       expect(ANSI.brightBlue).toBe("\x1b[94m");
+      expect(ANSI.inverse).toBe("\x1b[7m");
     });
   });
 });

--- a/packages/cli/src/demo/registry.ts
+++ b/packages/cli/src/demo/registry.ts
@@ -112,6 +112,11 @@ export const THEME_METHOD_META: Record<keyof Theme, ThemeMethodMeta> = {
     description: "Dim styling",
     defaultExample: "De-emphasized",
   },
+  inverse: {
+    category: "utility",
+    description: "Inverse styling (swap fg/bg)",
+    defaultExample: "Inverted text",
+  },
 };
 
 /**

--- a/packages/cli/src/render/colors.ts
+++ b/packages/cli/src/render/colors.ts
@@ -21,6 +21,7 @@ export const ANSI = {
   dim: "\x1b[2m",
   italic: "\x1b[3m",
   underline: "\x1b[4m",
+  inverse: "\x1b[7m",
   // Foreground colors
   green: "\x1b[32m",
   yellow: "\x1b[33m",
@@ -94,6 +95,8 @@ export interface Theme {
   underline: (text: string) => string;
   /** Applies dim styling (alias for muted style) */
   dim: (text: string) => string;
+  /** Applies inverse styling (swaps foreground/background) */
+  inverse: (text: string) => string;
 }
 
 /**
@@ -174,6 +177,8 @@ export interface Tokens {
   underline: string;
   /** Dim styling */
   dim: string;
+  /** Inverse styling (swaps foreground/background) */
+  inverse: string;
 }
 
 /**
@@ -270,6 +275,7 @@ export function createTheme(): Theme {
     italic: colorFn(ANSI.italic),
     underline: colorFn(ANSI.underline),
     dim: colorFn(ANSI.dim),
+    inverse: colorFn(ANSI.inverse),
   };
 }
 
@@ -350,6 +356,7 @@ export function createTokens(options?: TokenOptions): Tokens {
       italic: "",
       underline: "",
       dim: "",
+      inverse: "",
     };
   }
 
@@ -374,6 +381,7 @@ export function createTokens(options?: TokenOptions): Tokens {
     italic: ANSI.italic,
     underline: ANSI.underline,
     dim: ANSI.dim,
+    inverse: ANSI.inverse,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds `ANSI.inverse` escape code (`\x1b[7m`) to the colors module
- Adds `inverse` to `Theme` and `Tokens` interfaces
- Updates `createTheme()` and `createTokens()` to include inverse styling
- Updates demo registry with inverse metadata

Closes #231

## Test plan
- [x] Existing colors tests updated to cover `inverse`
- [x] `ANSI.inverse` value assertion
- [x] Theme utility method assertions include `inverse`
- [x] Tokens disabled path returns empty string for `inverse`
- [x] Typecheck passes (demo registry exhaustive check)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)