### PR TITLE
feat(mcp): add tool annotations (OS-52)

### DIFF
--- a/packages/mcp/src/__tests__/tool-annotations.test.ts
+++ b/packages/mcp/src/__tests__/tool-annotations.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for MCP Tool Annotations (OS-52)
+ *
+ * Verifies that tools can declare behavioral hints:
+ * readOnlyHint, destructiveHint, idempotentHint, openWorldHint
+ */
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import { z } from "zod";
+import { createMcpServer, defineTool, type ToolAnnotations } from "../index.js";
+
+describe("Tool Annotations", () => {
+  it("tool with annotations serializes correctly", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "read-file",
+        description: "Read a file from the filesystem",
+        inputSchema: z.object({ path: z.string() }),
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        handler: async (input) => Result.ok({ content: `file: ${input.path}` }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it("tool without annotations omits the field", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "echo",
+        description: "Echo the input message",
+        inputSchema: z.object({ message: z.string() }),
+        handler: async (input) => Result.ok({ echo: input.message }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].annotations).toBeUndefined();
+  });
+
+  it("readOnlyHint works independently", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "reader",
+        description: "A read-only tool for reading data",
+        inputSchema: z.object({}),
+        annotations: { readOnlyHint: true },
+        handler: async () => Result.ok({ data: "read" }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools[0].annotations).toEqual({ readOnlyHint: true });
+  });
+
+  it("destructiveHint works independently", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "deleter",
+        description: "A destructive tool for deleting data",
+        inputSchema: z.object({}),
+        annotations: { destructiveHint: true },
+        handler: async () => Result.ok({ deleted: true }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools[0].annotations).toEqual({ destructiveHint: true });
+  });
+
+  it("idempotentHint works independently", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "setter",
+        description: "An idempotent tool for setting data",
+        inputSchema: z.object({}),
+        annotations: { idempotentHint: true },
+        handler: async () => Result.ok({ set: true }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools[0].annotations).toEqual({ idempotentHint: true });
+  });
+
+  it("openWorldHint works independently", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerTool(
+      defineTool({
+        name: "searcher",
+        description: "A tool that searches external data sources",
+        inputSchema: z.object({}),
+        annotations: { openWorldHint: true },
+        handler: async () => Result.ok({ results: [] }),
+      })
+    );
+
+    const tools = server.getTools();
+    expect(tools[0].annotations).toEqual({ openWorldHint: true });
+  });
+
+  it("ToolAnnotations type allows partial specification", () => {
+    const partial: ToolAnnotations = {
+      readOnlyHint: true,
+      idempotentHint: false,
+    };
+    expect(partial.readOnlyHint).toBe(true);
+    expect(partial.destructiveHint).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -75,5 +75,6 @@ export {
   type McpServerOptions,
   type ResourceDefinition,
   type SerializedTool,
+  type ToolAnnotations,
   type ToolDefinition,
 } from "./types.js";

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -22,6 +22,7 @@ import {
   type McpServerOptions,
   type ResourceDefinition,
   type SerializedTool,
+  type ToolAnnotations,
   type ToolDefinition,
 } from "./types.js";
 
@@ -60,6 +61,7 @@ interface StoredTool {
   description: string;
   inputSchema: unknown;
   deferLoading: boolean;
+  annotations?: ToolAnnotations;
   handler: (
     input: unknown,
     ctx: HandlerContext
@@ -185,14 +187,18 @@ export function createMcpServer(options: McpServerOptions): McpServer {
         tool.handler(input as TInput, ctx);
       const deferLoading = tool.deferLoading ?? true;
 
-      tools.set(tool.name, {
+      const stored: StoredTool = {
         name: tool.name,
         description,
         inputSchema: jsonSchema,
         deferLoading,
         handler,
         zodSchema: tool.inputSchema,
-      });
+      };
+      if (tool.annotations !== undefined) {
+        stored.annotations = tool.annotations;
+      }
+      tools.set(tool.name, stored);
 
       logger.info("Tool registered", { name: tool.name });
     },
@@ -212,6 +218,7 @@ export function createMcpServer(options: McpServerOptions): McpServer {
         description: tool.description,
         inputSchema: tool.inputSchema as Record<string, unknown>,
         defer_loading: tool.deferLoading,
+        ...(tool.annotations ? { annotations: tool.annotations } : {}),
       }));
     },
 

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -64,6 +64,32 @@ export interface McpServerOptions {
 }
 
 // ============================================================================
+// Tool Annotations
+// ============================================================================
+
+/**
+ * Behavioral hints for MCP tools.
+ *
+ * Annotations help clients understand tool behavior without invoking them.
+ * All fields are optional — only include hints that apply.
+ *
+ * @see https://spec.modelcontextprotocol.io/specification/2025-03-26/server/tools/#annotations
+ */
+export interface ToolAnnotations {
+  /** When true, the tool does not modify any state. */
+  readOnlyHint?: boolean;
+
+  /** When true, the tool may perform destructive operations (e.g., deleting data). */
+  destructiveHint?: boolean;
+
+  /** When true, calling the tool multiple times with the same input has the same effect. */
+  idempotentHint?: boolean;
+
+  /** When true, the tool may interact with external systems beyond the server. */
+  openWorldHint?: boolean;
+}
+
+// ============================================================================
 // Tool Definition
 // ============================================================================
 
@@ -133,6 +159,12 @@ export interface ToolDefinition<
   inputSchema: z.ZodType<TInput>;
 
   /**
+   * Optional behavioral annotations for the tool.
+   * Helps clients understand tool behavior without invoking it.
+   */
+  annotations?: ToolAnnotations;
+
+  /**
    * Handler function that processes the tool invocation.
    * Receives validated input and HandlerContext, returns Result.
    */
@@ -155,6 +187,9 @@ export interface SerializedTool {
 
   /** MCP tool-search hint: whether tool is deferred */
   defer_loading?: boolean;
+
+  /** Behavioral annotations for the tool */
+  annotations?: ToolAnnotations;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `ToolAnnotations` interface with 4 behavioral hints: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`
- Add optional `annotations` field to `ToolDefinition` and `SerializedTool`
- Annotations are omitted entirely when not provided (clean serialization)

Part of the MCP Spec Compliance epic (OS-51).

## Test plan

- [x] Tool with annotations serializes all 4 hints correctly
- [x] Tool without annotations omits the field entirely
- [x] Each hint works independently
- [x] `bun test` — 66 tests pass
- [x] Build and typecheck clean