### PR TITLE
feat(mcp): add resource read handlers and templates (OS-53, OS-54)

### DIFF
--- a/packages/mcp/src/__tests__/resource-templates.test.ts
+++ b/packages/mcp/src/__tests__/resource-templates.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for MCP Resource Templates (OS-54)
+ *
+ * Verifies URI template support with RFC 6570 Level 1 matching.
+ */
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import {
+  createMcpServer,
+  defineResource,
+  defineResourceTemplate,
+} from "../index.js";
+
+describe("Resource Templates", () => {
+  it("template registration and listing", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "file:///users/{userId}/profile",
+        name: "User Profile",
+        description: "User profile by ID",
+        handler: async (uri, variables) =>
+          Result.ok([{ uri, text: `Profile for ${variables.userId}` }]),
+      })
+    );
+
+    const templates = server.getResourceTemplates();
+    expect(templates).toHaveLength(1);
+    expect(templates[0].uriTemplate).toBe("file:///users/{userId}/profile");
+    expect(templates[0].name).toBe("User Profile");
+  });
+
+  it("URI matching extracts variables", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "db:///users/{userId}/posts/{postId}",
+        name: "User Post",
+        handler: async (uri, variables) =>
+          Result.ok([
+            {
+              uri,
+              text: `User ${variables.userId}, Post ${variables.postId}`,
+            },
+          ]),
+      })
+    );
+
+    const result = await server.readResource("db:///users/alice/posts/42");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect((result.value[0] as { text: string }).text).toBe(
+        "User alice, Post 42"
+      );
+    }
+  });
+
+  it("exact resource match takes priority over templates", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///users/admin/profile",
+        name: "Admin Profile",
+        handler: async () =>
+          Result.ok([
+            { uri: "file:///users/admin/profile", text: "exact match" },
+          ]),
+      })
+    );
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "file:///users/{userId}/profile",
+        name: "User Profile",
+        handler: async (uri, variables) =>
+          Result.ok([{ uri, text: `template match: ${variables.userId}` }]),
+      })
+    );
+
+    const result = await server.readResource("file:///users/admin/profile");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect((result.value[0] as { text: string }).text).toBe("exact match");
+    }
+  });
+
+  it("no match returns not_found error", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "file:///users/{userId}/profile",
+        name: "User Profile",
+        handler: async (uri, variables) =>
+          Result.ok([{ uri, text: `${variables.userId}` }]),
+      })
+    );
+
+    const result = await server.readResource(
+      "file:///completely/different/path"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not found");
+    }
+  });
+
+  it("multiple templates can be registered", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "db:///users/{userId}",
+        name: "User",
+        handler: async (uri) => Result.ok([{ uri, text: "user" }]),
+      })
+    );
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "db:///posts/{postId}",
+        name: "Post",
+        handler: async (uri) => Result.ok([{ uri, text: "post" }]),
+      })
+    );
+
+    const templates = server.getResourceTemplates();
+    expect(templates).toHaveLength(2);
+  });
+
+  it("URI with regex metacharacters matches correctly", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "file:///path/to/file.txt?version={version}",
+        name: "Versioned File",
+        handler: async (uri, variables) =>
+          Result.ok([{ uri, text: `v${variables.version}` }]),
+      })
+    );
+
+    const result = await server.readResource(
+      "file:///path/to/file.txt?version=2"
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect((result.value[0] as { text: string }).text).toBe("v2");
+    }
+
+    // Should NOT match a URI where the dot matches any character
+    const noMatch = await server.readResource(
+      "file:///path/to/fileXtxt?version=2"
+    );
+    expect(noMatch.isErr()).toBe(true);
+  });
+
+  it("template with mimeType is included in listing", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "file:///docs/{docId}",
+        name: "Document",
+        mimeType: "application/json",
+        handler: async (uri) => Result.ok([{ uri, text: "{}" }]),
+      })
+    );
+
+    const templates = server.getResourceTemplates();
+    expect(templates[0].mimeType).toBe("application/json");
+  });
+});

--- a/packages/mcp/src/__tests__/resources.test.ts
+++ b/packages/mcp/src/__tests__/resources.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for MCP Resource Read Handlers (OS-53)
+ *
+ * Verifies that resources can have read handlers that return content.
+ */
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import { createMcpServer, defineResource } from "../index.js";
+
+describe("Resource Read Handlers", () => {
+  it("resource with handler returns text content", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///config.json",
+        name: "Config",
+        description: "Application configuration",
+        mimeType: "application/json",
+        handler: async () =>
+          Result.ok([{ uri: "file:///config.json", text: '{"key":"value"}' }]),
+      })
+    );
+
+    const result = await server.readResource("file:///config.json");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].uri).toBe("file:///config.json");
+      expect((result.value[0] as { text: string }).text).toBe(
+        '{"key":"value"}'
+      );
+    }
+  });
+
+  it("resource with handler returns blob content", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///image.png",
+        name: "Image",
+        mimeType: "image/png",
+        handler: async () =>
+          Result.ok([
+            {
+              uri: "file:///image.png",
+              blob: "iVBORw0KGgoAAAANSUhEUg==",
+              mimeType: "image/png",
+            },
+          ]),
+      })
+    );
+
+    const result = await server.readResource("file:///image.png");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect((result.value[0] as { blob: string }).blob).toBe(
+        "iVBORw0KGgoAAAANSUhEUg=="
+      );
+    }
+  });
+
+  it("unknown URI returns not_found McpError", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    const result = await server.readResource("file:///nonexistent");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error._tag).toBe("McpError");
+      expect(result.error.message).toContain("not found");
+    }
+  });
+
+  it("metadata-only resource returns not readable error", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///metadata-only.txt",
+        name: "Metadata Only",
+      })
+    );
+
+    const result = await server.readResource("file:///metadata-only.txt");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error._tag).toBe("McpError");
+      expect(result.error.message).toContain("not readable");
+    }
+  });
+
+  it("handler errors translate to McpError", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///error.txt",
+        name: "Error Resource",
+        handler: async () => {
+          throw new Error("disk read failed");
+        },
+      })
+    );
+
+    const result = await server.readResource("file:///error.txt");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error._tag).toBe("McpError");
+      expect(result.error.message).toContain("disk read failed");
+    }
+  });
+
+  it("handler receives context with requestId and logger", async () => {
+    let receivedRequestId: string | undefined;
+    let receivedLogger: unknown;
+
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({
+        uri: "file:///ctx.txt",
+        name: "Context Resource",
+        handler: async (_uri, ctx) => {
+          receivedRequestId = ctx.requestId;
+          receivedLogger = ctx.logger;
+          return Result.ok([{ uri: "file:///ctx.txt", text: "content" }]);
+        },
+      })
+    );
+
+    await server.readResource("file:///ctx.txt");
+    expect(receivedRequestId).toBeDefined();
+    expect(receivedLogger).toBeDefined();
+  });
+
+  it("resources stored by URI are deduplicated", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({ uri: "file:///dup.txt", name: "First" })
+    );
+    server.registerResource(
+      defineResource({ uri: "file:///dup.txt", name: "Second" })
+    );
+
+    const resources = server.getResources();
+    expect(resources).toHaveLength(1);
+    expect(resources[0].name).toBe("Second");
+  });
+
+  it("multiple resources are listed correctly", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResource(
+      defineResource({ uri: "file:///a.txt", name: "A" })
+    );
+    server.registerResource(
+      defineResource({ uri: "file:///b.txt", name: "B" })
+    );
+
+    const resources = server.getResources();
+    expect(resources).toHaveLength(2);
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -59,7 +59,12 @@ export {
 // Schema utilities
 export { type JsonSchema, zodToJsonSchema } from "./schema.js";
 // Server
-export { createMcpServer, defineResource, defineTool } from "./server.js";
+export {
+  createMcpServer,
+  defineResource,
+  defineResourceTemplate,
+  defineTool,
+} from "./server.js";
 // Transport helpers
 export {
   connectStdio,
@@ -68,13 +73,19 @@ export {
 } from "./transport.js";
 // Types
 export {
+  type BlobResourceContent,
   type InvokeToolOptions,
   McpError,
   type McpHandlerContext,
   type McpServer,
   type McpServerOptions,
+  type ResourceContent,
   type ResourceDefinition,
+  type ResourceReadHandler,
+  type ResourceTemplateDefinition,
+  type ResourceTemplateReadHandler,
   type SerializedTool,
+  type TextResourceContent,
   type ToolAnnotations,
   type ToolDefinition,
 } from "./types.js";


### PR DESCRIPTION
## Summary

- Add `ResourceContent` types (text and blob variants) with read handlers
- Add `readResource(uri)` to `McpServer` interface with error translation
- Add `ResourceTemplateDefinition` with RFC 6570 Level 1 URI template matching
- Wire `ListResources`, `ReadResource`, `ListResourceTemplates` SDK handlers
- Dynamic `resources` capability detection based on registrations

Part of the MCP Spec Compliance epic (OS-51).

## Test plan

- [x] Resource with handler returns content
- [x] Unknown URI returns McpError
- [x] Metadata-only resource returns "not readable" error
- [x] Handler errors translate to McpError
- [x] Template URI matching extracts variables
- [x] Exact resource match takes priority over templates
- [x] `bun test` — 66 tests pass (14 new)
- [x] Build and typecheck clean