### PR TITLE
feat(mcp): add prompts and completions (OS-55, OS-56)

### DIFF
--- a/packages/mcp/src/__tests__/completions.test.ts
+++ b/packages/mcp/src/__tests__/completions.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for MCP Completions (OS-56)
+ *
+ * Verifies argument autocompletion for prompt args and resource template params.
+ */
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import {
+  createMcpServer,
+  definePrompt,
+  defineResourceTemplate,
+} from "../index.js";
+
+describe("Completions", () => {
+  it("prompt argument completion works", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "greet",
+        description: "Greeting prompt",
+        arguments: [
+          {
+            name: "language",
+            description: "Language",
+            required: true,
+            complete: async (value) => ({
+              values: ["english", "spanish", "french"].filter((l) =>
+                l.startsWith(value)
+              ),
+            }),
+          },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: {
+                  type: "text" as const,
+                  text: `Hello in ${args.language}`,
+                },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.complete(
+      { type: "ref/prompt", name: "greet" },
+      "language",
+      "sp"
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.values).toEqual(["spanish"]);
+    }
+  });
+
+  it("resource template parameter completion works", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerResourceTemplate(
+      defineResourceTemplate({
+        uriTemplate: "db:///users/{userId}",
+        name: "User",
+        complete: {
+          userId: async (value) => ({
+            values: ["alice", "bob", "charlie"].filter((u) =>
+              u.startsWith(value)
+            ),
+          }),
+        },
+        handler: async (uri) => Result.ok([{ uri, text: "user" }]),
+      })
+    );
+
+    const result = await server.complete(
+      { type: "ref/resource", uri: "db:///users/{userId}" },
+      "userId",
+      "a"
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.values).toEqual(["alice"]);
+    }
+  });
+
+  it("missing handler returns empty values", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "basic",
+        description: "Basic prompt",
+        arguments: [{ name: "name", description: "Name", required: true }],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: { type: "text" as const, text: `${args.name}` },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.complete(
+      { type: "ref/prompt", name: "basic" },
+      "name",
+      "a"
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.values).toEqual([]);
+    }
+  });
+
+  it("async handlers work", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "async-prompt",
+        description: "Async prompt",
+        arguments: [
+          {
+            name: "city",
+            description: "City",
+            complete: async (value) => {
+              // Simulate async lookup
+              await new Promise((resolve) => setTimeout(resolve, 1));
+              return {
+                values: ["New York", "Nashville"].filter((c) =>
+                  c.toLowerCase().startsWith(value.toLowerCase())
+                ),
+              };
+            },
+          },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: { type: "text" as const, text: `${args.city}` },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.complete(
+      { type: "ref/prompt", name: "async-prompt" },
+      "city",
+      "n"
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.values).toEqual(["New York", "Nashville"]);
+    }
+  });
+
+  it("unknown prompt returns error", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    const result = await server.complete(
+      { type: "ref/prompt", name: "nonexistent" },
+      "arg",
+      "val"
+    );
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("unknown resource template returns error", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    const result = await server.complete(
+      { type: "ref/resource", uri: "db:///unknown/{id}" },
+      "id",
+      "val"
+    );
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/prompts.test.ts
+++ b/packages/mcp/src/__tests__/prompts.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for MCP Prompts (OS-55)
+ *
+ * Verifies the full prompt system: registration, listing, invocation.
+ */
+import { describe, expect, it } from "bun:test";
+import { Result } from "@outfitter/contracts";
+import { createMcpServer, definePrompt } from "../index.js";
+
+describe("Prompts", () => {
+  it("registration and listing", () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "greet",
+        description: "Generate a greeting",
+        arguments: [
+          { name: "name", description: "Person to greet", required: true },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: {
+                  type: "text" as const,
+                  text: `Hello, ${args.name}!`,
+                },
+              },
+            ],
+          }),
+      })
+    );
+
+    const prompts = server.getPrompts();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].name).toBe("greet");
+    expect(prompts[0].description).toBe("Generate a greeting");
+    expect(prompts[0].arguments).toHaveLength(1);
+  });
+
+  it("invocation with args returns messages", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "summarize",
+        description: "Summarize a topic in a given style",
+        arguments: [
+          { name: "topic", description: "Topic to summarize", required: true },
+          { name: "style", description: "Writing style" },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: {
+                  type: "text" as const,
+                  text: `Summarize ${args.topic} in ${args.style ?? "default"} style`,
+                },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.getPrompt("summarize", {
+      topic: "AI",
+      style: "casual",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.messages).toHaveLength(1);
+      expect(result.value.messages[0].content.text).toBe(
+        "Summarize AI in casual style"
+      );
+    }
+  });
+
+  it("missing required arg returns validation McpError", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "greet",
+        description: "Generate a greeting",
+        arguments: [
+          { name: "name", description: "Person to greet", required: true },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: {
+                  type: "text" as const,
+                  text: `Hello, ${args.name}!`,
+                },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.getPrompt("greet", {});
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error._tag).toBe("McpError");
+      expect(result.error.message).toContain("name");
+    }
+  });
+
+  it("unknown prompt returns not_found McpError", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    const result = await server.getPrompt("nonexistent", {});
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error._tag).toBe("McpError");
+      expect(result.error.message).toContain("not found");
+    }
+  });
+
+  it("multi-message responses work", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "chat",
+        description: "Multi-turn chat prompt",
+        arguments: [],
+        handler: async () =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: { type: "text" as const, text: "What is 2+2?" },
+              },
+              {
+                role: "assistant" as const,
+                content: { type: "text" as const, text: "4" },
+              },
+              {
+                role: "user" as const,
+                content: { type: "text" as const, text: "And 3+3?" },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.getPrompt("chat", {});
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.messages).toHaveLength(3);
+      expect(result.value.messages[0].role).toBe("user");
+      expect(result.value.messages[1].role).toBe("assistant");
+    }
+  });
+
+  it("prompt with no arguments", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "hello",
+        description: "Simple hello prompt",
+        arguments: [],
+        handler: async () =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: { type: "text" as const, text: "Hello world!" },
+              },
+            ],
+          }),
+      })
+    );
+
+    const result = await server.getPrompt("hello", {});
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("optional args are not required", async () => {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+
+    server.registerPrompt(
+      definePrompt({
+        name: "greet",
+        description: "Greeting with optional title",
+        arguments: [
+          { name: "name", description: "Person name", required: true },
+          { name: "title", description: "Optional title" },
+        ],
+        handler: async (args) =>
+          Result.ok({
+            messages: [
+              {
+                role: "user" as const,
+                content: {
+                  type: "text" as const,
+                  text: `Hello, ${args.title ? `${args.title} ` : ""}${args.name}!`,
+                },
+              },
+            ],
+          }),
+      })
+    );
+
+    // Should succeed without optional "title" arg
+    const result = await server.getPrompt("greet", { name: "Alice" });
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -61,6 +61,7 @@ export { type JsonSchema, zodToJsonSchema } from "./schema.js";
 // Server
 export {
   createMcpServer,
+  definePrompt,
   defineResource,
   defineResourceTemplate,
   defineTool,
@@ -74,11 +75,20 @@ export {
 // Types
 export {
   type BlobResourceContent,
+  type CompletionHandler,
+  type CompletionRef,
+  type CompletionResult,
   type InvokeToolOptions,
   McpError,
   type McpHandlerContext,
   type McpServer,
   type McpServerOptions,
+  type PromptArgument,
+  type PromptDefinition,
+  type PromptHandler,
+  type PromptMessage,
+  type PromptMessageContent,
+  type PromptResult,
   type ResourceContent,
   type ResourceDefinition,
   type ResourceReadHandler,


### PR DESCRIPTION
## Summary

- Add full prompt system: `PromptDefinition`, `PromptArgument`, `PromptMessage`, `PromptResult`
- Add `registerPrompt()`, `getPrompts()`, `getPrompt()` to `McpServer`
- Add argument completion system for prompts and resource templates
- Add `complete()` method routing to prompt arg or template param handlers
- Wire `ListPrompts`, `GetPrompt`, `Complete` SDK handlers
- Dynamic `prompts` and `completions` capability detection

Part of the MCP Spec Compliance epic (OS-51).

## Test plan

- [x] Prompt registration and listing
- [x] Prompt invocation with args returns messages
- [x] Missing required arg returns validation McpError
- [x] Unknown prompt returns McpError
- [x] Prompt argument completion works
- [x] Resource template parameter completion works
- [x] Missing handler returns empty values
- [x] `bun test` — 79 tests pass (13 new)
- [x] Build and typecheck clean