### PR TITLE
fix(platform): avoid top-level node imports

### DIFF
--- a/packages/logging/src/__tests__/bundler-safety.test.ts
+++ b/packages/logging/src/__tests__/bundler-safety.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+function findTopLevelNodeImports(source: string): string[] {
+  return (
+    source.match(/^\s*import\s+[^;]+from\s+["']node:[^"']+["']\s*;?/gm) ?? []
+  );
+}
+
+describe("bundler safety", () => {
+  test("logging entry avoids top-level node:* imports", async () => {
+    const source = await Bun.file(
+      new URL("../index.ts", import.meta.url)
+    ).text();
+    expect(
+      findTopLevelNodeImports(source),
+      "logging/index.ts should not include node:* imports"
+    ).toHaveLength(0);
+  });
+});

--- a/packages/testing/src/__tests__/bundler-safety.test.ts
+++ b/packages/testing/src/__tests__/bundler-safety.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+function findTopLevelNodeImports(source: string): string[] {
+  return (
+    source.match(/^\s*import\s+[^;]+from\s+["']node:[^"']+["']\s*;?/gm) ?? []
+  );
+}
+
+describe("bundler safety", () => {
+  test("testing utilities avoid top-level node:* imports", async () => {
+    const fixturesSource = await Bun.file(
+      new URL("../fixtures.ts", import.meta.url)
+    ).text();
+    const harnessSource = await Bun.file(
+      new URL("../cli-harness.ts", import.meta.url)
+    ).text();
+
+    expect(
+      findTopLevelNodeImports(fixturesSource),
+      "testing/fixtures.ts should not include node:* imports"
+    ).toHaveLength(0);
+    expect(
+      findTopLevelNodeImports(harnessSource),
+      "testing/cli-harness.ts should not include node:* imports"
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid top-level node:* imports in logging/testing for non-Node bundlers
- switch file sink and process spawning to Bun APIs
- add bundler-safety coverage for logging/testing

## Testing
- bun run test

Closes #257
