### PR TITLE
feat(cli): add json output and prompt page size

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -83,6 +83,7 @@
     "@outfitter/cli": "workspace:*",
     "@outfitter/config": "workspace:*",
     "@outfitter/contracts": "workspace:*",
+    "@outfitter/logging": "workspace:*",
     "@outfitter/tooling": "workspace:*",
     "commander": "^14.0.2",
     "zod": "^4.3.5"

--- a/apps/outfitter/src/__tests__/no-console.test.ts
+++ b/apps/outfitter/src/__tests__/no-console.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Guard against direct console usage in CLI commands.
+ */
+
+import { describe, test } from "bun:test";
+import { join } from "node:path";
+
+const srcRoot = join(import.meta.dir, "..");
+
+function stripBlockCommentsKeepLines(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, (match) =>
+    match.replace(/[^\n]/g, "")
+  );
+}
+
+function findConsoleLines(source: string): number[] {
+  const withoutBlockComments = stripBlockCommentsKeepLines(source);
+  const lines = withoutBlockComments.split("\n");
+  const matches: number[] = [];
+
+  lines.forEach((line, index) => {
+    const withoutLineComments = line.replace(/\/\/.*$/g, "");
+    if (/\bconsole\./.test(withoutLineComments)) {
+      matches.push(index + 1);
+    }
+  });
+
+  return matches;
+}
+
+describe("cli commands", () => {
+  test("do not use console.* directly", async () => {
+    const glob = new Bun.Glob("commands/*.ts");
+    const commandFiles = Array.from(glob.scanSync({ cwd: srcRoot })).map(
+      (file) => join(srcRoot, file)
+    );
+
+    const files = [
+      ...commandFiles,
+      join(srcRoot, "actions.ts"),
+      join(srcRoot, "cli.ts"),
+    ];
+
+    const failures: string[] = [];
+
+    for (const file of files) {
+      const contents = await Bun.file(file).text();
+      const lines = findConsoleLines(contents);
+      if (lines.length > 0) {
+        failures.push(`${file}: ${lines.join(", ")}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(`console usage found:\n${failures.join("\n")}`);
+    }
+  });
+});

--- a/apps/outfitter/src/commands/demo.ts
+++ b/apps/outfitter/src/commands/demo.ts
@@ -8,6 +8,7 @@
  */
 
 import { isCancel, select } from "@clack/prompts";
+import { output } from "@outfitter/cli/output";
 import { createTheme, renderTable, SPINNERS } from "@outfitter/cli/render";
 import { ANSI } from "@outfitter/cli/streaming";
 import { isInteractive } from "@outfitter/cli/terminal";
@@ -216,18 +217,21 @@ async function runAnimatedSpinnerDemo(): Promise<void> {
 
   const stream = process.stdout;
   const isTTY = stream.isTTY ?? false;
+  const writeLine = (line: string): void => {
+    stream.write(`${line}\n`);
+  };
 
-  console.log("");
-  console.log(theme.bold("ANIMATED SPINNER DEMO"));
-  console.log(theme.muted("All styles running simultaneously"));
-  console.log(theme.muted("Press Ctrl+C to stop"));
-  console.log("");
+  writeLine("");
+  writeLine(theme.bold("ANIMATED SPINNER DEMO"));
+  writeLine(theme.muted("All styles running simultaneously"));
+  writeLine(theme.muted("Press Ctrl+C to stop"));
+  writeLine("");
 
   if (!isTTY) {
     // Non-TTY fallback: just show static frames
     for (const style of styles) {
       const spinner = SPINNERS[style];
-      console.log(`${style.padEnd(10)} ${spinner.frames.join(" ")}`);
+      writeLine(`${style.padEnd(10)} ${spinner.frames.join(" ")}`);
     }
     return;
   }
@@ -274,11 +278,9 @@ async function runAnimatedSpinnerDemo(): Promise<void> {
   const cleanup = (): void => {
     clearInterval(timer);
     stream.write(ANSI.showCursor);
-    console.log("");
-    console.log(
-      theme.muted("Use createSpinner() from @outfitter/cli/streaming")
-    );
-    console.log("");
+    writeLine("");
+    writeLine(theme.muted("Use createSpinner() from @outfitter/cli/streaming"));
+    writeLine("");
     process.exit(0);
   };
 
@@ -291,10 +293,10 @@ async function runAnimatedSpinnerDemo(): Promise<void> {
 }
 
 /**
- * Prints demo results to the console.
+ * Outputs demo results.
  */
-export function printDemoResults(result: DemoResult): void {
+export async function printDemoResults(result: DemoResult): Promise<void> {
   if (result.output) {
-    console.log(result.output);
+    await output(result.output, { mode: "human" });
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@outfitter/cli": "workspace:*",
         "@outfitter/config": "workspace:*",
         "@outfitter/contracts": "workspace:*",
+        "@outfitter/logging": "workspace:*",
         "@outfitter/tooling": "workspace:*",
         "commander": "^14.0.2",
         "zod": "^4.3.5",

--- a/packages/cli/src/__tests__/clack-mock.ts
+++ b/packages/cli/src/__tests__/clack-mock.ts
@@ -1,0 +1,45 @@
+import { mock } from "bun:test";
+
+const cancelSymbol = Symbol("clack-cancel");
+const confirmQueue: unknown[] = [];
+const selectCalls: unknown[] = [];
+const multiselectCalls: unknown[] = [];
+
+const confirmMock = mock(async () => confirmQueue.shift());
+const selectMock = mock(async (options: unknown) => {
+  selectCalls.push(options);
+  const typed = options as { options?: { value: unknown }[] };
+  return typed.options?.[0]?.value ?? "selected";
+});
+const multiselectMock = mock(async (options: unknown) => {
+  multiselectCalls.push(options);
+  const typed = options as { options?: { value: unknown }[] };
+  return typed.options?.map((item) => item.value) ?? [];
+});
+
+function queueConfirmResponse(value: unknown): void {
+  confirmQueue.push(value);
+}
+
+function resetClackMocks(): void {
+  confirmQueue.length = 0;
+  selectCalls.length = 0;
+  multiselectCalls.length = 0;
+  mock.clearAllMocks();
+}
+
+mock.module("@clack/prompts", () => ({
+  confirm: confirmMock,
+  select: selectMock,
+  multiselect: multiselectMock,
+  isCancel: (value: unknown) => value === cancelSymbol,
+}));
+
+export {
+  cancelSymbol,
+  confirmMock,
+  multiselectCalls,
+  queueConfirmResponse,
+  resetClackMocks,
+  selectCalls,
+};

--- a/packages/cli/src/__tests__/input.test.ts
+++ b/packages/cli/src/__tests__/input.test.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -21,23 +21,18 @@ import {
   parseRange,
   parseSortSpec,
 } from "../input.js";
+import {
+  cancelSymbol,
+  confirmMock,
+  queueConfirmResponse,
+  resetClackMocks,
+} from "./clack-mock.js";
 
 // =============================================================================
 // Test Utilities
 // =============================================================================
 
-const cancelSymbol = Symbol("clack-cancel");
-const confirmQueue: unknown[] = [];
-const confirmMock = mock(async () => confirmQueue.shift());
-
-function queueConfirmResponse(value: unknown): void {
-  confirmQueue.push(value);
-}
-
-mock.module("@clack/prompts", () => ({
-  confirm: confirmMock,
-  isCancel: (value: unknown) => value === cancelSymbol,
-}));
+// clack prompt mocks are provided by ./clack-mock.ts
 
 /**
  * Creates a temporary directory for test fixtures.
@@ -97,8 +92,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = originalEnv;
-  mock.clearAllMocks();
-  confirmQueue.length = 0;
+  resetClackMocks();
   Object.defineProperty(process.stdout, "isTTY", {
     value: originalIsTTY,
     writable: true,

--- a/packages/cli/src/__tests__/prompt-select-page-size.test.ts
+++ b/packages/cli/src/__tests__/prompt-select-page-size.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for select prompt page size mapping.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  multiselectCalls,
+  resetClackMocks,
+  selectCalls,
+} from "./clack-mock.js";
+
+const { promptMultiSelect, promptSelect } = await import("../prompt/select.js");
+
+beforeEach(() => {
+  resetClackMocks();
+});
+
+describe("promptSelect", () => {
+  test("maps pageSize to maxItems", async () => {
+    await promptSelect({
+      message: "Pick one",
+      options: [
+        { value: "one", label: "One" },
+        { value: "two", label: "Two" },
+      ],
+      pageSize: 4,
+    });
+
+    expect(selectCalls).toHaveLength(1);
+    const call = selectCalls[0] as { maxItems?: number };
+    expect(call.maxItems).toBe(4);
+  });
+});
+
+describe("promptMultiSelect", () => {
+  test("maps pageSize to maxItems", async () => {
+    await promptMultiSelect({
+      message: "Pick many",
+      options: [
+        { value: "one", label: "One" },
+        { value: "two", label: "Two" },
+      ],
+      pageSize: 6,
+    });
+
+    expect(multiselectCalls).toHaveLength(1);
+    const call = multiselectCalls[0] as { maxItems?: number };
+    expect(call.maxItems).toBe(6);
+  });
+});

--- a/packages/cli/src/prompt/select.ts
+++ b/packages/cli/src/prompt/select.ts
@@ -52,12 +52,15 @@ export async function promptSelect<T>(
   });
 
   // Build select options, excluding undefined values for exactOptionalPropertyTypes
-  const selectOptions: Parameters<typeof select>[0] = {
+  const selectOptions: Parameters<typeof select>[0] & { maxItems?: number } = {
     message: options.message,
     options: clackOptions as Parameters<typeof select>[0]["options"],
   };
   if (options.initialValue !== undefined) {
     selectOptions.initialValue = options.initialValue;
+  }
+  if (options.pageSize !== undefined) {
+    selectOptions.maxItems = options.pageSize;
   }
 
   const result = await select(selectOptions);
@@ -106,7 +109,9 @@ export async function promptMultiSelect<T>(
   });
 
   // Build multiselect options, excluding undefined values for exactOptionalPropertyTypes
-  const multiselectOptions: Parameters<typeof multiselect>[0] = {
+  const multiselectOptions: Parameters<typeof multiselect>[0] & {
+    maxItems?: number;
+  } = {
     message: options.message,
     options: clackOptions as Parameters<typeof multiselect>[0]["options"],
   };
@@ -115,6 +120,9 @@ export async function promptMultiSelect<T>(
   }
   if (options.required !== undefined) {
     multiselectOptions.required = options.required;
+  }
+  if (options.pageSize !== undefined) {
+    multiselectOptions.maxItems = options.pageSize;
   }
 
   const result = await multiselect(multiselectOptions);

--- a/packages/cli/src/prompt/types.ts
+++ b/packages/cli/src/prompt/types.ts
@@ -64,6 +64,8 @@ export interface SelectPromptOptions<T> {
   }>;
   /** Initial selected index */
   initialValue?: T;
+  /** Maximum number of items to display at once */
+  pageSize?: number;
 }
 
 /**
@@ -82,6 +84,8 @@ export interface MultiSelectPromptOptions<T> {
   initialValues?: T[];
   /** Require at least one selection */
   required?: boolean;
+  /** Maximum number of items to display at once */
+  pageSize?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add --json output mode for init/add/doctor and route output through output()/exitWithError()
- map prompt pageSize to clack maxItems
- add tests for prompt page size and console-free CLI actions

## Testing
- bun run test

Closes #248
Closes #242
