### PR TITLE
feat(kit): improve adoption package discovery and blast-radius planning

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -37,6 +37,9 @@ This creates a working CLI with:
 - Error handling with exit codes
 - XDG-compliant config loading
 
+`@outfitter/types` is optional. Install it when you need branded IDs or shared
+type utility helpers across packages.
+
 ## Tutorial: Build a CLI App
 
 CLIs are the fastest path to useful software. Build once, run anywhere, pipe to anything.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,10 @@ Each package has detailed API documentation. Stability labels indicate API matur
 ### Foundation (Stable)
 
 - [@outfitter/contracts](../packages/contracts/README.md) — Result/Error patterns, handler contract
-- [@outfitter/types](../packages/types/README.md) — Branded types, type utilities
+- [@outfitter/types](../packages/types/README.md) — Optional branded types, type utilities
+
+Adoption note: `@outfitter/types` is not a default dependency. Add it when you
+have concrete branded ID or shared utility adoption points.
 
 ### Runtime (Active)
 

--- a/plugins/kit/commands/adopt.md
+++ b/plugins/kit/commands/adopt.md
@@ -13,6 +13,9 @@ Target: $ARGUMENTS
 1. **Load Skills** — Use Skill tool to load `outfitter:context-management` for task persistence.
 2. **Init** — Delegate to **Plan subagent** with `kit:outfitter-init` to:
    - Scan codebase for adoption candidates (throws, console, paths, custom errors)
+   - Enumerate all published `@outfitter/*` packages (not just pattern-matched ones)
+   - Estimate caller blast radius for high-impact function conversions
+   - Keep `@outfitter/types` conditional unless clear adoption points exist
    - Assess scope and effort
    - Generate `.agents/plans/outfitter-init/` with scan results and staged plan
    - Return implementation strategy

--- a/plugins/kit/skills/outfitter-init/SKILL.md
+++ b/plugins/kit/skills/outfitter-init/SKILL.md
@@ -140,6 +140,11 @@ The script will refuse to run if a plan already exists (won't override).
 | 16+ throws | High effort — work through stages methodically |
 | Custom error classes | Map each to taxonomy (see `stages/errors.md`) |
 | High console count | Lots of logging to convert (see `stages/handlers.md`) |
+| Package Discovery table | Review all `@outfitter/*` options before installing |
+| High blast radius handlers | Split into caller-focused sub-phases before converting |
+
+`@outfitter/types` should be treated as **optional** unless the target project
+has clear branded-type or utility adoption points.
 
 ### Decision Point
 

--- a/plugins/kit/skills/outfitter-init/templates/SCAN.md
+++ b/plugins/kit/skills/outfitter-init/templates/SCAN.md
@@ -28,19 +28,29 @@
 | Documents | {{DOC_COUNT}} files | {{DOC_EFFORT}} |
 | Unknowns | {{UNKNOWN_COUNT}} items | Review required |
 
-## Dependencies to Add
+## Package Discovery
+
+Review all published `@outfitter/*` packages before deciding what to install.
+
+| Package | Purpose | Recommendation | Why |
+|---------|---------|----------------|-----|
+{{#each PACKAGE_RECOMMENDATIONS}}
+| `{{name}}` | {{purpose}} | **{{recommendation}}** | {{reason}} |
+{{/each}}
+
+Suggested first install set (adjust based on the table above):
 
 ```bash
 bun add @outfitter/contracts @outfitter/logging @outfitter/config
 ```
 
-Optional:
+Add transport/runtime packages as needed:
+
 ```bash
-bun add @outfitter/cli      # If building CLI
-bun add @outfitter/mcp      # If building MCP server
-bun add @outfitter/file-ops # If file operations with path security
-bun add @outfitter/daemon   # If building background services
+bun add @outfitter/cli @outfitter/mcp @outfitter/daemon @outfitter/file-ops @outfitter/testing
 ```
+
+Install `@outfitter/types` only when you have concrete branded type or utility adoption points.
 
 ## Migration Plan
 

--- a/plugins/kit/skills/outfitter-init/templates/stages/handlers.md
+++ b/plugins/kit/skills/outfitter-init/templates/stages/handlers.md
@@ -11,12 +11,13 @@ Convert functions with `throw` to handlers returning `Result<T, E>`.
 ## Handlers to Convert
 
 {{#each HANDLERS}}
-### {{this.name}}
+### {{name}}
 
-- **File:** `{{this.file}}:{{this.line}}`
-- **Current:** `{{this.signature}}`
-- **Throws:** {{this.throws}}
-- **Priority:** {{this.priority}}
+- **File:** `{{file}}:{{line}}`
+- **Current:** `{{signature}}`
+- **Throws:** {{throws}}
+- **Priority:** {{priority}}
+- **Blast Radius:** {{callerCount}} call sites across {{callerFiles}} files ({{blastRadius}})
 
 #### Conversion
 
@@ -27,11 +28,12 @@ Convert functions with `throw` to handlers returning `Result<T, E>`.
 - [ ] Replace `throw` with `Result.err()`
 - [ ] Add `createValidator()` for input
 - [ ] Update callers to use `isOk()` / `isErr()`
+- [ ] If blast radius is high, split into smaller caller-focused sub-phases
 - [ ] Add/update tests
 
 ```typescript
 // Target signature
-const {{this.name}}: Handler<{{this.inputType}}, {{this.outputType}}, {{this.errorType}}> = async (input, ctx) => {
+const {{name}}: Handler<{{inputType}}, {{outputType}}, {{errorType}}> = async (input, ctx) => {
   // ...
 };
 ```


### PR DESCRIPTION
## Summary
- Expand adoption planning to enumerate all published `@outfitter/*` packages during discovery
- Add caller blast-radius estimation for handler conversions so large cascades can be split early
- Update adoption guidance to treat `@outfitter/types` as optional/conditional by default
- Improve generated scan/stage output to include recommendation and blast-radius context

## Testing
- `bun run plugins/kit/skills/outfitter-init/scripts/scan.ts /tmp/outfitter-scan-smoke-3`
- `turbo run test` (pre-push hook)

Closes #247
Closes #224
Closes #244
