### PR TITLE
feat(config): add jsonc parsing and document mcp resource handlers

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -68,7 +68,7 @@ if (result.isOk()) {
 2. `$XDG_CONFIG_HOME/{appName}/config.{ext}`
 3. `~/.config/{appName}/config.{ext}`
 
-**File Format Preference:** `.toml` > `.yaml` > `.yml` > `.json` > `.json5`
+**File Format Preference:** `.toml` > `.yaml` > `.yml` > `.json` > `.jsonc` > `.json5`
 
 **Returns:** `Result<T, NotFoundError | ValidationError | ParseError>`
 
@@ -267,6 +267,7 @@ Higher precedence sources override lower ones. Nested objects are deep-merged.
 | `.toml` | smol-toml | Preferred for configuration |
 | `.yaml`, `.yml` | yaml | YAML anchors/aliases supported |
 | `.json` | JSON.parse | Strict parsing |
+| `.jsonc` | json5 | JSON with comments and trailing commas |
 | `.json5` | json5 | Comments and trailing commas allowed |
 
 ---

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -365,9 +365,9 @@ count = 42
   describe("search order", () => {
     it("searches config files in correct precedence order", async () => {
       // Expected search order:
-      // 1. $XDG_CONFIG_HOME/{appName}/config.{toml,yaml,json}
-      // 2. ~/.config/{appName}/config.{toml,yaml,json}
-      // 3. ./{appName}.config.{toml,yaml,json} (project-local)
+      // 1. $XDG_CONFIG_HOME/{appName}/config.{toml,yaml,yml,json,jsonc,json5}
+      // 2. ~/.config/{appName}/config.{toml,yaml,yml,json,jsonc,json5}
+      // 3. ./{appName}.config.{toml,yaml,yml,json,jsonc,json5} (project-local)
       const result = await loadConfig("ordered-app", TestConfigSchema);
 
       // Test verifies the precedence is respected
@@ -392,7 +392,7 @@ count = 42
 });
 
 // ============================================================================
-// Format Parsing Tests (9 tests)
+// Format Parsing Tests (10 tests)
 // ============================================================================
 
 describe("parseConfigFile()", () => {
@@ -532,6 +532,23 @@ server:
       const result = parseConfigFile(json5Content, "config.json5");
 
       expect(result.isOk()).toBe(true);
+    });
+
+    it("supports JSONC files with comments and trailing commas", () => {
+      const jsoncContent = `{
+  // jsonc comment
+  "server": {
+    "port": 3000,
+    "host": "localhost",
+  },
+}`;
+      const result = parseConfigFile(jsoncContent, "config.jsonc");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const parsed = result.unwrap();
+        expect(parsed.server.port).toBe(3000);
+      }
     });
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -344,6 +344,7 @@ function getExtension(filename: string): string {
  * - `.toml` - Parsed with smol-toml (preferred for config)
  * - `.yaml`, `.yml` - Parsed with yaml (merge key support enabled)
  * - `.json` - Parsed with strict JSON.parse
+ * - `.jsonc` - Parsed with json5 compatibility (comments/trailing commas)
  * - `.json5` - Parsed with json5 (comments and trailing commas allowed)
  *
  * @param content - Raw file content to parse
@@ -410,6 +411,7 @@ export function parseConfigFile(
         return Result.ok(parsed as Record<string, unknown>);
       }
 
+      case "jsonc":
       case "json5": {
         const parsed = JSON5.parse(content);
         return Result.ok(parsed as Record<string, unknown>);
@@ -556,7 +558,7 @@ export function resolveConfig<T>(
 // ============================================================================
 
 /** Supported config file extensions in preference order */
-const CONFIG_EXTENSIONS = ["toml", "yaml", "yml", "json", "json5"];
+const CONFIG_EXTENSIONS = ["toml", "yaml", "yml", "json", "jsonc", "json5"];
 
 /**
  * Options for the {@link loadConfig} function.
@@ -579,7 +581,7 @@ export interface LoadConfigOptions {
 
 /**
  * Find the first existing config file in the given directory.
- * Searches for config.{toml,yaml,yml,json,json5} in preference order.
+ * Searches for config.{toml,yaml,yml,json,jsonc,json5} in preference order.
  * @internal
  */
 function findConfigFile(dir: string): string | undefined {
@@ -622,7 +624,7 @@ function getDefaultSearchPaths(appName: string): string[] {
  * 2. `$XDG_CONFIG_HOME/{appName}/config.{ext}`
  * 3. `~/.config/{appName}/config.{ext}`
  *
- * File format preference: `.toml` > `.yaml` > `.yml` > `.json` > `.json5`
+ * File format preference: `.toml` > `.yaml` > `.yml` > `.json` > `.jsonc` > `.json5`
  *
  * @typeParam T - The configuration type (inferred from schema)
  * @param appName - Application name for XDG directory lookup


### PR DESCRIPTION
## Summary
- Add `.jsonc` support to `@outfitter/config` parsing and config file discovery preference order
- Add test coverage for JSONC parsing behavior
- Update `@outfitter/config` documentation for JSONC support
- Update `@outfitter/mcp` docs to show resource read handlers and resource/template server methods

## Testing
- `bun test packages/config/src/__tests__/config.test.ts`
- `turbo run test` (pre-push hook)

Closes #233
Closes #249
