### PR TITLE
feat(kit): add migration guide detection script

### DIFF
--- a/plugins/kit/scripts/__tests__/migration-guide.test.ts
+++ b/plugins/kit/scripts/__tests__/migration-guide.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  composeMigrationGuide,
+  detectVersions,
+  findMigrationDocs,
+  renderJSON,
+  renderMarkdown,
+} from "../migration-guide.js";
+
+// ---------------------------------------------------------------------------
+// detectVersions
+// ---------------------------------------------------------------------------
+
+describe("detectVersions", () => {
+  function createTempPkg(
+    deps: Record<string, string>,
+    devDeps?: Record<string, string>
+  ): string {
+    const dir = mkdtempSync(join(tmpdir(), "migration-test-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "test-project",
+        dependencies: deps,
+        devDependencies: devDeps ?? {},
+      })
+    );
+    return dir;
+  }
+
+  it("extracts @outfitter/* packages from dependencies", () => {
+    const dir = createTempPkg({
+      "@outfitter/contracts": "^0.1.0",
+      "@outfitter/cli": "~0.1.0",
+      zod: "^3.0.0",
+    });
+
+    const result = detectVersions(dir);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      name: "@outfitter/contracts",
+      version: "0.1.0",
+    });
+    expect(result[1]).toEqual({ name: "@outfitter/cli", version: "0.1.0" });
+
+    rmSync(dir, { recursive: true });
+  });
+
+  it("extracts from devDependencies too", () => {
+    const dir = createTempPkg(
+      { "@outfitter/contracts": "0.1.0" },
+      { "@outfitter/testing": "^0.1.0" }
+    );
+
+    const result = detectVersions(dir);
+
+    expect(result).toHaveLength(2);
+    const names = result.map((r) => r.name);
+    expect(names).toContain("@outfitter/contracts");
+    expect(names).toContain("@outfitter/testing");
+
+    rmSync(dir, { recursive: true });
+  });
+
+  it("sorts by dependency tier (foundation first)", () => {
+    const dir = createTempPkg({
+      "@outfitter/testing": "0.1.0",
+      "@outfitter/cli": "0.1.0",
+      "@outfitter/contracts": "0.1.0",
+      "@outfitter/types": "0.1.0",
+    });
+
+    const result = detectVersions(dir);
+    const names = result.map((r) => r.name);
+
+    expect(names).toEqual([
+      "@outfitter/contracts",
+      "@outfitter/types",
+      "@outfitter/cli",
+      "@outfitter/testing",
+    ]);
+
+    rmSync(dir, { recursive: true });
+  });
+
+  it("strips version range prefixes", () => {
+    const dir = createTempPkg({
+      "@outfitter/contracts": ">=0.2.0",
+      "@outfitter/cli": "~0.1.5",
+    });
+
+    const result = detectVersions(dir);
+
+    expect(result[0]?.version).toBe("0.2.0");
+    expect(result[1]?.version).toBe("0.1.5");
+
+    rmSync(dir, { recursive: true });
+  });
+
+  it("returns empty array when no package.json exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "migration-test-empty-"));
+    const result = detectVersions(dir);
+    expect(result).toEqual([]);
+    rmSync(dir, { recursive: true });
+  });
+
+  it("returns empty array when no @outfitter packages", () => {
+    const dir = createTempPkg({ zod: "^3.0.0", commander: "^14.0.0" });
+    const result = detectVersions(dir);
+    expect(result).toEqual([]);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMigrationDocs
+// ---------------------------------------------------------------------------
+
+describe("findMigrationDocs", () => {
+  it("finds migration docs for contracts from 0.1.0", () => {
+    const docs = findMigrationDocs("@outfitter/contracts", "0.1.0");
+
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+    expect(docs[0]?.package).toBe("@outfitter/contracts");
+    expect(docs[0]?.version).toBe("0.2.0");
+  });
+
+  it("returns empty when already at latest", () => {
+    const docs = findMigrationDocs("@outfitter/contracts", "0.2.0");
+    expect(docs).toEqual([]);
+  });
+
+  it("returns empty for unknown package", () => {
+    const docs = findMigrationDocs("@outfitter/nonexistent", "0.1.0");
+    expect(docs).toEqual([]);
+  });
+
+  it("parses breaking flag from frontmatter", () => {
+    const docs = findMigrationDocs("@outfitter/contracts", "0.1.0");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+    // Our 0.2.0 docs are non-breaking
+    expect(docs[0]?.breaking).toBe(false);
+  });
+
+  it("sorts docs by version ascending", () => {
+    // With only 0.2.0 docs, this verifies sorting works with single doc
+    const docs = findMigrationDocs("@outfitter/cli", "0.0.1");
+    expect(docs.length).toBeGreaterThanOrEqual(1);
+
+    for (let i = 1; i < docs.length; i++) {
+      expect(
+        Bun.semver.order(docs[i - 1]!.version, docs[i]!.version)
+      ).toBeLessThanOrEqual(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeMigrationGuide
+// ---------------------------------------------------------------------------
+
+describe("composeMigrationGuide", () => {
+  const installed = [
+    { name: "@outfitter/contracts", version: "0.1.0" },
+    { name: "@outfitter/cli", version: "0.1.0" },
+    { name: "@outfitter/config", version: "0.1.0" },
+  ];
+
+  it("composes guides for all installed packages", () => {
+    const guide = composeMigrationGuide(installed);
+
+    expect(guide.installed).toEqual(installed);
+    expect(guide.docs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("filters by package name", () => {
+    const guide = composeMigrationGuide(installed, "contracts");
+
+    expect(guide.docs.every((d) => d.package === "@outfitter/contracts")).toBe(
+      true
+    );
+  });
+
+  it("orders docs by version then tier", () => {
+    const guide = composeMigrationGuide(installed);
+
+    // All 0.2.0 docs should have contracts before cli
+    const contractsIdx = guide.docs.findIndex(
+      (d) => d.package === "@outfitter/contracts"
+    );
+    const cliIdx = guide.docs.findIndex((d) => d.package === "@outfitter/cli");
+
+    if (contractsIdx !== -1 && cliIdx !== -1) {
+      expect(contractsIdx).toBeLessThan(cliIdx);
+    }
+  });
+
+  it("returns empty docs for up-to-date packages", () => {
+    const upToDate = [
+      { name: "@outfitter/contracts", version: "0.2.0" },
+      { name: "@outfitter/cli", version: "0.2.0" },
+    ];
+
+    const guide = composeMigrationGuide(upToDate);
+    expect(guide.docs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderMarkdown
+// ---------------------------------------------------------------------------
+
+describe("renderMarkdown", () => {
+  it("renders installed packages table", () => {
+    const guide = composeMigrationGuide([
+      { name: "@outfitter/contracts", version: "0.1.0" },
+    ]);
+
+    const md = renderMarkdown(guide);
+
+    expect(md).toContain("# Migration Guide");
+    expect(md).toContain("@outfitter/contracts");
+    expect(md).toContain("0.1.0");
+  });
+
+  it("renders up-to-date message when no migrations", () => {
+    const guide: {
+      installed: { name: string; version: string }[];
+      docs: never[];
+    } = {
+      installed: [{ name: "@outfitter/contracts", version: "0.2.0" }],
+      docs: [],
+    };
+
+    const md = renderMarkdown(guide);
+    expect(md).toContain("All packages are up to date");
+  });
+
+  it("strips frontmatter from doc content", () => {
+    const guide = composeMigrationGuide([
+      { name: "@outfitter/contracts", version: "0.1.0" },
+    ]);
+
+    const md = renderMarkdown(guide);
+    expect(md).not.toContain("---\npackage:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderJSON
+// ---------------------------------------------------------------------------
+
+describe("renderJSON", () => {
+  it("produces valid JSON", () => {
+    const guide = composeMigrationGuide([
+      { name: "@outfitter/contracts", version: "0.1.0" },
+    ]);
+
+    const json = renderJSON(guide);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.installed).toBeDefined();
+    expect(parsed.migrations).toBeDefined();
+    expect(typeof parsed.totalMigrations).toBe("number");
+    expect(typeof parsed.hasBreaking).toBe("boolean");
+  });
+
+  it("includes migration metadata without full content", () => {
+    const guide = composeMigrationGuide([
+      { name: "@outfitter/contracts", version: "0.1.0" },
+    ]);
+
+    const json = renderJSON(guide);
+    const parsed = JSON.parse(json);
+
+    for (const m of parsed.migrations) {
+      expect(m.package).toBeDefined();
+      expect(m.version).toBeDefined();
+      expect(typeof m.breaking).toBe("boolean");
+      expect(m.filePath).toBeDefined();
+      // Content should not be in JSON output
+      expect(m.content).toBeUndefined();
+    }
+  });
+
+  it("reports hasBreaking correctly for non-breaking migrations", () => {
+    const guide = composeMigrationGuide([
+      { name: "@outfitter/contracts", version: "0.1.0" },
+    ]);
+
+    const parsed = JSON.parse(renderJSON(guide));
+    expect(parsed.hasBreaking).toBe(false);
+  });
+});

--- a/plugins/kit/scripts/migration-guide.ts
+++ b/plugins/kit/scripts/migration-guide.ts
@@ -1,0 +1,358 @@
+#!/usr/bin/env bun
+/**
+ * Migration guide composer for @outfitter/* packages.
+ *
+ * Detects installed @outfitter/* versions from package.json,
+ * finds relevant migration docs, and composes a sequenced guide.
+ *
+ * Usage:
+ *   bun migration-guide.ts [options]
+ *
+ * Options:
+ *   --cwd <path>      Working directory (default: process.cwd())
+ *   --package <name>  Filter to a specific package (e.g., "contracts")
+ *   --json            Output as JSON manifest instead of markdown
+ *   --help            Show this help message
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InstalledPackage {
+  name: string;
+  version: string;
+}
+
+interface MigrationDoc {
+  package: string;
+  version: string;
+  breaking: boolean;
+  filePath: string;
+  content: string;
+}
+
+interface MigrationGuide {
+  installed: InstalledPackage[];
+  docs: MigrationDoc[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Dependency tier ordering for migration sequencing. */
+const PACKAGE_TIER: Record<string, number> = {
+  contracts: 0,
+  types: 1,
+  cli: 10,
+  mcp: 11,
+  config: 12,
+  logging: 13,
+  "file-ops": 14,
+  state: 15,
+  index: 16,
+  daemon: 17,
+  testing: 18,
+  kit: 20,
+  tooling: 21,
+  outfitter: 30,
+};
+
+/** Resolve the migrations directory relative to this script. */
+const MIGRATIONS_DIR = resolve(import.meta.dir, "../shared/migrations");
+
+// ---------------------------------------------------------------------------
+// Core Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse package.json at `cwd` and extract @outfitter/* dependencies.
+ */
+export function detectVersions(cwd: string): InstalledPackage[] {
+  const pkgPath = join(cwd, "package.json");
+  let raw: string;
+  try {
+    raw = readFileSync(pkgPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  let pkg: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  try {
+    pkg = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+  const result: InstalledPackage[] = [];
+
+  for (const [name, version] of Object.entries(deps)) {
+    if (name.startsWith("@outfitter/")) {
+      // Handle workspace protocol: workspace:* → skip, workspace:^0.1.0 → extract version
+      if (version.startsWith("workspace:")) {
+        const wsVersion = version.slice("workspace:".length);
+        if (wsVersion === "*" || wsVersion === "~" || wsVersion === "^") {
+          continue;
+        }
+        // Strip range prefix from workspace version (e.g., "workspace:^0.1.0" → "0.1.0")
+        const wsClean = wsVersion.replace(/^[\^~>=<]+/, "");
+        try {
+          if (!Bun.semver.satisfies(wsClean, "*")) continue;
+        } catch {
+          continue;
+        }
+        result.push({ name, version: wsClean });
+        continue;
+      }
+
+      // Strip range prefixes (^, ~, >=, etc.) for comparison
+      const cleaned = version.replace(/^[\^~>=<]+/, "");
+
+      // Skip non-semver versions (file:, git+ssh:, etc.)
+      try {
+        if (!Bun.semver.satisfies(cleaned, "*")) continue;
+      } catch {
+        continue;
+      }
+
+      result.push({ name, version: cleaned });
+    }
+  }
+
+  // Sort by dependency tier
+  result.sort((a, b) => {
+    const aKey = a.name.replace("@outfitter/", "");
+    const bKey = b.name.replace("@outfitter/", "");
+    return (PACKAGE_TIER[aKey] ?? 99) - (PACKAGE_TIER[bKey] ?? 99);
+  });
+
+  return result;
+}
+
+/**
+ * Find migration docs for a package within a version range.
+ *
+ * Returns docs where the doc version is greater than `fromVersion`.
+ * If `toVersion` is provided, also filters to docs <= `toVersion`.
+ */
+export function findMigrationDocs(
+  pkg: string,
+  fromVersion: string,
+  toVersion?: string
+): MigrationDoc[] {
+  const shortName = pkg.replace("@outfitter/", "");
+  const glob = new Bun.Glob(`outfitter-${shortName}-*.md`);
+  const docs: MigrationDoc[] = [];
+
+  for (const entry of glob.scanSync({ cwd: MIGRATIONS_DIR })) {
+    // Extract version from filename: outfitter-contracts-0.2.0.md → 0.2.0
+    const match = entry.match(
+      new RegExp(`^outfitter-${shortName}-(\\d+\\.\\d+\\.\\d+)\\.md$`)
+    );
+    if (!match) continue;
+
+    const docVersion = match[1];
+
+    // Filter: doc version must be greater than current installed version
+    if (Bun.semver.order(docVersion, fromVersion) <= 0) continue;
+
+    // Filter: if toVersion specified, doc version must be <= toVersion
+    if (toVersion && Bun.semver.order(docVersion, toVersion) > 0) continue;
+
+    const filePath = join(MIGRATIONS_DIR, entry);
+    const content = readFileSync(filePath, "utf-8");
+
+    // Parse frontmatter
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    let breaking = false;
+    if (fmMatch) {
+      const breakingMatch = fmMatch[1].match(/breaking:\s*(true|false)/);
+      if (breakingMatch) {
+        breaking = breakingMatch[1] === "true";
+      }
+    }
+
+    docs.push({
+      package: pkg,
+      version: docVersion,
+      breaking,
+      filePath,
+      content,
+    });
+  }
+
+  // Sort by version ascending
+  docs.sort((a, b) => Bun.semver.order(a.version, b.version));
+
+  return docs;
+}
+
+/**
+ * Compose a migration guide from detection results.
+ *
+ * Groups docs by version (ascending), then within each version
+ * orders by dependency tier (foundation first).
+ */
+export function composeMigrationGuide(
+  installed: InstalledPackage[],
+  packageFilter?: string
+): MigrationGuide {
+  const allDocs: MigrationDoc[] = [];
+
+  for (const pkg of installed) {
+    if (packageFilter && !pkg.name.includes(packageFilter)) continue;
+
+    const docs = findMigrationDocs(pkg.name, pkg.version);
+    allDocs.push(...docs);
+  }
+
+  // Sort: version ascending, then package tier
+  allDocs.sort((a, b) => {
+    const versionCmp = Bun.semver.order(a.version, b.version);
+    if (versionCmp !== 0) return versionCmp;
+
+    const aKey = a.package.replace("@outfitter/", "");
+    const bKey = b.package.replace("@outfitter/", "");
+    return (PACKAGE_TIER[aKey] ?? 99) - (PACKAGE_TIER[bKey] ?? 99);
+  });
+
+  return { installed, docs: allDocs };
+}
+
+/**
+ * Render a migration guide as markdown.
+ */
+export function renderMarkdown(guide: MigrationGuide): string {
+  const lines: string[] = [];
+
+  lines.push("# Migration Guide\n");
+  lines.push("## Installed Packages\n");
+  lines.push("| Package | Version |");
+  lines.push("|---------|---------|");
+  for (const pkg of guide.installed) {
+    lines.push(`| ${pkg.name} | ${pkg.version} |`);
+  }
+  lines.push("");
+
+  if (guide.docs.length === 0) {
+    lines.push("All packages are up to date. No migrations available.\n");
+    return lines.join("\n");
+  }
+
+  lines.push(`## Available Migrations (${guide.docs.length})\n`);
+
+  const breakingCount = guide.docs.filter((d) => d.breaking).length;
+  if (breakingCount > 0) {
+    lines.push(
+      `**Warning:** ${breakingCount} migration(s) contain breaking changes.\n`
+    );
+  }
+
+  for (const doc of guide.docs) {
+    // Strip frontmatter from content
+    const contentBody = doc.content.replace(/^---\n[\s\S]*?\n---\n*/, "");
+    lines.push(contentBody.trim());
+    lines.push("\n---\n");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render a migration guide as JSON.
+ */
+export function renderJSON(guide: MigrationGuide): string {
+  return JSON.stringify(
+    {
+      installed: guide.installed,
+      migrations: guide.docs.map((d) => ({
+        package: d.package,
+        version: d.version,
+        breaking: d.breaking,
+        filePath: d.filePath,
+      })),
+      totalMigrations: guide.docs.length,
+      hasBreaking: guide.docs.some((d) => d.breaking),
+    },
+    null,
+    2
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI Entry Point
+// ---------------------------------------------------------------------------
+
+function printHelp(): void {
+  console.log(`Usage: bun migration-guide.ts [options]
+
+Detect installed @outfitter/* versions and compose migration guidance.
+
+Options:
+  --cwd <path>      Working directory (default: current directory)
+  --package <name>  Filter to a specific package (e.g., "contracts")
+  --json            Output as JSON manifest
+  --help            Show this help message`);
+}
+
+export function main(): void {
+  const { values } = parseArgs({
+    options: {
+      cwd: { type: "string", default: process.cwd() },
+      package: { type: "string" },
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const cwd = resolve(values.cwd ?? process.cwd());
+  const installed = detectVersions(cwd);
+
+  if (installed.length === 0) {
+    if (values.json) {
+      console.log(
+        JSON.stringify(
+          {
+            installed: [],
+            migrations: [],
+            totalMigrations: 0,
+            hasBreaking: false,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      console.log("No @outfitter/* packages found in package.json at:", cwd);
+    }
+    process.exit(0);
+  }
+
+  const guide = composeMigrationGuide(installed, values.package);
+
+  if (values.json) {
+    console.log(renderJSON(guide));
+  } else {
+    console.log(renderMarkdown(guide));
+  }
+}
+
+// Only run when executed directly (not when imported as a module)
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Create `plugins/kit/scripts/migration-guide.ts` — standalone script for detecting installed @outfitter/* versions and composing migration guidance
- Core functions: `detectVersions()`, `findMigrationDocs()`, `composeMigrationGuide()`, `renderMarkdown()`, `renderJSON()`
- CLI flags: `--cwd`, `--package` (filter), `--json` (structured output)
- Handles `workspace:*` protocol versions and range prefixes (`^`, `~`, `>=`)
- Orders output by semver version ascending, then by dependency tier (foundation → runtime → tooling)
- 21 tests covering version detection, doc discovery, ordering, JSON output, and edge cases

## Test plan

- [x] `bun test plugins/kit/scripts/__tests__/migration-guide.test.ts` — 21 pass
- [ ] `bun plugins/kit/scripts/migration-guide.ts --cwd <project-with-outfitter-deps>` produces correct markdown
- [ ] `--json` flag produces valid JSON manifest