### PR TITLE
fix(cli): default to human output mode for non-TTY

### DIFF
--- a/.changeset/fix-output-non-tty.md
+++ b/.changeset/fix-output-non-tty.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/cli": patch
+---
+
+Fix `output()` to default to human mode for non-TTY environments. Previously, non-TTY output (piped, subprocess) unexpectedly emitted JSON. Machine-readable output now requires explicit `--json` flag or `OUTFITTER_JSON=1` env var, per CLI conventions.

--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -433,7 +433,7 @@ const updateAction = defineAction({
     }
 
     await printUpdateResults(result.value, {
-      mode: outputMode,
+      ...(outputMode ? { mode: outputMode } : {}),
       guide: updateInput.guide,
       cwd: updateInput.cwd,
     });

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -183,16 +183,17 @@ describe("output() mode detection", () => {
     expect(captured.stdout).not.toContain('{"name":"test"}');
   });
 
-  test("uses json mode when stdout is not a TTY", async () => {
+  test("uses human mode when stdout is not a TTY (no implicit JSON)", async () => {
     setTTY({ stdout: false });
 
     const captured = await captureOutput(() => {
       output({ name: "test" });
     });
 
-    // Non-TTY should output JSON
-    const parsed = JSON.parse(captured.stdout.trim());
-    expect(parsed).toEqual({ name: "test" });
+    // Non-TTY defaults to human — machine output requires explicit --json
+    expect(captured.stdout).not.toContain('{"name":"test"}');
+    expect(captured.stdout).toContain("name");
+    expect(captured.stdout).toContain("test");
   });
 
   test("respects explicit mode option", async () => {
@@ -437,8 +438,6 @@ describe("output() human mode", () => {
 
 describe("exitWithError() error serialization (JSON mode)", () => {
   test("includes _tag field", async () => {
-    setTTY({ stdout: false, stderr: false });
-
     const error = createMockError(
       "ValidationError",
       "validation",
@@ -449,7 +448,7 @@ describe("exitWithError() error serialization (JSON mode)", () => {
     try {
       const captured = await captureOutput(() => {
         try {
-          exitWithError(error);
+          exitWithError(error, { mode: "json" });
         } catch {
           // Expected: process.exit mock throws
         }
@@ -465,8 +464,6 @@ describe("exitWithError() error serialization (JSON mode)", () => {
   });
 
   test("includes category field", async () => {
-    setTTY({ stdout: false, stderr: false });
-
     const error = createMockError(
       "NotFoundError",
       "not_found",
@@ -477,7 +474,7 @@ describe("exitWithError() error serialization (JSON mode)", () => {
     try {
       const captured = await captureOutput(() => {
         try {
-          exitWithError(error);
+          exitWithError(error, { mode: "json" });
         } catch {
           // Expected: process.exit mock throws
         }
@@ -493,8 +490,6 @@ describe("exitWithError() error serialization (JSON mode)", () => {
   });
 
   test("includes message field", async () => {
-    setTTY({ stdout: false, stderr: false });
-
     const error = createMockError(
       "ValidationError",
       "validation",
@@ -505,7 +500,7 @@ describe("exitWithError() error serialization (JSON mode)", () => {
     try {
       const captured = await captureOutput(() => {
         try {
-          exitWithError(error);
+          exitWithError(error, { mode: "json" });
         } catch {
           // Expected: process.exit mock throws
         }
@@ -521,8 +516,6 @@ describe("exitWithError() error serialization (JSON mode)", () => {
   });
 
   test("serializes context (non-sensitive fields)", async () => {
-    setTTY({ stdout: false, stderr: false });
-
     const error = createMockError(
       "ValidationError",
       "validation",
@@ -537,7 +530,7 @@ describe("exitWithError() error serialization (JSON mode)", () => {
     try {
       const captured = await captureOutput(() => {
         try {
-          exitWithError(error);
+          exitWithError(error, { mode: "json" });
         } catch {
           // Expected: process.exit mock throws
         }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -50,16 +50,12 @@ function writeWithBackpressure(
 /**
  * Detects output mode based on environment and options.
  *
- * Priority: explicit option > env var > TTY detection
+ * Priority: explicit option > env var > default (human)
+ *
+ * Per CLI conventions (clig.dev), human output is the default.
+ * Machine-readable output requires explicit opt-in via --json flag
+ * or OUTFITTER_JSON=1 environment variable.
  */
-function getStreamIsTTY(stream?: NodeJS.WritableStream): boolean | undefined {
-  if (!stream) return undefined;
-  if ("isTTY" in stream) {
-    return Boolean((stream as NodeJS.WriteStream).isTTY);
-  }
-  return undefined;
-}
-
 function detectMode(options?: OutputOptions): OutputMode {
   // Explicit mode takes highest priority
   if (options?.mode) {
@@ -73,10 +69,8 @@ function detectMode(options?: OutputOptions): OutputMode {
   if (envJson === "1") return "json";
   if (envJsonl === "0" || envJson === "0") return "human";
 
-  // Default: JSON for non-TTY, human for TTY
-  const streamIsTTY = getStreamIsTTY(options?.stream);
-  const isTTY = streamIsTTY ?? process.stdout.isTTY;
-  return isTTY ? "human" : "json";
+  // Default: always human. Use --json or OUTFITTER_JSON=1 for machine output.
+  return "human";
 }
 
 /**


### PR DESCRIPTION
## Summary

Per CLI conventions (clig.dev), human output should be the default regardless of TTY status. Machine-readable output requires explicit opt-in via `--json` flag or `OUTFITTER_JSON=1` env var.

Previously, `detectMode()` returned `"json"` for non-TTY environments, causing piped or subprocess output to unexpectedly emit JSON arrays instead of human-readable text.

## Changes

- `packages/cli/src/output.ts` — `detectMode()` now returns `"human"` by default. Removed unused `getStreamIsTTY()` helper.
- `packages/cli/src/__tests__/output.test.ts` — Updated non-TTY test to expect human mode. JSON serialization tests now use explicit `{ mode: "json" }`.
- `apps/outfitter/src/actions.ts` — Fixed `exactOptionalPropertyTypes` issue with optional `outputMode`.

## Test plan

- [x] 695 CLI tests pass
- [x] Typecheck clean across all packages
- [x] `outfitter update` outputs human-readable table (not JSON array) when piped
- [x] `outfitter update --json` still emits structured JSON

Closes OS-66

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)