### PR TITLE
feat(cli): add --json as global CLI option

### DIFF
--- a/.changeset/global-json-flag.md
+++ b/.changeset/global-json-flag.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/cli": minor
+---
+
+Add `--json` as a global CLI option, replacing per-command definitions. All commands now inherit `--json` automatically via `createCLI()`.

--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -124,11 +124,6 @@ const commonInitOptions: ActionCliOption[] = [
     description: "Alias for --local",
     defaultValue: false,
   },
-  {
-    flags: "--json",
-    description: "Output as JSON",
-    defaultValue: false,
-  },
 ];
 
 const templateOption: ActionCliOption = {
@@ -206,11 +201,15 @@ const demoAction = defineAction({
         defaultValue: false,
       },
     ],
-    mapInput: (context) => ({
-      section: context.args[0] as string | undefined,
-      list: Boolean(context.flags["list"]),
-      animate: Boolean(context.flags["animate"]),
-    }),
+    mapInput: (context) => {
+      // Consume --json so it's not silently ignored
+      resolveOutputMode(context.flags);
+      return {
+        section: context.args[0] as string | undefined,
+        list: Boolean(context.flags["list"]),
+        animate: Boolean(context.flags["animate"]),
+      };
+    },
   },
   handler: async (input) => {
     const result = await runDemo(input);
@@ -232,13 +231,6 @@ const doctorAction = defineAction({
   cli: {
     command: "doctor",
     description: "Validate environment and dependencies",
-    options: [
-      {
-        flags: "--json",
-        description: "Output as JSON",
-        defaultValue: false,
-      },
-    ],
     mapInput: (context) => {
       const outputMode = resolveOutputMode(context.flags);
       return {
@@ -290,11 +282,6 @@ const addAction = defineAction({
         description: "Show what would be added without making changes",
         defaultValue: false,
       },
-      {
-        flags: "--json",
-        description: "Output as JSON",
-        defaultValue: false,
-      },
     ],
     mapInput: (context) => {
       const outputMode = resolveOutputMode(context.flags);
@@ -337,13 +324,6 @@ const listBlocksAction = defineAction({
     group: "add",
     command: "list",
     description: "List available blocks",
-    options: [
-      {
-        flags: "--json",
-        description: "Output as JSON",
-        defaultValue: false,
-      },
-    ],
     mapInput: (context) => {
       const outputMode = resolveOutputMode(context.flags);
       return {
@@ -402,11 +382,6 @@ const updateAction = defineAction({
       {
         flags: "--guide",
         description: "Show migration instructions for available updates",
-        defaultValue: false,
-      },
-      {
-        flags: "--json",
-        description: "Output as JSON",
         defaultValue: false,
       },
     ],

--- a/apps/outfitter/src/commands/init.ts
+++ b/apps/outfitter/src/commands/init.ts
@@ -788,12 +788,12 @@ export function initCommand(program: Command): void {
       .option("-f, --force", "Overwrite existing files", false)
       .option("--local", "Use workspace:* for @outfitter dependencies", false)
       .option("--workspace", "Alias for --local", false)
-      .option("--json", "Output as JSON", false)
       .option(
         "--with <blocks>",
         "Tooling to add (comma-separated: scaffolding, claude, biome, lefthook, bootstrap)"
       )
-      .option("--no-tooling", "Skip tooling setup");
+      .option("--no-tooling", "Skip tooling setup")
+      .option("--json", "Output as JSON", false);
 
   const resolveOutputMode = (
     flags: InitCommandFlags

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,6 +54,9 @@ export function createCLI(config: CLIConfig): CLI {
     program.description(config.description);
   }
 
+  // Global --json flag available to all commands
+  program.option("--json", "Output as JSON", false);
+
   const exit = config.onExit ?? ((code: number): never => process.exit(code));
 
   program.exitOverride((error) => {


### PR DESCRIPTION
## Summary

Move `--json` from per-command option to global program option in `createCLI()`. All commands inherit it via Commander's `optsWithGlobals()`.

Removes 5 duplicate `--json` option definitions from outfitter actions. The flag now appears in top-level `--help` output, making it discoverable for agents and scripts.

## Changes

- `packages/cli/src/cli.ts` — Add `--json` as global option on the Commander program
- `apps/outfitter/src/actions.ts` — Remove 5 per-command `--json` option definitions

## Test plan

- [x] All CLI tests pass (695/695)
- [x] Typecheck clean
- [x] `outfitter --help` shows `--json` as global option
- [x] `outfitter update --json` works via global flag

Closes OS-67

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)