### PR TITLE
feat(mcp): integrate environment profiles for default log level

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "apps/outfitter": {
       "name": "outfitter",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "outfitter": "./dist/cli.js",
         "out": "./dist/cli.js",
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "@outfitter/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "@outfitter/config": "workspace:*",
@@ -76,7 +76,7 @@
     },
     "packages/config": {
       "name": "@outfitter/config",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -89,7 +89,7 @@
     },
     "packages/contracts": {
       "name": "@outfitter/contracts",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "better-result": "^2.5.0",
         "zod": "^4.3.5",
@@ -101,7 +101,7 @@
     },
     "packages/daemon": {
       "name": "@outfitter/daemon",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/file-ops": {
       "name": "@outfitter/file-ops",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -126,7 +126,7 @@
     },
     "packages/index": {
       "name": "@outfitter/index",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -138,7 +138,7 @@
     },
     "packages/kit": {
       "name": "@outfitter/kit",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.8.0",
@@ -174,7 +174,7 @@
     },
     "packages/logging": {
       "name": "@outfitter/logging",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@logtape/logtape": "^2.0.0",
         "@outfitter/contracts": "workspace:*",
@@ -186,9 +186,10 @@
     },
     "packages/mcp": {
       "name": "@outfitter/mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "@outfitter/config": "workspace:*",
         "@outfitter/contracts": "workspace:*",
         "@outfitter/logging": "workspace:*",
         "zod": "^4.3.5",
@@ -200,7 +201,7 @@
     },
     "packages/state": {
       "name": "@outfitter/state",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -212,7 +213,7 @@
     },
     "packages/testing": {
       "name": "@outfitter/testing",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/mcp": "workspace:*",
@@ -225,7 +226,7 @@
     },
     "packages/tooling": {
       "name": "@outfitter/tooling",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "tooling": "./dist/cli/index.js",
       },
@@ -251,7 +252,7 @@
     },
     "packages/types": {
       "name": "@outfitter/types",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "better-result": "^2.5.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@outfitter/config": "workspace:*",
     "@outfitter/contracts": "workspace:*",
     "@outfitter/logging": "workspace:*",
     "zod": "^4.3.5"

--- a/packages/mcp/src/__tests__/environment-integration.test.ts
+++ b/packages/mcp/src/__tests__/environment-integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for MCP environment profile integration (OS-71 Phase 2)
+ *
+ * Verifies the precedence chain for default log level:
+ * OUTFITTER_LOG_LEVEL > options.defaultLogLevel > environment profile > null
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createMcpServer } from "../index.js";
+
+describe("MCP Environment Integration", () => {
+  let originalEnv: string | undefined;
+  let originalLogLevel: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env["OUTFITTER_ENV"];
+    originalLogLevel = process.env["OUTFITTER_LOG_LEVEL"];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["OUTFITTER_ENV"];
+    } else {
+      process.env["OUTFITTER_ENV"] = originalEnv;
+    }
+    if (originalLogLevel === undefined) {
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+    } else {
+      process.env["OUTFITTER_LOG_LEVEL"] = originalLogLevel;
+    }
+  });
+
+  function createServerWithMock(options?: { defaultLogLevel?: string | null }) {
+    const server = createMcpServer({
+      name: "test-server",
+      version: "1.0.0",
+      ...options,
+    });
+
+    const sentMessages: unknown[] = [];
+    const mockSdkServer = {
+      sendLoggingMessage: (params: unknown) => {
+        sentMessages.push(params);
+        return Promise.resolve();
+      },
+      sendToolListChanged: () => Promise.resolve(),
+      sendResourceListChanged: () => Promise.resolve(),
+      sendPromptListChanged: () => Promise.resolve(),
+    };
+
+    server.bindSdkServer?.(mockSdkServer);
+    return { server, sentMessages };
+  }
+
+  describe("default log level precedence", () => {
+    it("defaults to null in production (no forwarding)", () => {
+      delete process.env["OUTFITTER_ENV"];
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock();
+
+      server.sendLogMessage("error", "should not forward");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    it("uses environment profile when OUTFITTER_ENV is set", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock();
+
+      // Development profile defaults to debug — should forward all
+      server.sendLogMessage("debug", "dev debug message");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("options.defaultLogLevel overrides environment profile", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      // Development profile would give "debug", but options says "error"
+      const { server, sentMessages } = createServerWithMock({
+        defaultLogLevel: "error",
+      });
+
+      server.sendLogMessage("debug", "should be filtered");
+      server.sendLogMessage("error", "should pass");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("OUTFITTER_LOG_LEVEL overrides options.defaultLogLevel", () => {
+      process.env["OUTFITTER_ENV"] = "production";
+      process.env["OUTFITTER_LOG_LEVEL"] = "warning";
+
+      // Options says "error" but env var says "warning"
+      const { server, sentMessages } = createServerWithMock({
+        defaultLogLevel: "error",
+      });
+
+      server.sendLogMessage("warning", "should pass via env var");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("null defaultLogLevel disables forwarding even in development", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock({
+        defaultLogLevel: null,
+      });
+
+      server.sendLogMessage("debug", "should not forward");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    it("ignores invalid OUTFITTER_LOG_LEVEL values", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      process.env["OUTFITTER_LOG_LEVEL"] = "verbose";
+
+      // Invalid env var should fall through to options, then profile
+      const { server, sentMessages } = createServerWithMock();
+
+      // Falls through to development profile (debug)
+      server.sendLogMessage("debug", "should forward via profile");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("client setLogLevel overrides everything", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock();
+
+      // Development default is debug, but client says error
+      server.setLogLevel?.("error");
+      server.sendLogMessage("debug", "should be filtered");
+      server.sendLogMessage("error", "should pass");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("rebind resets to computed default, not null", () => {
+      process.env["OUTFITTER_ENV"] = "development";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock();
+
+      // Client overrides to error
+      server.setLogLevel?.("error");
+
+      // Rebind — should reset to development profile default (debug)
+      const newMock = {
+        sendLoggingMessage: (params: unknown) => {
+          sentMessages.push(params);
+          return Promise.resolve();
+        },
+        sendToolListChanged: () => Promise.resolve(),
+        sendResourceListChanged: () => Promise.resolve(),
+        sendPromptListChanged: () => Promise.resolve(),
+      };
+      server.bindSdkServer?.(newMock);
+
+      server.sendLogMessage("debug", "should forward at dev default");
+      expect(sentMessages).toHaveLength(1);
+    });
+
+    it("test environment defaults to no forwarding", () => {
+      process.env["OUTFITTER_ENV"] = "test";
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+
+      const { server, sentMessages } = createServerWithMock();
+
+      server.sendLogMessage("error", "should not forward in test");
+      expect(sentMessages).toHaveLength(0);
+    });
+  });
+});

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -61,6 +61,20 @@ export interface McpServerOptions {
    * If not provided, a no-op logger is used.
    */
   logger?: Logger;
+
+  /**
+   * Default MCP log level for client-facing log forwarding.
+   *
+   * Precedence (highest wins):
+   * 1. `OUTFITTER_LOG_LEVEL` environment variable
+   * 2. This option
+   * 3. Environment profile (`OUTFITTER_ENV`)
+   * 4. `null` (no forwarding until client opts in)
+   *
+   * Set to `null` to explicitly disable forwarding regardless of environment.
+   * The MCP client can always override via `logging/setLevel`.
+   */
+  defaultLogLevel?: import("./logging.js").McpLogLevel | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `defaultLogLevel` option to `McpServerOptions` for explicit log level control
- Implement precedence-based log level resolution: `OUTFITTER_LOG_LEVEL` env var > `options.defaultLogLevel` > `OUTFITTER_ENV` profile > `null`
- Add `@outfitter/config` dependency for environment profile reading
- Rebind resets to computed default (not hardcoded `null`)

Phase 2 of OS-71 (unified environment profiles). Stacked on #273 and #274.

## Test plan

- [x] 9 new tests covering full precedence chain
- [x] All 128 MCP tests pass
- [x] Full monorepo test suite green (29 tasks)
- [x] Typecheck clean

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)