### PR TITLE
feat(logging,cli): integrate environment profiles for log level and verbose defaults

### DIFF
--- a/.changeset/environment-profiles.md
+++ b/.changeset/environment-profiles.md
@@ -1,0 +1,16 @@
+---
+"@outfitter/config": minor
+"@outfitter/mcp": minor
+"@outfitter/logging": minor
+"@outfitter/cli": minor
+---
+
+Add unified environment profiles (`OUTFITTER_ENV`) for cross-package defaults.
+
+**@outfitter/config:** New `getEnvironment()` and `getEnvironmentDefaults()` for reading environment profiles (development/production/test).
+
+**@outfitter/mcp:** Add `defaultLogLevel` option to `McpServerOptions` with precedence-based resolution: `OUTFITTER_LOG_LEVEL` > options > environment profile > null. Also adds `sendLogMessage()` for server-to-client log forwarding.
+
+**@outfitter/logging:** New `resolveLogLevel()` utility with precedence: `OUTFITTER_LOG_LEVEL` > explicit level > environment profile > "info".
+
+**@outfitter/cli:** New `resolveVerbose()` utility with precedence: `OUTFITTER_VERBOSE` > explicit flag > environment profile > false.

--- a/bun.lock
+++ b/bun.lock
@@ -177,6 +177,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@logtape/logtape": "^2.0.0",
+        "@outfitter/config": "workspace:*",
         "@outfitter/contracts": "workspace:*",
       },
       "devDependencies": {

--- a/packages/cli/src/__tests__/verbose.test.ts
+++ b/packages/cli/src/__tests__/verbose.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for resolveVerbose() environment integration (OS-71 Phase 3)
+ *
+ * Verifies the precedence chain:
+ * OUTFITTER_VERBOSE > explicit option > environment profile > false
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resolveVerbose } from "../output.js";
+
+describe("resolveVerbose()", () => {
+  let originalEnv: string | undefined;
+  let originalVerbose: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env["OUTFITTER_ENV"];
+    originalVerbose = process.env["OUTFITTER_VERBOSE"];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["OUTFITTER_ENV"];
+    } else {
+      process.env["OUTFITTER_ENV"] = originalEnv;
+    }
+    if (originalVerbose === undefined) {
+      delete process.env["OUTFITTER_VERBOSE"];
+    } else {
+      process.env["OUTFITTER_VERBOSE"] = originalVerbose;
+    }
+  });
+
+  it("defaults to false in production", () => {
+    delete process.env["OUTFITTER_ENV"];
+    delete process.env["OUTFITTER_VERBOSE"];
+
+    expect(resolveVerbose()).toBe(false);
+  });
+
+  it("uses explicit value when provided", () => {
+    delete process.env["OUTFITTER_ENV"];
+    delete process.env["OUTFITTER_VERBOSE"];
+
+    expect(resolveVerbose(true)).toBe(true);
+    expect(resolveVerbose(false)).toBe(false);
+  });
+
+  it("uses environment profile when no explicit value", () => {
+    process.env["OUTFITTER_ENV"] = "development";
+    delete process.env["OUTFITTER_VERBOSE"];
+
+    expect(resolveVerbose()).toBe(true);
+  });
+
+  it("explicit value overrides environment profile", () => {
+    process.env["OUTFITTER_ENV"] = "development";
+    delete process.env["OUTFITTER_VERBOSE"];
+
+    expect(resolveVerbose(false)).toBe(false);
+  });
+
+  it("OUTFITTER_VERBOSE=1 overrides explicit value", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_VERBOSE"] = "1";
+
+    expect(resolveVerbose(false)).toBe(true);
+  });
+
+  it("OUTFITTER_VERBOSE=0 overrides environment profile", () => {
+    process.env["OUTFITTER_ENV"] = "development";
+    process.env["OUTFITTER_VERBOSE"] = "0";
+
+    expect(resolveVerbose()).toBe(false);
+  });
+
+  it("ignores invalid OUTFITTER_VERBOSE values", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_VERBOSE"] = "yes";
+
+    // Invalid value falls through to explicit or profile or default
+    expect(resolveVerbose()).toBe(false);
+  });
+
+  it("test environment defaults to non-verbose", () => {
+    process.env["OUTFITTER_ENV"] = "test";
+    delete process.env["OUTFITTER_VERBOSE"];
+
+    expect(resolveVerbose()).toBe(false);
+  });
+});

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -27,6 +27,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@outfitter/config": "workspace:*",
     "@outfitter/contracts": "workspace:*",
     "@logtape/logtape": "^2.0.0"
   },

--- a/packages/logging/src/__tests__/resolve-log-level.test.ts
+++ b/packages/logging/src/__tests__/resolve-log-level.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for resolveLogLevel() environment integration (OS-71 Phase 3)
+ *
+ * Verifies the precedence chain:
+ * OUTFITTER_LOG_LEVEL > explicit level > environment profile > "info"
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resolveLogLevel } from "../index.js";
+
+describe("resolveLogLevel()", () => {
+  let originalEnv: string | undefined;
+  let originalLogLevel: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env["OUTFITTER_ENV"];
+    originalLogLevel = process.env["OUTFITTER_LOG_LEVEL"];
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env["OUTFITTER_ENV"];
+    } else {
+      process.env["OUTFITTER_ENV"] = originalEnv;
+    }
+    if (originalLogLevel === undefined) {
+      delete process.env["OUTFITTER_LOG_LEVEL"];
+    } else {
+      process.env["OUTFITTER_LOG_LEVEL"] = originalLogLevel;
+    }
+  });
+
+  it("defaults to info when nothing is configured", () => {
+    delete process.env["OUTFITTER_ENV"];
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    expect(resolveLogLevel()).toBe("info");
+  });
+
+  it("uses explicit level when provided", () => {
+    delete process.env["OUTFITTER_ENV"];
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    expect(resolveLogLevel("debug")).toBe("debug");
+    expect(resolveLogLevel("error")).toBe("error");
+  });
+
+  it("uses environment profile when no explicit level", () => {
+    process.env["OUTFITTER_ENV"] = "development";
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    expect(resolveLogLevel()).toBe("debug");
+  });
+
+  it("explicit level overrides environment profile", () => {
+    process.env["OUTFITTER_ENV"] = "development";
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    expect(resolveLogLevel("error")).toBe("error");
+  });
+
+  it("OUTFITTER_LOG_LEVEL overrides explicit level", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_LOG_LEVEL"] = "debug";
+
+    expect(resolveLogLevel("error")).toBe("debug");
+  });
+
+  it("OUTFITTER_LOG_LEVEL overrides environment profile", () => {
+    process.env["OUTFITTER_ENV"] = "production";
+    process.env["OUTFITTER_LOG_LEVEL"] = "debug";
+
+    expect(resolveLogLevel()).toBe("debug");
+  });
+
+  it("maps warning to warn (MCP to logging convention)", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_LOG_LEVEL"] = "warning";
+
+    expect(resolveLogLevel()).toBe("warn");
+  });
+
+  it("maps emergency to fatal (MCP to logging convention)", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_LOG_LEVEL"] = "emergency";
+
+    expect(resolveLogLevel()).toBe("fatal");
+  });
+
+  it("ignores invalid OUTFITTER_LOG_LEVEL values", () => {
+    delete process.env["OUTFITTER_ENV"];
+    process.env["OUTFITTER_LOG_LEVEL"] = "verbose";
+
+    expect(resolveLogLevel()).toBe("info");
+  });
+
+  it("production environment defaults to info", () => {
+    process.env["OUTFITTER_ENV"] = "production";
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    // Production profile has logLevel: null → falls through to "info"
+    expect(resolveLogLevel()).toBe("info");
+  });
+
+  it("test environment defaults to info", () => {
+    process.env["OUTFITTER_ENV"] = "test";
+    delete process.env["OUTFITTER_LOG_LEVEL"];
+
+    // Test profile has logLevel: null → falls through to "info"
+    expect(resolveLogLevel()).toBe("info");
+  });
+});


### PR DESCRIPTION
## Summary

**Logging (`@outfitter/logging`):**
- Add `resolveLogLevel()` utility with precedence: `OUTFITTER_LOG_LEVEL` > explicit level > `OUTFITTER_ENV` profile > `"info"`
- Maps MCP-style levels (`warning` → `warn`, `emergency` → `fatal`) for cross-package consistency
- Add `@outfitter/config` dependency

**CLI (`@outfitter/cli`):**
- Add `resolveVerbose()` utility with precedence: `OUTFITTER_VERBOSE` > explicit flag > `OUTFITTER_ENV` profile > `false`

Phase 3 of OS-71 (unified environment profiles). Stacked on #273, #274, #275.

## Test plan

- [x] 11 new tests for `resolveLogLevel()` covering full precedence chain and level mapping
- [x] 8 new tests for `resolveVerbose()` covering full precedence chain
- [x] All 75 logging tests pass
- [x] All 703 CLI tests pass
- [x] Full monorepo suite green (29 tasks)
- [x] Typecheck clean

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)