### PR TITLE
fix(mcp): collapse nested if to satisfy style/useCollapsedIf lint rule

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -128,15 +128,14 @@ function resolveDefaultLogLevel(options: McpServerOptions): McpLogLevel | null {
   }
 
   // 2. options.defaultLogLevel (validated)
-  if (options.defaultLogLevel !== undefined) {
-    if (
-      options.defaultLogLevel === null ||
-      VALID_MCP_LOG_LEVELS.has(options.defaultLogLevel)
-    ) {
-      return options.defaultLogLevel;
-    }
-    // Invalid value — fall through to profile
+  if (
+    options.defaultLogLevel !== undefined &&
+    (options.defaultLogLevel === null ||
+      VALID_MCP_LOG_LEVELS.has(options.defaultLogLevel))
+  ) {
+    return options.defaultLogLevel;
   }
+  // Invalid defaultLogLevel values fall through to profile
 
   // 3. Environment profile (map from config convention to MCP convention)
   const env = getEnvironment();


### PR DESCRIPTION
## Summary

- Collapse nested `if` in `resolveDefaultLogLevel()` to satisfy Biome's `style/useCollapsedIf` rule
- This was causing CI lint failures on `main` after the environment profiles stack merged (#274–#277)

## Test plan

- [x] `bun run check` passes (0 lint errors)
- [x] `bun test` in `packages/mcp` passes (128 tests)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)