### PR TITLE
feat(contracts): add backend-agnostic logger factory contract

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,16 +15,28 @@
         "default": "./dist/validation.js"
       }
     },
-    ".": {
+    "./result": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/result/index.d.ts",
+        "default": "./dist/result/index.js"
       }
     },
     "./actions": {
       "import": {
         "types": "./dist/actions.d.ts",
         "default": "./dist/actions.js"
+      }
+    },
+    "./redactor": {
+      "import": {
+        "types": "./dist/redactor.d.ts",
+        "default": "./dist/redactor.js"
+      }
+    },
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     },
     "./handler": {
@@ -39,16 +51,16 @@
         "default": "./dist/recovery.js"
       }
     },
+    "./logging": {
+      "import": {
+        "types": "./dist/logging.d.ts",
+        "default": "./dist/logging.js"
+      }
+    },
     "./assert": {
       "import": {
         "types": "./dist/assert/index.d.ts",
         "default": "./dist/assert/index.js"
-      }
-    },
-    "./result": {
-      "import": {
-        "types": "./dist/result/index.d.ts",
-        "default": "./dist/result/index.js"
       }
     },
     "./result/utilities": {
@@ -79,12 +91,6 @@
       "import": {
         "types": "./dist/serialization.d.ts",
         "default": "./dist/serialization.js"
-      }
-    },
-    "./redactor": {
-      "import": {
-        "types": "./dist/redactor.d.ts",
-        "default": "./dist/redactor.js"
       }
     },
     "./errors": {

--- a/packages/contracts/src/__tests__/logging-contract.test.ts
+++ b/packages/contracts/src/__tests__/logging-contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createLoggerFactory,
+  type Logger,
+  type LoggerAdapter,
+  type LoggerFactoryConfig,
+} from "../logging.js";
+
+interface TestBackendOptions {
+  transport: "console" | "json";
+  redactionEnabled: boolean;
+}
+
+describe("logger factory contract", () => {
+  it("creates loggers through the provided adapter", () => {
+    let observedConfig: LoggerFactoryConfig<TestBackendOptions> | undefined;
+    const logger = createMockLogger();
+
+    const adapter: LoggerAdapter<TestBackendOptions> = {
+      createLogger(config) {
+        observedConfig = config;
+        return logger;
+      },
+    };
+
+    const factory = createLoggerFactory(adapter);
+    const created = factory.createLogger({
+      name: "test-service",
+      level: "debug",
+      context: { requestId: "req-1" },
+      backend: { transport: "console", redactionEnabled: true },
+    });
+
+    expect(created).toBe(logger);
+    expect(observedConfig).toEqual({
+      name: "test-service",
+      level: "debug",
+      context: { requestId: "req-1" },
+      backend: { transport: "console", redactionEnabled: true },
+    });
+  });
+
+  it("supports optional adapter flush lifecycle", async () => {
+    let flushed = false;
+
+    const factory = createLoggerFactory<TestBackendOptions>({
+      createLogger: () => createMockLogger(),
+      async flush() {
+        flushed = true;
+      },
+    });
+
+    await factory.flush();
+    expect(flushed).toBe(true);
+  });
+
+  it("treats missing adapter flush as a no-op", async () => {
+    const factory = createLoggerFactory<TestBackendOptions>({
+      createLogger: () => createMockLogger(),
+    });
+
+    await expect(factory.flush()).resolves.toBeUndefined();
+  });
+});
+
+function createMockLogger(): Logger {
+  const createMethod = (): Logger["debug"] => {
+    function method(
+      _message: string,
+      _metadata?: Record<string, unknown>
+    ): void;
+    function method(
+      _metadata: Record<string, unknown>,
+      _message: string
+    ): never;
+    function method(
+      _messageOrMetadata: string | Record<string, unknown>,
+      _metadataOrMessage?: Record<string, unknown> | string
+    ): void {
+      return;
+    }
+
+    return method;
+  };
+
+  const createLogger = (): Logger => ({
+    trace: createMethod(),
+    debug: createMethod(),
+    info: createMethod(),
+    warn: createMethod(),
+    error: createMethod(),
+    fatal: createMethod(),
+    child(_context: Record<string, unknown>): Logger {
+      return createLogger();
+    },
+  });
+
+  return createLogger();
+}

--- a/packages/contracts/src/handler.ts
+++ b/packages/contracts/src/handler.ts
@@ -1,48 +1,11 @@
 import type { Result } from "better-result";
 import type { OutfitterError } from "./errors.js";
+import type { Logger } from "./logging.js";
 
 /**
- * Logger interface for handler context.
- * Implementations provided by @outfitter/logging.
- *
- * All log methods accept an optional context object that will be merged
- * with any context inherited from parent loggers created via `child()`.
+ * Re-export logger contract so existing imports from handler remain valid.
  */
-export interface Logger {
-  trace(message: string, metadata?: Record<string, unknown>): void;
-  trace(metadata: Record<string, unknown>, message: string): never;
-  debug(message: string, metadata?: Record<string, unknown>): void;
-  debug(metadata: Record<string, unknown>, message: string): never;
-  info(message: string, metadata?: Record<string, unknown>): void;
-  info(metadata: Record<string, unknown>, message: string): never;
-  warn(message: string, metadata?: Record<string, unknown>): void;
-  warn(metadata: Record<string, unknown>, message: string): never;
-  error(message: string, metadata?: Record<string, unknown>): void;
-  error(metadata: Record<string, unknown>, message: string): never;
-  fatal(message: string, metadata?: Record<string, unknown>): void;
-  fatal(metadata: Record<string, unknown>, message: string): never;
-
-  /**
-   * Creates a child logger with additional context.
-   *
-   * Context from the child is merged with the parent's context,
-   * with child context taking precedence for duplicate keys.
-   * Child loggers are composable (can create nested children).
-   *
-   * @param context - Additional context to include in all log messages
-   * @returns A new Logger instance with the merged context
-   *
-   * @example
-   * ```typescript
-   * const requestLogger = ctx.logger.child({ requestId: ctx.requestId });
-   * requestLogger.info("Processing request"); // includes requestId
-   *
-   * const opLogger = requestLogger.child({ operation: "create" });
-   * opLogger.debug("Starting"); // includes requestId + operation
-   * ```
-   */
-  child(context: Record<string, unknown>): Logger;
-}
+export type { Logger } from "./logging.js";
 
 /**
  * Resolved configuration interface.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -118,10 +118,20 @@ export {
 export type {
   Handler,
   HandlerContext,
-  Logger,
   ResolvedConfig,
   SyncHandler,
 } from "./handler.js";
+export type {
+  Logger,
+  LoggerAdapter,
+  LoggerFactory,
+  LoggerFactoryConfig,
+  LogLevel,
+  LogMetadata,
+  LogMethod,
+} from "./logging.js";
+// Logging contracts
+export { createLoggerFactory } from "./logging.js";
 // Recovery heuristics
 export {
   type BackoffOptions,

--- a/packages/contracts/src/logging.ts
+++ b/packages/contracts/src/logging.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared logging contracts for backend-agnostic logger integration.
+ *
+ * The `Logger` interface is the minimal surface required by handler contexts.
+ * `LoggerAdapter` and `createLoggerFactory` allow runtime packages to plug in
+ * backend-specific implementations while keeping transports backend-agnostic.
+ */
+
+/**
+ * Log levels ordered from least to most severe.
+ *
+ * The special `silent` level disables logging output.
+ */
+export type LogLevel =
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal"
+  | "silent";
+
+/** Structured metadata attached to log messages. */
+export type LogMetadata = Record<string, unknown>;
+
+/**
+ * Message-first logger method with metadata-first overload for strict misuse
+ * detection in TypeScript. Calling with metadata first intentionally resolves to
+ * `never` for compile-time feedback.
+ */
+export interface LogMethod {
+  (message: string, metadata?: LogMetadata): void;
+  (metadata: LogMetadata, message: string): never;
+}
+
+/**
+ * Logger interface for handler contexts and cross-package contracts.
+ */
+export interface Logger {
+  trace: LogMethod;
+  debug: LogMethod;
+  info: LogMethod;
+  warn: LogMethod;
+  error: LogMethod;
+  fatal: LogMethod;
+  child(context: LogMetadata): Logger;
+}
+
+/**
+ * Configuration passed through the logger factory to backend adapters.
+ *
+ * `backend` carries adapter-specific configuration in a strongly typed way.
+ */
+export interface LoggerFactoryConfig<TBackendOptions = unknown> {
+  /** Logger category/name identifying the source (e.g., "cli", "mcp") */
+  name: string;
+  /** Minimum level to emit */
+  level?: LogLevel;
+  /** Static context attached to every emitted record */
+  context?: LogMetadata;
+  /** Adapter-specific backend options */
+  backend?: TBackendOptions;
+}
+
+/**
+ * Backend adapter contract used by the logger factory.
+ *
+ * Runtime packages provide concrete adapters (for example logtape or custom
+ * implementations) behind this contract.
+ */
+export interface LoggerAdapter<TBackendOptions = unknown> {
+  createLogger(config: LoggerFactoryConfig<TBackendOptions>): Logger;
+  flush?(): Promise<void>;
+}
+
+/**
+ * Backend-agnostic logger factory surface consumed by CLI/MCP runtime code.
+ */
+export interface LoggerFactory<TBackendOptions = unknown> {
+  createLogger(config: LoggerFactoryConfig<TBackendOptions>): Logger;
+  flush(): Promise<void>;
+}
+
+/**
+ * Create a logger factory from a backend adapter implementation.
+ */
+export function createLoggerFactory<TBackendOptions = unknown>(
+  adapter: LoggerAdapter<TBackendOptions>
+): LoggerFactory<TBackendOptions> {
+  return {
+    createLogger(config) {
+      return adapter.createLogger(config);
+    },
+    async flush() {
+      await adapter.flush?.();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Defines a backend-agnostic logger factory contract in `@outfitter/contracts`.
- Establishes the typed adapter boundary for logger backend implementations.

## Scope
- Contract/type additions for logger creation and adaptation.
- Foundation layer for subsequent logging stack PRs.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
