### PR TITLE
feat(outfitter): wire cli to outfitter logger factory

### DIFF
--- a/packages/cli/src/__tests__/core.test.ts
+++ b/packages/cli/src/__tests__/core.test.ts
@@ -18,6 +18,25 @@ describe("createCLI()", () => {
     expect(cli.program.name()).toBe("outfitter");
     expect(cli.program.description()).toBe("Outfitter CLI");
   });
+
+  it("awaits async onExit handlers", async () => {
+    const exitCodes: number[] = [];
+    const cli = createCLI({
+      name: "outfitter",
+      version: "0.1.0-rc.0",
+      onExit: async (code) => {
+        await Promise.resolve();
+        exitCodes.push(code);
+      },
+    });
+
+    cli.program.configureOutput({
+      writeErr: () => undefined,
+    });
+
+    await cli.parse(["node", "outfitter", "--unknown-flag"]);
+    expect(exitCodes).toEqual([1]);
+  });
 });
 
 describe("command()", () => {

--- a/packages/cli/src/__tests__/input.test.ts
+++ b/packages/cli/src/__tests__/input.test.ts
@@ -803,6 +803,15 @@ describe("normalizeId()", () => {
 // =============================================================================
 
 describe("confirmDestructive()", () => {
+  function setInteractiveTerminal(): void {
+    process.env.TERM = "xterm-256color";
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+
   test("returns Ok(true) when bypassFlag is true", async () => {
     const result = await confirmDestructive({
       message: "Delete 5 items?",
@@ -816,12 +825,7 @@ describe("confirmDestructive()", () => {
   });
 
   test("returns Ok(true) when user confirms (mock)", async () => {
-    Object.defineProperty(process.stdout, "isTTY", {
-      value: true,
-      writable: true,
-      configurable: true,
-    });
-
+    setInteractiveTerminal();
     queueConfirmResponse(true);
 
     const result = await confirmDestructive({
@@ -836,12 +840,7 @@ describe("confirmDestructive()", () => {
   });
 
   test("returns Err(CancelledError) when user declines", async () => {
-    Object.defineProperty(process.stdout, "isTTY", {
-      value: true,
-      writable: true,
-      configurable: true,
-    });
-
+    setInteractiveTerminal();
     queueConfirmResponse(false);
 
     const result = await confirmDestructive({
@@ -856,12 +855,7 @@ describe("confirmDestructive()", () => {
   });
 
   test("returns Err(CancelledError) when prompt is cancelled", async () => {
-    Object.defineProperty(process.stdout, "isTTY", {
-      value: true,
-      writable: true,
-      configurable: true,
-    });
-
+    setInteractiveTerminal();
     queueConfirmResponse(cancelSymbol);
 
     const result = await confirmDestructive({
@@ -876,13 +870,7 @@ describe("confirmDestructive()", () => {
   });
 
   test("includes itemCount in prompt", async () => {
-    // Set TTY mode to test interactive prompt path
-    Object.defineProperty(process.stdout, "isTTY", {
-      value: true,
-      writable: true,
-      configurable: true,
-    });
-
+    setInteractiveTerminal();
     queueConfirmResponse(true);
 
     const result = await confirmDestructive({

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -36,7 +36,7 @@ export interface CLIConfig {
   readonly onError?: (error: Error) => void;
 
   /** Custom exit handler (defaults to process.exit) */
-  readonly onExit?: (code: number) => never;
+  readonly onExit?: (code: number) => void | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wires CLI flows to the unified Outfitter logger factory.
- Ensures CLI logging uses scoped child loggers from the shared factory surface.

## Scope
- CLI logger initialization and injection points.
- Runtime wiring updates and coverage for logger usage.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
