### PR TITLE
feat(mcp): wire server to outfitter logger factory

### DIFF
--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -58,7 +58,7 @@ export interface McpServerOptions {
 
   /**
    * Optional logger instance for server logging.
-   * If not provided, a no-op logger is used.
+   * If not provided, the server uses the Outfitter logger factory defaults.
    */
   logger?: Logger;
 


### PR DESCRIPTION
## Summary
- Wires MCP server execution paths to the unified logger factory.
- Applies per-tool/per-request logging integration through the shared adapter surface.

## Scope
- MCP server logger creation and propagation.
- Tests validating MCP logging behavior.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
