### PR TITLE
feat(kit): repurpose package as foundation facade

### DIFF
--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -1,130 +1,60 @@
 # @outfitter/kit
 
-Version coordination meta-package for Outfitter.
+Foundation facade for Outfitter.
 
-## Purpose
+`@outfitter/kit` provides a single foundation entrypoint over:
 
-This package ensures compatible versions across all `@outfitter/*` packages. Install it alongside specific packages to get coordinated version constraints via `peerDependencies`.
+- `@outfitter/contracts`
+- `@outfitter/types`
 
-## Installation
+Runtime and transport packages (`@outfitter/cli`, `@outfitter/mcp`, etc.) remain explicit dependencies.
+
+## Install
 
 ```bash
 bun add @outfitter/kit
 ```
 
-## When to Use
+## Root Facade
 
-Use `@outfitter/kit` when:
+The root entrypoint re-exports the contracts surface and exposes types under a namespace.
 
-1. **Building applications** that use multiple Outfitter packages
-2. **Ensuring compatibility** between package versions
-3. **Checking version requirements** programmatically
+```typescript
+import { Result, ValidationError, Types } from "@outfitter/kit";
+
+const value = Result.ok({ id: Types.shortId() });
+```
+
+## Foundation Subpaths
+
+Use subpaths when you want explicit import intent.
+
+### Contracts
+
+```typescript
+import { Result, createLoggerFactory } from "@outfitter/kit/foundation/contracts";
+```
+
+### Types
+
+```typescript
+import { shortId, isDefined } from "@outfitter/kit/foundation/types";
+```
+
+### Aggregate Foundation
+
+```typescript
+import { Result, Types } from "@outfitter/kit/foundation";
+```
+
+## What Kit Does Not Hide
+
+`@outfitter/kit` does not implicitly install or expose runtime transports.
+Keep transport dependencies explicit in your app:
 
 ```bash
-# Install stack alongside the packages you need
-bun add @outfitter/kit @outfitter/cli @outfitter/logging @outfitter/config
+bun add @outfitter/kit @outfitter/cli @outfitter/mcp
 ```
-
-The stack's `peerDependencies` will warn if you have incompatible versions installed.
-
-## Version Matrix
-
-See [VERSIONS.md](./VERSIONS.md) for the complete compatibility matrix.
-
-### Current Release (0.1.0-rc.1)
-
-| Package | Minimum Version |
-|---------|-----------------|
-| @outfitter/contracts | 0.1.0-rc.1 |
-| @outfitter/types | 0.1.0-rc.1 |
-| @outfitter/cli | 0.1.0-rc.1 |
-| @outfitter/config | 0.1.0-rc.1 |
-| @outfitter/logging | 0.1.0-rc.1 |
-| @outfitter/file-ops | 0.1.0-rc.1 |
-| @outfitter/state | 0.1.0-rc.1 |
-| @outfitter/mcp | 0.1.0-rc.1 |
-| @outfitter/index | 0.1.0-rc.1 |
-| @outfitter/daemon | 0.1.0-rc.1 |
-| @outfitter/testing | 0.1.0-rc.1 |
-
-## Exports
-
-### STACK_VERSION
-
-The current stack version (matches package.json).
-
-```typescript
-import { STACK_VERSION } from "@outfitter/kit";
-
-console.log(`Using Outfitter Stack ${STACK_VERSION}`);
-```
-
-### MINIMUM_VERSIONS
-
-Minimum compatible versions for each package.
-
-```typescript
-import { MINIMUM_VERSIONS } from "@outfitter/kit";
-
-// Check if a package meets the minimum version
-const cliMinimum = MINIMUM_VERSIONS["@outfitter/cli"]; // "0.1.0-rc.0"
-```
-
-### OutfitterPackage
-
-Type for valid package names in the stack.
-
-```typescript
-import { type OutfitterPackage, MINIMUM_VERSIONS } from "@outfitter/kit";
-
-function getMinVersion(pkg: OutfitterPackage): string {
-  return MINIMUM_VERSIONS[pkg];
-}
-
-getMinVersion("@outfitter/cli"); // "0.1.0-rc.0"
-getMinVersion("@outfitter/invalid"); // TypeScript error
-```
-
-## API Reference
-
-| Export | Type | Description |
-|--------|------|-------------|
-| `STACK_VERSION` | `string` | Current stack version |
-| `MINIMUM_VERSIONS` | `Record<OutfitterPackage, string>` | Minimum versions for all packages |
-| `OutfitterPackage` | `type` | Union type of valid package names |
-
-## Dependency Tiers
-
-Packages are organized into tiers based on stability:
-
-### Foundation (cold)
-Stable APIs, rarely change:
-- `@outfitter/contracts` - Result/Error patterns
-- `@outfitter/types` - Branded types
-
-### Runtime (warm)
-Expected to evolve:
-- `@outfitter/cli` - CLI framework (includes terminal rendering)
-- `@outfitter/config` - Configuration
-- `@outfitter/logging` - Structured logging
-- `@outfitter/file-ops` - File operations
-- `@outfitter/state` - State management
-- `@outfitter/mcp` - MCP server framework
-- `@outfitter/index` - SQLite FTS5 indexing
-- `@outfitter/daemon` - Daemon lifecycle
-
-### Tooling (lukewarm)
-Workflow-focused:
-- `@outfitter/testing` - Test harnesses
-
-## Related Packages
-
-All `@outfitter/*` packages are designed to work together. See individual package documentation:
-
-- [@outfitter/contracts](../contracts/README.md) - Result types and error patterns
-- [@outfitter/cli](../cli/README.md) - CLI framework
-- [@outfitter/daemon](../daemon/README.md) - Daemon lifecycle management
-- [@outfitter/testing](../testing/README.md) - Test harnesses
 
 ## License
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@outfitter/kit",
-  "description": "Version coordination meta-package for Outfitter",
+  "description": "Foundation facade for Outfitter contracts and types",
   "version": "0.2.1",
   "type": "module",
   "files": [
     "dist",
-    "VERSIONS.md",
     "shared/migrations"
   ],
   "module": "./dist/index.js",
@@ -17,62 +16,33 @@
         "default": "./dist/index.js"
       }
     },
+    "./foundation/contracts": {
+      "import": {
+        "types": "./dist/foundation/contracts.d.ts",
+        "default": "./dist/foundation/contracts.js"
+      }
+    },
+    "./foundation/types": {
+      "import": {
+        "types": "./dist/foundation/types.d.ts",
+        "default": "./dist/foundation/types.js"
+      }
+    },
+    "./foundation": {
+      "import": {
+        "types": "./dist/foundation/index.d.ts",
+        "default": "./dist/foundation/index.js"
+      }
+    },
     "./package.json": "./package.json"
   },
-  "peerDependencies": {
-    "@outfitter/cli": ">=0.1.0",
-    "@outfitter/config": ">=0.1.0",
-    "@outfitter/contracts": ">=0.1.0",
-    "@outfitter/daemon": ">=0.1.0",
-    "@outfitter/file-ops": ">=0.1.0",
-    "@outfitter/index": ">=0.1.0",
-    "@outfitter/logging": ">=0.1.0",
-    "@outfitter/mcp": ">=0.1.0",
-    "@outfitter/state": ">=0.1.0",
-    "@outfitter/testing": ">=0.1.0",
-    "@outfitter/types": ">=0.1.0",
-    "@outfitter/ui": ">=0.1.0-rc.1"
-  },
-  "peerDependenciesMeta": {
-    "@outfitter/cli": {
-      "optional": true
-    },
-    "@outfitter/config": {
-      "optional": true
-    },
-    "@outfitter/contracts": {
-      "optional": true
-    },
-    "@outfitter/daemon": {
-      "optional": true
-    },
-    "@outfitter/file-ops": {
-      "optional": true
-    },
-    "@outfitter/index": {
-      "optional": true
-    },
-    "@outfitter/logging": {
-      "optional": true
-    },
-    "@outfitter/mcp": {
-      "optional": true
-    },
-    "@outfitter/state": {
-      "optional": true
-    },
-    "@outfitter/testing": {
-      "optional": true
-    },
-    "@outfitter/types": {
-      "optional": true
-    },
-    "@outfitter/ui": {
-      "optional": true
-    }
+  "dependencies": {
+    "@outfitter/contracts": "workspace:*",
+    "@outfitter/types": "workspace:*"
   },
   "scripts": {
-    "build": "bun run sync:migrations && bunup --filter @outfitter/kit",
+    "build": "bun run sync:migrations && cd ../.. && bunup --filter @outfitter/kit",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "sync:migrations": "bun run ../../scripts/sync-migrations.ts",
     "prepack": "bun run sync:migrations"

--- a/packages/kit/src/__tests__/foundation-facade.test.ts
+++ b/packages/kit/src/__tests__/foundation-facade.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createLoggerFactory as ContractCreateLoggerFactory,
+  ValidationError,
+} from "@outfitter/contracts";
+import { brand, isDefined } from "@outfitter/types";
+import {
+  Result as FoundationContractsResult,
+  createLoggerFactory as FoundationCreateLoggerFactory,
+} from "../foundation/contracts";
+import {
+  Result as FoundationResult,
+  ValidationError as FoundationValidationError,
+} from "../foundation/index";
+import {
+  brand as foundationBrand,
+  isDefined as foundationIsDefined,
+} from "../foundation/types";
+import {
+  Result as RootResult,
+  Types as RootTypes,
+  ValidationError as RootValidationError,
+} from "../index";
+
+describe("@outfitter/kit foundation facade", () => {
+  it("root facade re-exports contracts surface", () => {
+    const ok = RootResult.ok({ ok: true });
+    expect(ok.isOk()).toBe(true);
+    expect(RootValidationError).toBe(ValidationError);
+  });
+
+  it("root facade exposes types as a namespace", () => {
+    expect(RootTypes.brand).toBe(brand);
+    expect(RootTypes.isDefined).toBe(isDefined);
+  });
+
+  it("foundation facade exports contracts directly", () => {
+    const err = FoundationResult.err(
+      new FoundationValidationError({ message: "bad" })
+    );
+    expect(err.isErr()).toBe(true);
+  });
+
+  it("foundation/contracts forwards logger contract types", () => {
+    expect(FoundationCreateLoggerFactory).toBe(ContractCreateLoggerFactory);
+    expect(FoundationContractsResult).toBe(RootResult);
+  });
+
+  it("foundation/types forwards branded and guard helpers", () => {
+    expect(foundationBrand).toBe(brand);
+    expect(foundationIsDefined).toBe(isDefined);
+  });
+});

--- a/packages/kit/src/foundation/contracts.ts
+++ b/packages/kit/src/foundation/contracts.ts
@@ -1,0 +1,5 @@
+/**
+ * Explicit contracts foundation surface.
+ */
+// biome-ignore lint/performance/noBarrelFile: this file is an intentional facade entrypoint.
+export * from "@outfitter/contracts";

--- a/packages/kit/src/foundation/index.ts
+++ b/packages/kit/src/foundation/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Foundation facade entrypoint.
+ *
+ * Provides direct contracts exports and a namespaced types surface.
+ */
+// biome-ignore lint/performance/noBarrelFile: this file is an intentional facade entrypoint.
+export * from "@outfitter/contracts";
+export * as Types from "@outfitter/types";

--- a/packages/kit/src/foundation/types.ts
+++ b/packages/kit/src/foundation/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Explicit types foundation surface.
+ */
+// biome-ignore lint/performance/noBarrelFile: this file is an intentional facade entrypoint.
+export * from "@outfitter/types";

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -1,35 +1,11 @@
 /**
- * @outfitter/kit - Version coordination meta-package
+ * @outfitter/kit - Foundation facade for Outfitter
  *
- * This package coordinates versions across all @outfitter packages.
- * Install it alongside specific packages to ensure compatible versions.
+ * Root exports the contracts surface and exposes @outfitter/types under
+ * `Types`. For explicit imports, use `@outfitter/kit/foundation/*` subpaths.
  *
  * @packageDocumentation
  */
 
-/**
- * Stack version - matches package.json version
- */
-export const STACK_VERSION = "0.1.0-rc.1";
-
-/**
- * Minimum compatible versions for each package
- */
-export const MINIMUM_VERSIONS = {
-  "@outfitter/cli": "0.1.0-rc.1",
-  "@outfitter/config": "0.1.0-rc.1",
-  "@outfitter/contracts": "0.1.0-rc.1",
-  "@outfitter/daemon": "0.1.0-rc.1",
-  "@outfitter/file-ops": "0.1.0-rc.1",
-  "@outfitter/index": "0.1.0-rc.1",
-  "@outfitter/logging": "0.1.0-rc.1",
-  "@outfitter/mcp": "0.1.0-rc.1",
-  "@outfitter/state": "0.1.0-rc.1",
-  "@outfitter/testing": "0.1.0-rc.1",
-  "@outfitter/types": "0.1.0-rc.1",
-} as const;
-
-/**
- * Type for package names in the stack
- */
-export type OutfitterPackage = keyof typeof MINIMUM_VERSIONS;
+export * from "@outfitter/contracts";
+export * as Types from "@outfitter/types";


### PR DESCRIPTION
## Summary
- Repurposes `@outfitter/kit` as a foundation facade for adoption.
- Consolidates kit-facing entry points that support the migration path.

## Scope
- Kit package surface and related dependency/docs updates.
- Foundation-level adoption alignment.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
