### PR TITLE
chore(outfitter): make templates kit-first with explicit transport deps

### DIFF
--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -120,10 +120,11 @@ describe("init command file creation", () => {
     const packageJsonPath = join(tempDir, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
     expect(packageJson.devDependencies["@outfitter/tooling"]).toBeUndefined();
-    expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.1.0");
-    expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.1.0");
-    expect(packageJson.dependencies["@outfitter/config"]).toBe("^0.1.0");
-    expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.1.0");
+    expect(packageJson.dependencies["@outfitter/kit"]).toBe("^0.1.0-rc.0");
+    expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.1.0-rc.0");
+    expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.1.0-rc.0");
+    expect(packageJson.dependencies["@outfitter/contracts"]).toBeUndefined();
+    expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
 
     const tsconfigPath = join(tempDir, "tsconfig.json");
     const tsconfig = JSON.parse(readFileSync(tsconfigPath, "utf-8"));
@@ -324,12 +325,11 @@ describe("init command local dependency rewriting", () => {
 
     const packageJsonPath = join(tempDir, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+    expect(packageJson.dependencies["@outfitter/kit"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/cli"]).toBe("workspace:*");
-    expect(packageJson.dependencies["@outfitter/config"]).toBe("workspace:*");
-    expect(packageJson.dependencies["@outfitter/contracts"]).toBe(
-      "workspace:*"
-    );
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("workspace:*");
+    expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
+    expect(packageJson.dependencies["@outfitter/contracts"]).toBeUndefined();
     expect(packageJson.dependencies.commander).toBe("^12.0.0");
   });
 });

--- a/apps/outfitter/templates/cli/package.json.template
+++ b/apps/outfitter/templates/cli/package.json.template
@@ -25,10 +25,9 @@
 		"format": "biome format --write ."
 	},
 	"dependencies": {
-		"@outfitter/cli": "^0.1.0",
-		"@outfitter/contracts": "^0.1.0",
-		"@outfitter/config": "^0.1.0",
-		"@outfitter/logging": "^0.1.0",
+		"@outfitter/kit": "^0.1.0-rc.0",
+		"@outfitter/cli": "^0.1.0-rc.0",
+		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},
 	"devDependencies": {

--- a/apps/outfitter/templates/daemon/package.json.template
+++ b/apps/outfitter/templates/daemon/package.json.template
@@ -27,11 +27,10 @@
 		"format": "biome format --write ."
 	},
 	"dependencies": {
-		"@outfitter/daemon": "^0.1.0",
-		"@outfitter/cli": "^0.1.0",
-		"@outfitter/contracts": "^0.1.0",
-		"@outfitter/config": "^0.1.0",
-		"@outfitter/logging": "^0.1.0",
+		"@outfitter/kit": "^0.1.0-rc.0",
+		"@outfitter/daemon": "^0.1.0-rc.0",
+		"@outfitter/cli": "^0.1.0-rc.0",
+		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},
 	"devDependencies": {

--- a/apps/outfitter/templates/mcp/package.json.template
+++ b/apps/outfitter/templates/mcp/package.json.template
@@ -26,10 +26,9 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.0.0",
-		"@outfitter/mcp": "^0.1.0",
-		"@outfitter/contracts": "^0.1.0",
-		"@outfitter/config": "^0.1.0",
-		"@outfitter/logging": "^0.1.0"
+		"@outfitter/kit": "^0.1.0-rc.0",
+		"@outfitter/mcp": "^0.1.0-rc.0",
+		"@outfitter/logging": "^0.1.0-rc.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0",

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -25,9 +25,8 @@
 		"format": "biome format --write ."
 	},
 	"dependencies": {
+		"@outfitter/kit": "^0.1.0-rc.0",
 		"@outfitter/cli": "^0.1.0-rc.0",
-		"@outfitter/contracts": "^0.1.0-rc.0",
-		"@outfitter/config": "^0.1.0-rc.0",
 		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},

--- a/templates/daemon/package.json.template
+++ b/templates/daemon/package.json.template
@@ -27,10 +27,9 @@
 		"format": "biome format --write ."
 	},
 	"dependencies": {
+		"@outfitter/kit": "^0.1.0-rc.0",
 		"@outfitter/daemon": "^0.1.0-rc.0",
 		"@outfitter/cli": "^0.1.0-rc.0",
-		"@outfitter/contracts": "^0.1.0-rc.0",
-		"@outfitter/config": "^0.1.0-rc.0",
 		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},

--- a/templates/mcp/package.json.template
+++ b/templates/mcp/package.json.template
@@ -26,9 +26,8 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.0.0",
+		"@outfitter/kit": "^0.1.0-rc.0",
 		"@outfitter/mcp": "^0.1.0-rc.0",
-		"@outfitter/contracts": "^0.1.0-rc.0",
-		"@outfitter/config": "^0.1.0-rc.0",
 		"@outfitter/logging": "^0.1.0-rc.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Updates templates to a kit-first dependency model.
- Makes transport dependencies explicit in generated outputs.

## Scope
- Template dependency declarations and scaffolding outputs.
- Associated checks/tests for generated structure.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
