### PR TITLE
feat(outfitter): add create planning presets and protocol

### DIFF
--- a/apps/outfitter/src/__tests__/index.test.ts
+++ b/apps/outfitter/src/__tests__/index.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { InitError, initCommand } from "../index.js";
+import {
+  CREATE_PRESET_IDS,
+  InitError,
+  initCommand,
+  planCreateProject,
+} from "../index.js";
 
 describe("outfitter public API", () => {
   test("exports initCommand", () => {
@@ -18,5 +23,20 @@ describe("outfitter public API", () => {
     const err = new InitError("test");
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("InitError");
+  });
+
+  test("exports create presets", () => {
+    expect(CREATE_PRESET_IDS).toEqual(["basic", "cli", "daemon", "mcp"]);
+  });
+
+  test("exports planCreateProject", () => {
+    const result = planCreateProject({
+      name: "smoke-app",
+      targetDir: "/tmp/smoke-app",
+      preset: "basic",
+      year: "2026",
+    });
+
+    expect(result.isOk()).toBe(true);
   });
 });

--- a/apps/outfitter/src/create/__tests__/planner.test.ts
+++ b/apps/outfitter/src/create/__tests__/planner.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { planCreateProject } from "../planner.js";
+
+describe("create planner", () => {
+  test("builds a deterministic plan for a preset", () => {
+    const result = planCreateProject({
+      name: "hello-cli",
+      targetDir: "/tmp/hello-cli",
+      preset: "cli",
+      year: "2026",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.preset.id).toBe("cli");
+    expect(result.value.values).toEqual({
+      packageName: "hello-cli",
+      projectName: "hello-cli",
+      version: "0.1.0",
+      description: "A new project created with Outfitter",
+      binName: "hello-cli",
+      year: "2026",
+    });
+    expect(result.value.changes).toEqual([
+      {
+        type: "copy-template",
+        template: "cli",
+        targetDir: "/tmp/hello-cli",
+        overlayBaseTemplate: true,
+      },
+      { type: "inject-shared-config" },
+      { type: "add-blocks", blocks: ["scaffolding"] },
+    ]);
+  });
+
+  test("adds local dependency rewrite when local mode is enabled", () => {
+    const result = planCreateProject({
+      name: "local-app",
+      targetDir: "/tmp/local-app",
+      preset: "basic",
+      local: true,
+      year: "2026",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.changes).toContainEqual({
+      type: "rewrite-local-dependencies",
+      mode: "workspace",
+    });
+  });
+
+  test("omits tooling blocks when includeTooling is false", () => {
+    const result = planCreateProject({
+      name: "no-tooling",
+      targetDir: "/tmp/no-tooling",
+      preset: "mcp",
+      includeTooling: false,
+      year: "2026",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(
+      result.value.changes.find((change) => change.type === "add-blocks")
+    ).toBeUndefined();
+  });
+
+  test("derives scoped project and bin names from packageName", () => {
+    const result = planCreateProject({
+      name: "ignored-name",
+      packageName: "@outfitter/my-mcp",
+      targetDir: "/tmp/my-mcp",
+      preset: "mcp",
+      year: "2026",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.values.projectName).toBe("my-mcp");
+    expect(result.value.values.binName).toBe("my-mcp");
+  });
+
+  test("rejects packageName with missing scoped segment", () => {
+    const result = planCreateProject({
+      name: "@",
+      targetDir: "/tmp/invalid-scoped",
+      preset: "basic",
+      year: "2026",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.field).toBe("packageName");
+    }
+  });
+
+  test("returns validation error for unknown preset input", () => {
+    const result = planCreateProject({
+      name: "valid-name",
+      targetDir: "/tmp/unknown-preset",
+      preset: "unknown" as unknown as "basic",
+      year: "2026",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.field).toBe("preset");
+    }
+  });
+
+  test("returns validation error when required inputs are empty", () => {
+    const emptyName = planCreateProject({
+      name: "   ",
+      targetDir: "/tmp/empty-name",
+      preset: "basic",
+    });
+    expect(emptyName.isErr()).toBe(true);
+
+    const emptyDir = planCreateProject({
+      name: "valid-name",
+      targetDir: "   ",
+      preset: "basic",
+    });
+    expect(emptyDir.isErr()).toBe(true);
+  });
+});

--- a/apps/outfitter/src/create/index.ts
+++ b/apps/outfitter/src/create/index.ts
@@ -1,0 +1,14 @@
+// biome-ignore lint/performance/noBarrelFile: intentional re-export for create module API surface.
+export { planCreateProject } from "./planner.js";
+export {
+  CREATE_PRESET_IDS,
+  CREATE_PRESETS,
+  getCreatePreset,
+} from "./presets.js";
+export type {
+  CreatePlanChange,
+  CreatePresetDefinition,
+  CreatePresetId,
+  CreateProjectInput,
+  CreateProjectPlan,
+} from "./types.js";

--- a/apps/outfitter/src/create/planner.ts
+++ b/apps/outfitter/src/create/planner.ts
@@ -1,0 +1,107 @@
+import { Result, ValidationError } from "@outfitter/contracts";
+import { getCreatePreset } from "./presets.js";
+import type {
+  CreatePlanChange,
+  CreateProjectInput,
+  CreateProjectPlan,
+} from "./types.js";
+
+function derivePackageName(input: CreateProjectInput): string {
+  return (input.packageName ?? input.name).trim();
+}
+
+function deriveProjectName(packageName: string): string {
+  if (!packageName.startsWith("@")) {
+    return packageName.trim();
+  }
+
+  const scopeSeparator = packageName.indexOf("/");
+  if (scopeSeparator < 0) {
+    return "";
+  }
+
+  return packageName.slice(scopeSeparator + 1).trim();
+}
+
+function deriveBinName(projectName: string): string {
+  return projectName.toLowerCase().replace(/\s+/g, "-");
+}
+
+export function planCreateProject(
+  input: CreateProjectInput
+): Result<CreateProjectPlan, ValidationError> {
+  const packageName = derivePackageName(input);
+  if (packageName.length === 0) {
+    return Result.err(
+      new ValidationError({
+        message: "Project name must not be empty",
+        field: "name",
+      })
+    );
+  }
+
+  const targetDir = input.targetDir.trim();
+  if (targetDir.length === 0) {
+    return Result.err(
+      new ValidationError({
+        message: "Target directory must not be empty",
+        field: "targetDir",
+      })
+    );
+  }
+
+  const projectName = deriveProjectName(packageName);
+  if (projectName.length === 0) {
+    return Result.err(
+      new ValidationError({
+        message: "Could not derive a project name from package name",
+        field: "packageName",
+      })
+    );
+  }
+
+  const preset = getCreatePreset(input.preset);
+  if (!preset) {
+    return Result.err(
+      new ValidationError({
+        message: `Unknown create preset '${input.preset}'`,
+        field: "preset",
+      })
+    );
+  }
+  const includeTooling = input.includeTooling ?? true;
+  const defaultBlocks = includeTooling ? [...preset.defaultBlocks] : [];
+  const changes: CreatePlanChange[] = [
+    {
+      type: "copy-template",
+      template: preset.template,
+      targetDir,
+      overlayBaseTemplate: true,
+    },
+    { type: "inject-shared-config" },
+  ];
+
+  if (input.local) {
+    changes.push({ type: "rewrite-local-dependencies", mode: "workspace" });
+  }
+
+  if (defaultBlocks.length > 0) {
+    changes.push({ type: "add-blocks", blocks: defaultBlocks });
+  }
+
+  const plan: CreateProjectPlan = {
+    preset,
+    values: {
+      packageName,
+      projectName,
+      version: input.version?.trim() || "0.1.0",
+      description:
+        input.description?.trim() || "A new project created with Outfitter",
+      binName: deriveBinName(projectName),
+      year: input.year ?? String(new Date().getFullYear()),
+    },
+    changes,
+  };
+
+  return Result.ok(plan);
+}

--- a/apps/outfitter/src/create/presets.ts
+++ b/apps/outfitter/src/create/presets.ts
@@ -1,0 +1,41 @@
+import type { CreatePresetDefinition, CreatePresetId } from "./types.js";
+
+export const CREATE_PRESETS: Readonly<
+  Record<CreatePresetId, CreatePresetDefinition>
+> = {
+  basic: {
+    id: "basic",
+    template: "basic",
+    summary: "Minimal Bun + TypeScript project.",
+    defaultBlocks: ["scaffolding"],
+  },
+  cli: {
+    id: "cli",
+    template: "cli",
+    summary: "CLI starter with Outfitter command ergonomics.",
+    defaultBlocks: ["scaffolding"],
+  },
+  daemon: {
+    id: "daemon",
+    template: "daemon",
+    summary: "Daemon + control CLI starter.",
+    defaultBlocks: ["scaffolding"],
+  },
+  mcp: {
+    id: "mcp",
+    template: "mcp",
+    summary: "MCP server starter.",
+    defaultBlocks: ["scaffolding"],
+  },
+} as const;
+
+export const CREATE_PRESET_IDS = Object.keys(
+  CREATE_PRESETS
+) as CreatePresetId[];
+
+export function getCreatePreset(
+  id: string
+): CreatePresetDefinition | undefined {
+  const presets = CREATE_PRESETS as Record<string, CreatePresetDefinition>;
+  return presets[id];
+}

--- a/apps/outfitter/src/create/types.ts
+++ b/apps/outfitter/src/create/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Create planner types for kit-first project scaffolding.
+ *
+ * These types model preset intent separately from execution so future flows can
+ * consume a deterministic plan before mutating the filesystem.
+ */
+
+export type CreatePresetId = "basic" | "cli" | "daemon" | "mcp";
+
+export interface CreatePresetDefinition {
+  readonly id: CreatePresetId;
+  readonly template: CreatePresetId;
+  readonly summary: string;
+  readonly defaultBlocks: readonly string[];
+}
+
+export interface CreateProjectInput {
+  readonly name: string;
+  readonly targetDir: string;
+  readonly preset: CreatePresetId;
+  readonly packageName?: string;
+  readonly description?: string;
+  readonly version?: string;
+  readonly includeTooling?: boolean;
+  readonly local?: boolean;
+  readonly year?: string;
+}
+
+export type CreatePlanChange =
+  | {
+      readonly type: "copy-template";
+      readonly template: string;
+      readonly targetDir: string;
+      readonly overlayBaseTemplate: boolean;
+    }
+  | {
+      readonly type: "inject-shared-config";
+    }
+  | {
+      readonly type: "rewrite-local-dependencies";
+      readonly mode: "workspace";
+    }
+  | {
+      readonly type: "add-blocks";
+      readonly blocks: readonly string[];
+    };
+
+export interface CreateProjectPlan {
+  readonly preset: CreatePresetDefinition;
+  readonly values: {
+    readonly packageName: string;
+    readonly projectName: string;
+    readonly version: string;
+    readonly description: string;
+    readonly binName: string;
+    readonly year: string;
+  };
+  readonly changes: readonly CreatePlanChange[];
+}

--- a/apps/outfitter/src/index.ts
+++ b/apps/outfitter/src/index.ts
@@ -31,3 +31,16 @@ export {
   initCommand,
   runInit,
 } from "./commands/init";
+
+// Create planner
+export {
+  CREATE_PRESET_IDS,
+  CREATE_PRESETS,
+  type CreatePlanChange,
+  type CreatePresetDefinition,
+  type CreatePresetId,
+  type CreateProjectInput,
+  type CreateProjectPlan,
+  getCreatePreset,
+  planCreateProject,
+} from "./create/index.js";


### PR DESCRIPTION
## Summary
- Adds create-planning presets and protocol definitions for scaffolding.
- Standardizes preset selection inputs before full interactive flow execution.

## Scope
- Preset/protocol implementation in outfitter create flow.
- Tests and docs tied to preset behavior.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
