### PR TITLE
feat(outfitter): add migrate kit codemod command

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -52,10 +52,10 @@
         "default": "./dist/create/presets.js"
       }
     },
-    "./commands/init": {
+    "./create": {
       "import": {
-        "types": "./dist/commands/init.d.ts",
-        "default": "./dist/commands/init.js"
+        "types": "./dist/create/index.d.ts",
+        "default": "./dist/create/index.js"
       }
     },
     "./commands/shared-deps": {
@@ -98,12 +98,12 @@
     "@outfitter/logging": "workspace:*",
     "@outfitter/tooling": "workspace:*",
     "commander": "^14.0.2",
+    "typescript": "^5.9.3",
     "zod": "^4.3.5"
   },
   "devDependencies": {
     "@types/bun": "^1.3.7",
-    "@types/node": "^25.0.10",
-    "typescript": "^5.9.3"
+    "@types/node": "^25.0.10"
   },
   "engines": {
     "bun": ">=1.3.7"

--- a/apps/outfitter/src/__tests__/index.test.ts
+++ b/apps/outfitter/src/__tests__/index.test.ts
@@ -12,8 +12,10 @@ import {
   CreateError,
   InitError,
   initCommand,
+  MigrateKitError,
   planCreateProject,
   runCreate,
+  runMigrateKit,
 } from "../index.js";
 
 describe("outfitter public API", () => {
@@ -32,6 +34,13 @@ describe("outfitter public API", () => {
     const err = new CreateError("test");
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("CreateError");
+  });
+
+  test("exports runMigrateKit and MigrateKitError", () => {
+    expect(typeof runMigrateKit).toBe("function");
+    const err = new MigrateKitError("test");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("MigrateKitError");
   });
 
   test("exports create presets", () => {

--- a/apps/outfitter/src/__tests__/migrate-kit.test.ts
+++ b/apps/outfitter/src/__tests__/migrate-kit.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for `outfitter migrate kit` codemod.
+ *
+ * @packageDocumentation
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+
+function createTempDir(): string {
+  const tempDir = join(
+    tmpdir(),
+    `outfitter-migrate-kit-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  return tempDir;
+}
+
+function cleanupTempDir(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = createTempDir();
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+
+describe("migrate kit command", () => {
+  test("rewrites foundation imports and package.json deps", async () => {
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+
+    writeJson(join(tempDir, "package.json"), {
+      name: "demo-app",
+      version: "0.1.0",
+      dependencies: {
+        "@outfitter/contracts": "^0.2.0",
+        "@outfitter/types": "^0.2.0",
+        "@outfitter/cli": "^0.2.0",
+      },
+    });
+
+    writeFileSync(
+      join(tempDir, "src", "index.ts"),
+      [
+        'import { Result } from "@outfitter/contracts";',
+        'import type { Brand } from "@outfitter/types";',
+        "",
+        'export type UserId = Brand<string, "UserId">;',
+        "export const ok = Result.ok({});",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const result = await runMigrateKit({
+      targetDir: tempDir,
+      dryRun: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.changedFiles.length).toBe(2);
+    expect(result.value.importRewrites).toBe(2);
+    expect(result.value.manifestUpdates).toBe(1);
+
+    const source = readFileSync(join(tempDir, "src", "index.ts"), "utf-8");
+    expect(source).toContain("@outfitter/kit/foundation/contracts");
+    expect(source).toContain("@outfitter/kit/foundation/types");
+
+    const packageJson = JSON.parse(
+      readFileSync(join(tempDir, "package.json"), "utf-8")
+    );
+
+    expect(packageJson.dependencies["@outfitter/contracts"]).toBeUndefined();
+    expect(packageJson.dependencies["@outfitter/types"]).toBeUndefined();
+    expect(packageJson.dependencies["@outfitter/kit"]).toBe("^0.2.0");
+  });
+
+  test("supports dry-run without writing files and includes diff preview", async () => {
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+
+    const packageJsonPath = join(tempDir, "package.json");
+    const sourcePath = join(tempDir, "src", "main.ts");
+
+    writeJson(packageJsonPath, {
+      name: "dry-run-app",
+      version: "0.1.0",
+      devDependencies: {
+        "@outfitter/contracts": "~0.2.0",
+      },
+    });
+
+    writeFileSync(
+      sourcePath,
+      'export { Result } from "@outfitter/contracts";\n',
+      "utf-8"
+    );
+
+    const beforePackage = readFileSync(packageJsonPath, "utf-8");
+    const beforeSource = readFileSync(sourcePath, "utf-8");
+
+    const result = await runMigrateKit({
+      targetDir: tempDir,
+      dryRun: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.changedFiles.length).toBe(2);
+    expect(result.value.diffs.length).toBe(2);
+    expect(result.value.diffs[0]?.preview).toContain("--- a/");
+    expect(result.value.diffs[0]?.preview).toContain("+++ b/");
+
+    const afterPackage = readFileSync(packageJsonPath, "utf-8");
+    const afterSource = readFileSync(sourcePath, "utf-8");
+
+    expect(afterPackage).toBe(beforePackage);
+    expect(afterSource).toBe(beforeSource);
+  });
+
+  test("is idempotent after first migration", async () => {
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeJson(join(tempDir, "package.json"), {
+      name: "idempotent-app",
+      version: "0.1.0",
+      dependencies: {
+        "@outfitter/contracts": "^0.2.0",
+      },
+    });
+    writeFileSync(
+      join(tempDir, "src", "main.ts"),
+      'import { Result } from "@outfitter/contracts";\n',
+      "utf-8"
+    );
+
+    const first = await runMigrateKit({ targetDir: tempDir, dryRun: false });
+    expect(first.isOk()).toBe(true);
+    if (first.isErr()) return;
+
+    const second = await runMigrateKit({ targetDir: tempDir, dryRun: false });
+    expect(second.isOk()).toBe(true);
+    if (second.isErr()) return;
+
+    expect(second.value.changedFiles).toHaveLength(0);
+    expect(second.value.importRewrites).toBe(0);
+    expect(second.value.manifestUpdates).toBe(0);
+  });
+
+  test("traverses workspace package manifests and source files", async () => {
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    const pkgA = join(tempDir, "packages", "pkg-a");
+    const pkgB = join(tempDir, "packages", "pkg-b");
+
+    mkdirSync(join(pkgA, "src"), { recursive: true });
+    mkdirSync(join(pkgB, "src"), { recursive: true });
+
+    writeJson(join(tempDir, "package.json"), {
+      name: "workspace-root",
+      private: true,
+      workspaces: ["packages/*"],
+      dependencies: {
+        "@outfitter/types": "^0.2.0",
+      },
+    });
+
+    writeJson(join(pkgA, "package.json"), {
+      name: "@acme/pkg-a",
+      version: "0.1.0",
+      dependencies: {
+        "@outfitter/contracts": "^0.2.0",
+      },
+    });
+
+    writeJson(join(pkgB, "package.json"), {
+      name: "@acme/pkg-b",
+      version: "0.1.0",
+      dependencies: {
+        zod: "^4.0.0",
+      },
+    });
+
+    writeFileSync(
+      join(pkgA, "src", "index.ts"),
+      [
+        'import { Result } from "@outfitter/contracts";',
+        'import { isDefined } from "@outfitter/types";',
+        "export const maybe = isDefined(Result.ok(true));",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    writeFileSync(
+      join(pkgB, "src", "index.ts"),
+      'export const untouched = "ok";\n',
+      "utf-8"
+    );
+
+    const result = await runMigrateKit({
+      targetDir: tempDir,
+      dryRun: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    expect(result.value.packageJsonFiles).toBe(3);
+    expect(result.value.sourceFiles).toBe(2);
+    expect(result.value.importRewrites).toBe(2);
+    expect(result.value.manifestUpdates).toBe(2);
+
+    const rootPackage = JSON.parse(
+      readFileSync(join(tempDir, "package.json"), "utf-8")
+    );
+    expect(rootPackage.dependencies["@outfitter/types"]).toBeUndefined();
+    expect(rootPackage.dependencies["@outfitter/kit"]).toBe("^0.2.0");
+
+    const pkgASource = readFileSync(join(pkgA, "src", "index.ts"), "utf-8");
+    expect(pkgASource).toContain("@outfitter/kit/foundation/contracts");
+    expect(pkgASource).toContain("@outfitter/kit/foundation/types");
+
+    const pkgBSource = readFileSync(join(pkgB, "src", "index.ts"), "utf-8");
+    expect(pkgBSource).toBe('export const untouched = "ok";\n');
+  });
+
+  test("keeps foundation dependency when subpath imports remain", async () => {
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeJson(join(tempDir, "package.json"), {
+      name: "subpath-app",
+      version: "0.1.0",
+      dependencies: {
+        "@outfitter/contracts": "^0.2.0",
+      },
+    });
+
+    writeFileSync(
+      join(tempDir, "src", "index.ts"),
+      [
+        'import { Result } from "@outfitter/contracts";',
+        'import { ValidationError } from "@outfitter/contracts/errors";',
+        "",
+        "export const value = Result.ok(new ValidationError({ message: \"x\" }));",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const result = await runMigrateKit({ targetDir: tempDir, dryRun: false });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) return;
+
+    const source = readFileSync(join(tempDir, "src", "index.ts"), "utf-8");
+    expect(source).toContain("@outfitter/kit/foundation/contracts");
+    expect(source).toContain("@outfitter/contracts/errors");
+
+    const packageJson = JSON.parse(
+      readFileSync(join(tempDir, "package.json"), "utf-8")
+    );
+    expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.2.0");
+    expect(packageJson.dependencies["@outfitter/kit"]).toBe("^0.2.0");
+  });
+
+  test("returns a Result error when source tree traversal fails", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const { runMigrateKit } = await import("../commands/migrate-kit.js");
+
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeJson(join(tempDir, "package.json"), {
+      name: "broken-tree",
+      version: "0.1.0",
+      dependencies: {
+        "@outfitter/contracts": "^0.2.0",
+      },
+    });
+
+    symlinkSync("missing-target.ts", join(tempDir, "src", "broken.ts"));
+
+    const result = await runMigrateKit({ targetDir: tempDir, dryRun: true });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Failed to read source tree entry");
+    }
+  });
+
+  test("migrateKitCommand is idempotent when registered multiple times", async () => {
+    const { migrateKitCommand } = await import("../commands/migrate-kit.js");
+
+    const program = new Command();
+    migrateKitCommand(program);
+    migrateKitCommand(program);
+
+    const migrate = program.commands.find((command) => command.name() === "migrate");
+    expect(migrate).toBeDefined();
+    expect(
+      migrate?.commands.filter((command) => command.name() === "kit")
+    ).toHaveLength(1);
+  });
+});

--- a/apps/outfitter/src/commands/migrate-kit.ts
+++ b/apps/outfitter/src/commands/migrate-kit.ts
@@ -1,0 +1,1093 @@
+/**
+ * `outfitter migrate kit` - codemod for kit-first foundation adoption.
+ *
+ * Rewrites foundation imports from `@outfitter/contracts` and `@outfitter/types`
+ * to `@outfitter/kit/foundation/*` and updates package manifests to depend on
+ * `@outfitter/kit`.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { output } from "@outfitter/cli/output";
+import type { OutputMode } from "@outfitter/cli/types";
+import { Result } from "@outfitter/contracts";
+import type { Command } from "commander";
+import ts from "typescript";
+
+const FOUNDATION_IMPORT_MAP = {
+  "@outfitter/contracts": "@outfitter/kit/foundation/contracts",
+  "@outfitter/types": "@outfitter/kit/foundation/types",
+} as const;
+
+const FOUNDATION_PACKAGES = [
+  "@outfitter/contracts",
+  "@outfitter/types",
+] as const;
+type FoundationPackage = (typeof FOUNDATION_PACKAGES)[number];
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
+
+type DependencySection = (typeof DEPENDENCY_SECTIONS)[number];
+
+interface ManifestRecord {
+  workspaces?: unknown;
+  [key: string]: unknown;
+}
+
+interface DiffPreview {
+  readonly path: string;
+  readonly preview: string;
+}
+
+interface ChangeSet {
+  readonly path: string;
+  readonly before: string;
+  readonly after: string;
+}
+
+/**
+ * Options for the migrate-kit command.
+ */
+export interface MigrateKitOptions {
+  /** Target directory to migrate (defaults to cwd). */
+  readonly targetDir?: string | undefined;
+  /** Run codemod without writing changes to disk. */
+  readonly dryRun?: boolean | undefined;
+}
+
+/**
+ * Result from migrate-kit execution.
+ */
+export interface MigrateKitResult {
+  readonly targetDir: string;
+  readonly dryRun: boolean;
+  readonly packageJsonFiles: number;
+  readonly sourceFiles: number;
+  readonly manifestUpdates: number;
+  readonly importRewrites: number;
+  readonly changedFiles: readonly string[];
+  readonly diffs: readonly DiffPreview[];
+}
+
+/**
+ * Error returned when migration fails.
+ */
+export class MigrateKitError extends Error {
+  readonly _tag = "MigrateKitError" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrateKitError";
+  }
+}
+
+interface Replacement {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replaceAll("\\", "/");
+}
+
+function parseManifest(
+  filePath: string
+): Result<ManifestRecord, MigrateKitError> {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return Result.err(
+        new MigrateKitError(`Invalid package.json at ${filePath}`)
+      );
+    }
+    return Result.ok(parsed as ManifestRecord);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return Result.err(
+      new MigrateKitError(
+        `Failed to read package.json at ${filePath}: ${message}`
+      )
+    );
+  }
+}
+
+function resolveWorkspacePatterns(manifest: ManifestRecord): string[] {
+  const workspaces = manifest["workspaces"];
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (value): value is string => typeof value === "string"
+    );
+  }
+
+  if (
+    !workspaces ||
+    typeof workspaces !== "object" ||
+    Array.isArray(workspaces)
+  ) {
+    return [];
+  }
+
+  const packages = (workspaces as { packages?: unknown }).packages;
+  if (!Array.isArray(packages)) {
+    return [];
+  }
+
+  return packages.filter((value): value is string => typeof value === "string");
+}
+
+function normalizeWorkspacePattern(pattern: string): string {
+  let value = pattern.trim().replaceAll("\\", "/");
+  if (value.length === 0) return value;
+  if (value.endsWith("/")) {
+    value = value.slice(0, -1);
+  }
+  if (value.endsWith("package.json")) {
+    return value;
+  }
+  return `${value}/package.json`;
+}
+
+function collectPackageJsonFiles(
+  rootDir: string
+): Result<string[], MigrateKitError> {
+  const rootPackageJson = join(rootDir, "package.json");
+  if (!existsSync(rootPackageJson)) {
+    return Result.err(
+      new MigrateKitError(`No package.json found at ${rootPackageJson}`)
+    );
+  }
+
+  const manifestResult = parseManifest(rootPackageJson);
+  if (manifestResult.isErr()) {
+    return manifestResult;
+  }
+
+  const workspacePatterns = resolveWorkspacePatterns(manifestResult.value);
+  const files = new Set<string>([rootPackageJson]);
+
+  for (const pattern of workspacePatterns) {
+    const normalized = normalizeWorkspacePattern(pattern);
+    if (normalized.length === 0) {
+      continue;
+    }
+
+    const glob = new Bun.Glob(normalized);
+    for (const entry of glob.scanSync({ cwd: rootDir })) {
+      const absolute = resolve(rootDir, entry);
+      if (existsSync(absolute) && basename(absolute) === "package.json") {
+        files.add(absolute);
+      }
+    }
+  }
+
+  return Result.ok(Array.from(files).sort((a, b) => a.localeCompare(b)));
+}
+
+function isSourceFile(filename: string): boolean {
+  for (const extension of SOURCE_EXTENSIONS) {
+    if (filename.endsWith(extension)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function collectSourceFiles(
+  packageDir: string
+): Result<string[], MigrateKitError> {
+  const files: string[] = [];
+  const stack = [packageDir];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+    if (!currentDir) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(currentDir).sort((a, b) => a.localeCompare(b));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return Result.err(
+        new MigrateKitError(
+          `Failed to read source directory ${currentDir}: ${message}`
+        )
+      );
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry);
+      let stat: ReturnType<typeof statSync>;
+      try {
+        stat = statSync(fullPath);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        return Result.err(
+          new MigrateKitError(
+            `Failed to read source tree entry ${fullPath}: ${message}`
+          )
+        );
+      }
+
+      if (stat.isDirectory()) {
+        if (IGNORED_DIRECTORIES.has(entry)) {
+          continue;
+        }
+
+        // Treat nested package.json as a package boundary to avoid duplicate traversal.
+        if (existsSync(join(fullPath, "package.json"))) {
+          continue;
+        }
+
+        stack.push(fullPath);
+        continue;
+      }
+
+      if (!stat.isFile()) {
+        continue;
+      }
+
+      if (!isSourceFile(entry)) {
+        continue;
+      }
+
+      files.push(fullPath);
+    }
+  }
+
+  return Result.ok(files.sort((a, b) => a.localeCompare(b)));
+}
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (filePath.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (filePath.endsWith(".mts")) return ts.ScriptKind.TS;
+  if (filePath.endsWith(".cts")) return ts.ScriptKind.TS;
+  if (filePath.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (filePath.endsWith(".js")) return ts.ScriptKind.JS;
+  if (filePath.endsWith(".mjs")) return ts.ScriptKind.JS;
+  if (filePath.endsWith(".cjs")) return ts.ScriptKind.JS;
+  return ts.ScriptKind.Unknown;
+}
+
+function mapFoundationSpecifier(specifier: string): string | undefined {
+  return FOUNDATION_IMPORT_MAP[specifier as keyof typeof FOUNDATION_IMPORT_MAP];
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function collectRemainingFoundationImports(
+  content: string
+): Set<FoundationPackage> {
+  const remaining = new Set<FoundationPackage>();
+
+  for (const foundationPackage of FOUNDATION_PACKAGES) {
+    const pattern = new RegExp(
+      `["']${escapeRegex(foundationPackage)}(?:\\/[^"'\\s]+)?["']`
+    );
+    if (pattern.test(content)) {
+      remaining.add(foundationPackage);
+    }
+  }
+
+  return remaining;
+}
+
+function mergeFoundationImportsForPackage(
+  byPackage: Map<string, Set<FoundationPackage>>,
+  packageDir: string,
+  imports: ReadonlySet<FoundationPackage>
+): void {
+  if (imports.size === 0) {
+    return;
+  }
+
+  const existing = byPackage.get(packageDir);
+  if (existing) {
+    for (const importPath of imports) {
+      existing.add(importPath);
+    }
+    return;
+  }
+
+  byPackage.set(packageDir, new Set(imports));
+}
+
+function findOwningPackageDir(
+  filePath: string,
+  packageDirs: readonly string[]
+): string | undefined {
+  const normalizedFilePath = normalizePath(filePath);
+
+  for (const packageDir of packageDirs) {
+    const normalizedPackageDir = normalizePath(packageDir);
+    if (
+      normalizedFilePath === normalizedPackageDir ||
+      normalizedFilePath.startsWith(`${normalizedPackageDir}/`)
+    ) {
+      return packageDir;
+    }
+  }
+
+  return undefined;
+}
+
+function quoteForLiteral(literalText: string): '"' | "'" {
+  return literalText.startsWith("'") ? "'" : '"';
+}
+
+function enqueueModuleSpecifierReplacement(
+  sourceFile: ts.SourceFile,
+  literal: ts.StringLiteral,
+  replacements: Replacement[]
+): boolean {
+  const mapped = mapFoundationSpecifier(literal.text);
+  if (!mapped) {
+    return false;
+  }
+
+  const quote = quoteForLiteral(literal.getText(sourceFile));
+  replacements.push({
+    start: literal.getStart(sourceFile),
+    end: literal.getEnd(),
+    text: `${quote}${mapped}${quote}`,
+  });
+  return true;
+}
+
+function enqueueImportTypeReplacement(
+  sourceFile: ts.SourceFile,
+  node: ts.ImportTypeNode,
+  replacements: Replacement[]
+): boolean {
+  const argument = node.argument;
+  if (!ts.isLiteralTypeNode(argument)) {
+    return false;
+  }
+
+  if (!ts.isStringLiteral(argument.literal)) {
+    return false;
+  }
+
+  return enqueueModuleSpecifierReplacement(
+    sourceFile,
+    argument.literal,
+    replacements
+  );
+}
+
+function enqueueCallExpressionReplacement(
+  sourceFile: ts.SourceFile,
+  node: ts.CallExpression,
+  replacements: Replacement[]
+): boolean {
+  const [firstArg] = node.arguments;
+  if (!(firstArg && ts.isStringLiteral(firstArg))) {
+    return false;
+  }
+
+  const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+  const isRequireCall =
+    ts.isIdentifier(node.expression) && node.expression.text === "require";
+
+  if (!(isDynamicImport || isRequireCall)) {
+    return false;
+  }
+
+  return enqueueModuleSpecifierReplacement(sourceFile, firstArg, replacements);
+}
+
+function applyReplacements(
+  content: string,
+  replacements: readonly Replacement[]
+): string {
+  if (replacements.length === 0) {
+    return content;
+  }
+
+  let next = content;
+  const ordered = [...replacements].sort((a, b) => b.start - a.start);
+
+  for (const replacement of ordered) {
+    next =
+      next.slice(0, replacement.start) +
+      replacement.text +
+      next.slice(replacement.end);
+  }
+
+  return next;
+}
+
+function rewriteFoundationImports(
+  filePath: string
+): Result<{ content: string; rewrites: number }, MigrateKitError> {
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return Result.err(
+      new MigrateKitError(`Failed to read source file ${filePath}: ${message}`)
+    );
+  }
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath)
+  );
+
+  const replacements: Replacement[] = [];
+  let rewrites = 0;
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      if (
+        enqueueModuleSpecifierReplacement(
+          sourceFile,
+          node.moduleSpecifier,
+          replacements
+        )
+      ) {
+        rewrites += 1;
+      }
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      if (
+        enqueueModuleSpecifierReplacement(
+          sourceFile,
+          node.moduleSpecifier,
+          replacements
+        )
+      ) {
+        rewrites += 1;
+      }
+    } else if (ts.isImportTypeNode(node)) {
+      if (enqueueImportTypeReplacement(sourceFile, node, replacements)) {
+        rewrites += 1;
+      }
+    } else if (
+      ts.isCallExpression(node) &&
+      enqueueCallExpressionReplacement(sourceFile, node, replacements)
+    ) {
+      rewrites += 1;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (replacements.length === 0) {
+    return Result.ok({ content, rewrites: 0 });
+  }
+
+  return Result.ok({
+    content: applyReplacements(content, replacements),
+    rewrites,
+  });
+}
+
+function sortRecord(
+  value: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!value) return value;
+  return Object.fromEntries(
+    Object.entries(value).sort(([left], [right]) => left.localeCompare(right))
+  );
+}
+
+function rewriteManifestDependencies(
+  content: string,
+  options?: {
+    keepFoundationPackages?: ReadonlySet<FoundationPackage>;
+    addKitDependency?: boolean;
+  }
+): Result<{ content: string; changed: boolean }, MigrateKitError> {
+  let manifest: ManifestRecord;
+  try {
+    const parsed = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return Result.err(
+        new MigrateKitError("package.json must contain an object")
+      );
+    }
+    manifest = parsed as ManifestRecord;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return Result.err(
+      new MigrateKitError(`Invalid package.json JSON: ${message}`)
+    );
+  }
+
+  const keepFoundationPackages = options?.keepFoundationPackages;
+  const addKitDependency = options?.addKitDependency ?? false;
+  let changed = false;
+  let kitVersionCandidate: string | undefined;
+  let kitSectionCandidate: DependencySection | undefined;
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const current = manifest[section];
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      continue;
+    }
+
+    const deps = { ...(current as Record<string, unknown>) };
+
+    for (const foundationName of FOUNDATION_PACKAGES) {
+      const version = deps[foundationName];
+      if (typeof version !== "string") {
+        continue;
+      }
+
+      if (!kitVersionCandidate) {
+        kitVersionCandidate = version;
+        kitSectionCandidate = section;
+      }
+
+      if (keepFoundationPackages?.has(foundationName)) {
+        continue;
+      }
+
+      delete deps[foundationName];
+      changed = true;
+    }
+
+    manifest[section] = sortRecord(deps);
+  }
+
+  let hasKitDependency = false;
+  for (const section of DEPENDENCY_SECTIONS) {
+    const current = manifest[section];
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      continue;
+    }
+
+    const deps = current as Record<string, unknown>;
+    if (typeof deps["@outfitter/kit"] === "string") {
+      hasKitDependency = true;
+      break;
+    }
+  }
+
+  const shouldAddKit = addKitDependency || changed;
+  if (kitVersionCandidate && shouldAddKit && !hasKitDependency) {
+    const targetSection = kitSectionCandidate ?? "dependencies";
+    const existingSection = manifest[targetSection];
+    const deps =
+      existingSection &&
+      typeof existingSection === "object" &&
+      !Array.isArray(existingSection)
+        ? { ...(existingSection as Record<string, unknown>) }
+        : {};
+
+    deps["@outfitter/kit"] = kitVersionCandidate;
+    manifest[targetSection] = sortRecord(deps);
+    changed = true;
+  }
+
+  if (!changed) {
+    return Result.ok({ content, changed: false });
+  }
+
+  return Result.ok({
+    content: `${JSON.stringify(manifest, null, 2)}\n`,
+    changed: true,
+  });
+}
+
+interface DiffOp {
+  readonly type: "equal" | "remove" | "add";
+  readonly line: string;
+}
+
+function splitLines(value: string): string[] {
+  return value.replace(/\r\n/g, "\n").split("\n");
+}
+
+function createLineDiff(before: string, after: string): DiffOp[] {
+  const left = splitLines(before);
+  const right = splitLines(after);
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+
+  const lcs: number[][] = Array.from({ length: rows }, () =>
+    new Array<number>(cols).fill(0)
+  );
+
+  for (let i = left.length - 1; i >= 0; i -= 1) {
+    const row = lcs[i];
+    if (!row) {
+      continue;
+    }
+
+    for (let j = right.length - 1; j >= 0; j -= 1) {
+      const leftLine = left[i];
+      const rightLine = right[j];
+
+      if (leftLine === rightLine) {
+        row[j] = 1 + (lcs[i + 1]?.[j + 1] ?? 0);
+      } else {
+        row[j] = Math.max(lcs[i + 1]?.[j] ?? 0, lcs[i]?.[j + 1] ?? 0);
+      }
+    }
+  }
+
+  const ops: DiffOp[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < left.length && j < right.length) {
+    const leftLine = left[i];
+    const rightLine = right[j];
+    if (leftLine === undefined || rightLine === undefined) {
+      break;
+    }
+
+    if (leftLine === rightLine) {
+      ops.push({ type: "equal", line: leftLine });
+      i += 1;
+      j += 1;
+      continue;
+    }
+
+    if ((lcs[i + 1]?.[j] ?? 0) >= (lcs[i]?.[j + 1] ?? 0)) {
+      ops.push({ type: "remove", line: leftLine });
+      i += 1;
+    } else {
+      ops.push({ type: "add", line: rightLine });
+      j += 1;
+    }
+  }
+
+  while (i < left.length) {
+    const line = left[i];
+    if (line === undefined) break;
+    ops.push({ type: "remove", line });
+    i += 1;
+  }
+
+  while (j < right.length) {
+    const line = right[j];
+    if (line === undefined) break;
+    ops.push({ type: "add", line });
+    j += 1;
+  }
+
+  return ops;
+}
+
+function createUnifiedDiff(
+  filePath: string,
+  before: string,
+  after: string
+): string {
+  if (before === after) {
+    return "";
+  }
+
+  const ops = createLineDiff(before, after);
+  const context = 3;
+  const changedIndexes = ops
+    .map((op, index) => (op.type === "equal" ? -1 : index))
+    .filter((index) => index >= 0);
+
+  if (changedIndexes.length === 0) {
+    return "";
+  }
+
+  const firstChanged = changedIndexes[0];
+  if (firstChanged === undefined) {
+    return "";
+  }
+
+  const hunks: Array<{ start: number; end: number }> = [];
+  let groupStart = firstChanged;
+  let previous = firstChanged;
+
+  for (let index = 1; index < changedIndexes.length; index += 1) {
+    const current = changedIndexes[index];
+    if (current === undefined) {
+      continue;
+    }
+    if (current - previous <= context * 2) {
+      previous = current;
+      continue;
+    }
+
+    hunks.push({
+      start: Math.max(0, groupStart - context),
+      end: Math.min(ops.length, previous + context + 1),
+    });
+    groupStart = current;
+    previous = current;
+  }
+
+  hunks.push({
+    start: Math.max(0, groupStart - context),
+    end: Math.min(ops.length, previous + context + 1),
+  });
+
+  const oldLineAt: number[] = [];
+  const newLineAt: number[] = [];
+  let oldLine = 1;
+  let newLine = 1;
+
+  for (const op of ops) {
+    oldLineAt.push(oldLine);
+    newLineAt.push(newLine);
+    if (op.type !== "add") {
+      oldLine += 1;
+    }
+    if (op.type !== "remove") {
+      newLine += 1;
+    }
+  }
+
+  const lines: string[] = [`--- a/${filePath}`, `+++ b/${filePath}`];
+
+  for (const hunk of hunks) {
+    const oldStart = oldLineAt[hunk.start] ?? 1;
+    const newStart = newLineAt[hunk.start] ?? 1;
+    let oldCount = 0;
+    let newCount = 0;
+
+    for (let index = hunk.start; index < hunk.end; index += 1) {
+      const op = ops[index];
+      if (!op) {
+        continue;
+      }
+      if (op.type !== "add") {
+        oldCount += 1;
+      }
+      if (op.type !== "remove") {
+        newCount += 1;
+      }
+    }
+
+    lines.push(`@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`);
+
+    for (let index = hunk.start; index < hunk.end; index += 1) {
+      const op = ops[index];
+      if (!op) {
+        continue;
+      }
+      if (op.type === "equal") {
+        lines.push(` ${op.line}`);
+      } else if (op.type === "remove") {
+        lines.push(`-${op.line}`);
+      } else {
+        lines.push(`+${op.line}`);
+      }
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function writeChanges(
+  changes: readonly ChangeSet[],
+  dryRun: boolean
+): Result<void, MigrateKitError> {
+  if (dryRun) {
+    return Result.ok(undefined);
+  }
+
+  for (const change of changes) {
+    try {
+      writeFileSync(change.path, change.after, "utf-8");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return Result.err(
+        new MigrateKitError(`Failed to write ${change.path}: ${message}`)
+      );
+    }
+  }
+
+  return Result.ok(undefined);
+}
+
+/**
+ * Runs the migrate-kit codemod programmatically.
+ */
+// biome-ignore lint/suspicious/useAwait: async for API consistency with other command runners.
+export async function runMigrateKit(
+  options: MigrateKitOptions
+): Promise<Result<MigrateKitResult, MigrateKitError>> {
+  const targetDir = resolve(options.targetDir ?? process.cwd());
+  const dryRun = options.dryRun ?? false;
+
+  const packageJsonResult = collectPackageJsonFiles(targetDir);
+  if (packageJsonResult.isErr()) {
+    return packageJsonResult;
+  }
+  const packageJsonFiles = packageJsonResult.value;
+  const packageDirectories = Array.from(
+    new Set(packageJsonFiles.map((path) => resolve(dirname(path))))
+  ).sort((left, right) => right.length - left.length);
+
+  const sourceSet = new Set<string>();
+  for (const packageDir of packageDirectories) {
+    const sourceFilesResult = collectSourceFiles(packageDir);
+    if (sourceFilesResult.isErr()) {
+      return sourceFilesResult;
+    }
+
+    for (const file of sourceFilesResult.value) {
+      sourceSet.add(file);
+    }
+  }
+  const sourceFiles = Array.from(sourceSet).sort((a, b) => a.localeCompare(b));
+  const remainingFoundationImportsByPackage = new Map<
+    string,
+    Set<FoundationPackage>
+  >();
+  const rewritesByPackage = new Map<string, number>();
+
+  const changes: ChangeSet[] = [];
+  const diffs: DiffPreview[] = [];
+  let importRewrites = 0;
+  let manifestUpdates = 0;
+
+  for (const sourceFile of sourceFiles) {
+    const rewriteResult = rewriteFoundationImports(sourceFile);
+    if (rewriteResult.isErr()) {
+      return rewriteResult;
+    }
+
+    const packageDir = findOwningPackageDir(sourceFile, packageDirectories);
+    if (packageDir) {
+      const remainingImports = collectRemainingFoundationImports(
+        rewriteResult.value.content
+      );
+      mergeFoundationImportsForPackage(
+        remainingFoundationImportsByPackage,
+        packageDir,
+        remainingImports
+      );
+
+      if (rewriteResult.value.rewrites > 0) {
+        rewritesByPackage.set(
+          packageDir,
+          (rewritesByPackage.get(packageDir) ?? 0) + rewriteResult.value.rewrites
+        );
+      }
+    }
+
+    if (rewriteResult.value.rewrites === 0) {
+      continue;
+    }
+
+    const before = readFileSync(sourceFile, "utf-8");
+    const after = rewriteResult.value.content;
+    if (before === after) {
+      continue;
+    }
+
+    importRewrites += rewriteResult.value.rewrites;
+    const path = normalizePath(relative(targetDir, sourceFile));
+    changes.push({ path: sourceFile, before, after });
+    diffs.push({ path, preview: createUnifiedDiff(path, before, after) });
+  }
+
+  for (const packageJsonPath of packageJsonFiles) {
+    let before: string;
+    try {
+      before = readFileSync(packageJsonPath, "utf-8");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return Result.err(
+        new MigrateKitError(`Failed to read ${packageJsonPath}: ${message}`)
+      );
+    }
+
+    const packageDir = resolve(dirname(packageJsonPath));
+    const keepFoundationPackages =
+      remainingFoundationImportsByPackage.get(packageDir);
+    const rewriteResult = rewriteManifestDependencies(before, {
+      ...(keepFoundationPackages ? { keepFoundationPackages } : {}),
+      addKitDependency: (rewritesByPackage.get(packageDir) ?? 0) > 0,
+    });
+    if (rewriteResult.isErr()) {
+      return rewriteResult;
+    }
+
+    if (
+      !rewriteResult.value.changed ||
+      rewriteResult.value.content === before
+    ) {
+      continue;
+    }
+
+    manifestUpdates += 1;
+    const path = normalizePath(relative(targetDir, packageJsonPath));
+    changes.push({
+      path: packageJsonPath,
+      before,
+      after: rewriteResult.value.content,
+    });
+    diffs.push({
+      path,
+      preview: createUnifiedDiff(path, before, rewriteResult.value.content),
+    });
+  }
+
+  const writeResult = writeChanges(changes, dryRun);
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  const changedFiles = changes
+    .map((change) => normalizePath(relative(targetDir, change.path)))
+    .sort((a, b) => a.localeCompare(b));
+
+  return Result.ok({
+    targetDir,
+    dryRun,
+    packageJsonFiles: packageJsonFiles.length,
+    sourceFiles: sourceFiles.length,
+    manifestUpdates,
+    importRewrites,
+    changedFiles,
+    diffs: diffs.sort((left, right) => left.path.localeCompare(right.path)),
+  });
+}
+
+/**
+ * Print migrate-kit results.
+ */
+export async function printMigrateKitResults(
+  result: MigrateKitResult,
+  options?: { mode?: OutputMode }
+): Promise<void> {
+  const mode = options?.mode;
+  if (mode === "json" || mode === "jsonl") {
+    await output(result, { mode });
+    return;
+  }
+
+  const lines: string[] = [];
+
+  if (result.changedFiles.length === 0) {
+    lines.push("No kit migration changes needed.");
+    await output(lines);
+    return;
+  }
+
+  lines.push(
+    result.dryRun
+      ? "Dry run complete. No files were written."
+      : "Migration complete.",
+    ""
+  );
+  lines.push(`Changed files: ${result.changedFiles.length}`);
+  lines.push(`Import rewrites: ${result.importRewrites}`);
+  lines.push(`Manifest updates: ${result.manifestUpdates}`, "");
+
+  for (const file of result.changedFiles) {
+    lines.push(`  - ${file}`);
+  }
+
+  if (result.dryRun && result.diffs.length > 0) {
+    lines.push("", "Diff preview:", "");
+    for (const diff of result.diffs) {
+      lines.push(diff.preview.trimEnd(), "");
+    }
+  }
+
+  await output(lines);
+}
+
+/**
+ * Register `migrate kit` command directly on Commander.
+ */
+export function migrateKitCommand(program: Command): void {
+  interface CliFlags {
+    readonly dryRun?: unknown;
+    readonly json?: unknown;
+  }
+
+  const existingMigrate = program.commands.find(
+    (command) => command.name() === "migrate"
+  );
+  const migrate =
+    existingMigrate ??
+    program.command("migrate").description("Migration commands");
+
+  if (migrate.commands.some((command) => command.name() === "kit")) {
+    return;
+  }
+
+  migrate
+    .command("kit [directory]")
+    .description(
+      "Migrate foundation imports and dependencies to @outfitter/kit"
+    )
+    .option("--dry-run", "Preview changes without writing files", false)
+    .option("--json", "Output result as JSON", false)
+    .action(async (directory: string | undefined, flags: CliFlags) => {
+      if (flags.json) {
+        process.env["OUTFITTER_JSON"] = "1";
+      }
+
+      const result = await runMigrateKit({
+        ...(directory ? { targetDir: directory } : {}),
+        dryRun: Boolean(flags.dryRun),
+      });
+
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      await printMigrateKitResults(
+        result.value,
+        flags.json ? { mode: "json" } : undefined
+      );
+    });
+}

--- a/apps/outfitter/src/index.ts
+++ b/apps/outfitter/src/index.ts
@@ -41,6 +41,15 @@ export {
   initCommand,
   runInit,
 } from "./commands/init.js";
+// Migrate kit command
+export {
+  MigrateKitError,
+  type MigrateKitOptions,
+  type MigrateKitResult,
+  migrateKitCommand,
+  printMigrateKitResults,
+  runMigrateKit,
+} from "./commands/migrate-kit.js";
 
 // Create planner
 export {


### PR DESCRIPTION
## Summary
- Adds `outfitter migrate-kit` codemod command for adoption/migration.
- Performs AST-based import rewrites for kit migration scenarios.

## Scope
- Codemod command implementation and migration transforms.
- Tests for rewrite correctness and edge cases.

## Validation
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test`
