### PR TITLE
feat(contracts): add AlreadyExistsError and improve conflict error DX

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -85,6 +85,7 @@ export {
 } from "./envelope.js";
 // Errors
 export {
+  AlreadyExistsError,
   AmbiguousError,
   type AnyKitError,
   AssertionError,


### PR DESCRIPTION
## Summary

Adds `AlreadyExistsError` — the inverse of `NotFoundError` — as a dedicated error class for "resource already exists" scenarios. Also improves `ConflictError` documentation with decision guidance.

**Changes:**
- New `AlreadyExistsError` class with `resourceType`/`resourceId` fields (mirrors `NotFoundError`)
- Maps to `conflict` category (HTTP 409, exit code 3)
- Static factory: `AlreadyExistsError.create("file", "notes/meeting.md")`
- Updated `ConflictError` JSDoc with "choosing the right conflict error" guidance
- Full serialization/deserialization support
- 8 new tests (6 class behavior + 2 static factory)

**Context:** Filed from obsidian-glass adoption (OS-93). When implementing a `fileNew` handler that rejects writes to existing files, `ConflictError`'s docstring ("optimistic locking, concurrent modification") didn't clearly cover "already exists." The error code taxonomy already had `ALREADY_EXISTS: 3001` under conflict, but the class itself didn't surface this use case.

Closes OS-93

## Test plan

- [x] All 310 contracts tests pass (8 new)
- [x] Typecheck passes
- [x] Serialization round-trips correctly

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)