### PR TITLE
docs: run full documentation consistency pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ CLI and MCP are thin adapters over shared handlers. Handlers know nothing about 
 | permission | 4 | 403 |
 | timeout | 5 | 504 |
 | rate_limit | 6 | 429 |
-| network | 7 | 503 |
+| network | 7 | 502 |
 | internal | 8 | 500 |
 | auth | 9 | 401 |
 | cancelled | 130 | 499 |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shared infrastructure for building AI-agent-ready tools. CLIs, MCP servers, daem
 ## Quick Start
 
 ```bash
-bunx outfitter init cli my-project
+bunx outfitter create my-project --preset cli --structure single --yes
 cd my-project
 bun install
 bun run dev
@@ -99,7 +99,7 @@ bun run typecheck    # TypeScript validation
 
 ## Requirements
 
-Bun >= 1.3.6
+Bun >= 1.3.7
 
 ## License
 

--- a/apps/outfitter/README.md
+++ b/apps/outfitter/README.md
@@ -1,6 +1,6 @@
 # outfitter
 
-Umbrella CLI for scaffolding Outfitter projects and managing development environments.
+Umbrella CLI for scaffolding Outfitter projects and managing workspace adoption.
 
 ## Installation
 
@@ -11,186 +11,234 @@ bun add -g outfitter
 Or run directly with `bunx`:
 
 ```bash
-bunx outfitter init cli my-project
+bunx outfitter --help
 ```
 
 ## Quick Start
 
 ```bash
-# Scaffold a new CLI project
-outfitter init cli my-cli
-
-# Scaffold a new MCP server
-outfitter init mcp my-mcp
-
-# Scaffold a new daemon
-outfitter init daemon my-daemon
-
-# Check your environment
-outfitter doctor
+# Scaffold a new CLI project with defaults
+bunx outfitter create my-cli --preset cli --structure single --yes
+cd my-cli
+bun install
+bun run dev
 ```
 
-## Commands
+## CLI Overview
 
-### init
+```text
+outfitter [--json] <command>
+```
 
-Scaffolds a new Outfitter project from a template.
+Global options:
+
+- `--json` - Force JSON output for supported commands
+
+Top-level commands:
+
+- `create [directory]` - Interactive/new scaffolding flow (single package or workspace)
+- `init [directory]` - Template scaffolding with explicit flags
+- `add <block>` - Add a tooling block (`claude`, `biome`, `lefthook`, `bootstrap`, `scaffolding`)
+- `migrate kit [directory]` - Migrate foundation imports and dependencies to `@outfitter/kit`
+- `update` - Check installed `@outfitter/*` versions and optionally show migration guidance
+- `doctor` - Validate local environment and project dependencies
+- `demo [section]` - Showcase `@outfitter/cli` rendering
+
+## Command Reference
+
+### `create`
+
+Interactive/default scaffolding flow.
 
 ```bash
-outfitter init <cli|mcp|daemon> [directory] [options]
-outfitter init [directory] --template <template> [options]
+outfitter create [directory] [options]
 ```
 
-**Arguments:**
-- `directory` - Target directory (defaults to current directory)
+Options:
 
-**Options:**
-- `-n, --name <name>` - Project name (defaults to directory name)
-- `-b, --bin <name>` - Binary name (defaults to project name)
-- `-t, --template <template>` - Template to use (default: `basic`, used with `outfitter init`)
+- `-n, --name <name>` - Package name
+- `-p, --preset <preset>` - `basic | cli | daemon | mcp`
+- `-s, --structure <structure>` - `single | workspace`
+- `--workspace-name <name>` - Workspace root package name
+- `--local` - Use `workspace:*` for `@outfitter/*` dependencies
+- `--workspace` - Alias for `--local`
+- `-f, --force` - Overwrite existing files
+- `--with <blocks>` - Add specific tooling blocks
+- `--no-tooling` - Skip default tooling blocks
+- `-y, --yes` - Skip prompts and use defaults
+
+Examples:
+
+```bash
+outfitter create my-cli --preset cli --structure single --yes
+outfitter create . --preset mcp --yes --no-tooling
+outfitter create my-workspace --structure workspace --workspace-name @acme/root
+```
+
+### `init`
+
+Template-first scaffolding flow.
+
+```bash
+outfitter init [directory] [options]
+outfitter init cli [directory] [options]
+outfitter init mcp [directory] [options]
+outfitter init daemon [directory] [options]
+```
+
+Options:
+
+- `-n, --name <name>` - Package name
+- `-b, --bin <name>` - Binary name
+- `-t, --template <template>` - Template (`basic`, `cli`, `mcp`, `daemon`)
+- `--local` - Use `workspace:*` for `@outfitter/*` dependencies
+- `--workspace` - Alias for `--local`
+- `--with <blocks>` - Add specific tooling blocks
+- `--no-tooling` - Skip tooling setup
 - `-f, --force` - Overwrite existing files
 
-**Templates:**
-| Template | Description |
-|----------|-------------|
-| `basic` | Minimal TypeScript project structure |
-| `cli` | CLI application with Commander.js |
-| `mcp` | MCP server with typed tools |
-| `daemon` | Background daemon with IPC and health checks |
-
-**Examples:**
+Examples:
 
 ```bash
-# Create in new directory
 outfitter init cli my-project
-
-# Create with specific template
-outfitter init mcp my-mcp
-
-# Create in current directory with custom name
-outfitter init . --name my-custom-name
-
-# Create with a custom binary name
-outfitter init cli my-project --bin my-cli
-
-# Force overwrite existing files
-outfitter init my-project --force
+outfitter init . --template basic --name my-lib
+outfitter init mcp . --name my-mcp --no-tooling
 ```
 
-### doctor
+### `add`
 
-Validates your environment and project dependencies.
+Add a tooling block from the registry.
+
+```bash
+outfitter add <block> [options]
+outfitter add list
+```
+
+Options:
+
+- `-f, --force` - Overwrite existing files
+- `--dry-run` - Preview without writing files
+
+Examples:
+
+```bash
+outfitter add scaffolding
+outfitter add biome --dry-run
+outfitter add list
+```
+
+### `migrate kit`
+
+Codemod for kit-first foundation adoption.
+
+```bash
+outfitter migrate kit [directory] [options]
+```
+
+Options:
+
+- `--dry-run` - Preview changes without writing files
+
+Examples:
+
+```bash
+outfitter migrate kit --dry-run
+outfitter migrate kit .
+```
+
+### `update`
+
+Check installed `@outfitter/*` packages against npm versions.
+
+```bash
+outfitter update [options]
+```
+
+Options:
+
+- `--guide` - Include composed migration guidance
+- `--cwd <path>` - Working directory to inspect
+
+Examples:
+
+```bash
+outfitter update
+outfitter update --guide
+outfitter update --json --cwd .
+```
+
+### `doctor`
+
+Validate local environment and project structure.
 
 ```bash
 outfitter doctor
 ```
 
-Performs the following checks:
-- **Bun Version** - Ensures Bun >= 1.3.6 is installed
-- **package.json** - Validates required fields (name, version)
-- **Dependencies** - Checks if node_modules is present and complete
-- **tsconfig.json** - Verifies TypeScript configuration exists
-- **src/ directory** - Confirms source directory structure
+### `demo`
 
-**Example output:**
+Showcase CLI rendering primitives.
 
-```
-Outfitter Doctor
-
-==================================================
-[PASS] Bun Version: 1.3.6 (requires 1.3.6)
-[PASS] package.json
-       my-project@0.1.0-rc.0
-[PASS] Dependencies
-       12 dependencies installed
-[PASS] tsconfig.json
-[PASS] src/ directory
-
-==================================================
-5/5 checks passed
+```bash
+outfitter demo [section] [options]
 ```
 
-## Template Variables
+Options:
 
-Templates use placeholder syntax for project-specific values:
-
-| Placeholder | Description | Default |
-|-------------|-------------|---------|
-| `{{name}}` | Project name (legacy) | Directory name |
-| `{{projectName}}` | Project name | Directory name |
-| `{{binName}}` | Binary name | Project name |
-| `{{version}}` | Initial version | `0.1.0-rc.0` |
-| `{{description}}` | Project description | Generic description |
-
-Files ending in `.template` have their extension removed after processing (e.g., `package.json.template` becomes `package.json`).
+- `-l, --list` - List available sections
+- `-a, --animate` - Run animated spinner demo
 
 ## Programmatic API
 
-The CLI commands are also available as a programmatic API:
+Root exports:
 
 ```typescript
-import { runInit, runDoctor } from "outfitter";
-
-// Initialize a project programmatically
-const initResult = await runInit({
-  targetDir: "./my-project",
-  name: "my-project",
-  template: "cli",
-  force: false,
-});
-
-if (initResult.isErr()) {
-  console.error("Failed:", initResult.error.message);
-}
-
-// Run doctor checks programmatically
-const doctorResult = await runDoctor({ cwd: process.cwd() });
-
-if (doctorResult.exitCode === 0) {
-  console.log("All checks passed!");
-} else {
-  console.log(`${doctorResult.summary.failed} checks failed`);
-}
+import {
+  runCreate,
+  runDoctor,
+  runInit,
+  runMigrateKit,
+  type CreateOptions,
+  type InitOptions,
+  type MigrateKitOptions,
+} from "outfitter";
 ```
 
-### API Types
+Command subpath exports:
 
 ```typescript
-interface InitOptions {
-  readonly targetDir: string;
-  readonly name: string | undefined;
-  readonly template: string | undefined;
-  readonly force: boolean;
-}
+import { runAdd } from "outfitter/commands/add";
+import { runUpdate } from "outfitter/commands/update";
+```
 
-interface DoctorOptions {
-  readonly cwd: string;
-}
+Example:
 
-interface DoctorResult {
-  readonly checks: {
-    readonly bunVersion: BunVersionCheck;
-    readonly packageJson: PackageJsonCheck;
-    readonly dependencies: DependenciesCheck;
-    readonly configFiles: ConfigFilesCheck;
-    readonly directories: DirectoriesCheck;
-  };
-  readonly summary: DoctorSummary;
-  readonly exitCode: number;
+```typescript
+import { runCreate } from "outfitter";
+
+const result = await runCreate({
+  targetDir: "./my-app",
+  preset: "cli",
+  structure: "single",
+  force: false,
+  yes: true,
+});
+
+if (result.isErr()) {
+  console.error(result.error.message);
 }
 ```
 
 ## Requirements
 
-- Bun >= 1.3.6
+- Bun >= 1.3.7
 
 ## Related Packages
 
-- `@outfitter/cli` - CLI framework for building command-line tools
+- `@outfitter/cli` - CLI framework primitives
+- `@outfitter/contracts` - Result and error contracts
 - `@outfitter/mcp` - MCP server framework
-- `@outfitter/daemon` - Daemon lifecycle management
-- `@outfitter/config` - Configuration loading
-- `@outfitter/contracts` - Result types and error patterns
+- `@outfitter/tooling` - Tooling presets and verification CLI
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,7 +213,7 @@ switch (error._tag) {
   case "NotFoundError":
     return res.status(404).json({ error: error.message });
   case "ValidationError":
-    return res.status(400).json({ error: error.message, details: error.details });
+    return res.status(400).json({ error: error.message, context: error.context });
   // TypeScript ensures all cases are handled
 }
 ```
@@ -288,7 +288,7 @@ Ten error categories cover all failure modes:
 | `permission` | 4 | 403 | Forbidden action |
 | `timeout` | 5 | 504 | Operation took too long |
 | `rate_limit` | 6 | 429 | Too many requests |
-| `network` | 7 | 503 | Connection failures |
+| `network` | 7 | 502 | Connection failures |
 | `internal` | 8 | 500 | Unexpected errors, bugs |
 | `auth` | 9 | 401 | Authentication required |
 | `cancelled` | 130 | 499 | User interrupted (Ctrl+C) |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -4,7 +4,7 @@ Build CLI tools, MCP servers, and daemons with Outfitter's shared infrastructure
 
 ## Prerequisites
 
-- **Bun >= 1.3.6** — Install from [bun.sh](https://bun.sh)
+- **Bun >= 1.3.7** — Install from [bun.sh](https://bun.sh)
 - **TypeScript knowledge** — Outfitter is TypeScript-first
 - **Familiarity with Result types** — See [Patterns](./PATTERNS.md) if new to this style
 
@@ -14,7 +14,7 @@ The fastest way to start is with the `outfitter` CLI:
 
 ```bash
 # Scaffold a CLI project
-bunx outfitter init cli my-cli
+bunx outfitter create my-cli --preset cli --structure single --yes
 cd my-cli
 bun install
 bun run dev
@@ -33,7 +33,7 @@ Commands:
 
 This creates a working CLI with:
 - Typed commands via Commander.js
-- Output mode detection (human/JSON)
+- Human-first output with JSON/JSONL opt-in
 - Error handling with exit codes
 - XDG-compliant config loading
 

--- a/docs/RESULT-API.md
+++ b/docs/RESULT-API.md
@@ -283,9 +283,9 @@ For RPC boundaries and MCP transport. These are standalone functions from `@outf
 Convert an `OutfitterError` to a JSON-safe `SerializedError` object.
 
 ```typescript
-import { serializeError } from "@outfitter/contracts";
+import { NotFoundError, serializeError } from "@outfitter/contracts";
 
-const serialized = serializeError(new NotFoundError("note", "abc123"));
+const serialized = serializeError(NotFoundError.create("note", "abc123"));
 // { _tag: "NotFoundError", category: "not_found", message: "...", context: { resourceType: "note", resourceId: "abc123" } }
 ```
 

--- a/packages/claude-plugin/agents/implementer.md
+++ b/packages/claude-plugin/agents/implementer.md
@@ -96,7 +96,7 @@ export const myHandler: Handler<unknown, Output, ValidationError | NotFoundError
 
   const resource = await fetchResource(input.id);
   if (!resource) {
-    return Result.err(new NotFoundError("resource", input.id));
+    return Result.err(NotFoundError.create("resource", input.id));
   }
 
   return Result.ok(resource);
@@ -161,16 +161,16 @@ export const handler: Handler<unknown, Output, Error1 | Error2> = async (
 
 ```typescript
 // Not found
-return Result.err(new NotFoundError("user", userId));
+return Result.err(NotFoundError.create("user", userId));
 
 // Validation
-return Result.err(new ValidationError("Invalid email", { field: "email" }));
+return Result.err(ValidationError.create("email", "invalid"));
 
 // Conflict
-return Result.err(new ConflictError("User already exists", { userId }));
+return Result.err(ConflictError.create("User already exists", { userId }));
 
 // Internal (wrap unexpected)
-return Result.err(new InternalError("Unexpected error", { cause: error }));
+return Result.err(InternalError.create("Unexpected error", { cause: error }));
 ```
 
 ### Output Pattern

--- a/packages/claude-plugin/agents/reviewer.md
+++ b/packages/claude-plugin/agents/reviewer.md
@@ -142,7 +142,7 @@ Check context:
 
 1. **[file:line]** Throwing exception instead of Result.err
    - Found: `throw new Error("Not found")`
-   - Fix: `return Result.err(new NotFoundError("resource", id))`
+   - Fix: `return Result.err(NotFoundError.create("resource", id))`
 
 2. **[file:line]** Missing context parameter
    - Found: `async (input) => { ... }`

--- a/packages/claude-plugin/skills/debug/SKILL.md
+++ b/packages/claude-plugin/skills/debug/SKILL.md
@@ -19,7 +19,7 @@ Troubleshoot @outfitter/* package issues.
 ```typescript
 const inputResult = validateInput(rawInput);
 if (inputResult.isErr()) {
-  console.log("Validation failed:", inputResult.error.details);
+  console.log("Validation failed:", inputResult.error.context);
   return inputResult;
 }
 ```
@@ -57,7 +57,7 @@ const updateResult = await updateUser(getResult.value);
 if (result.isErr()) {
   switch (result.error._tag) {
     case "ValidationError":
-      console.log(result.error.details);
+      console.log(result.error.context);
       break;
     case "NotFoundError":
       console.log(result.error.resourceId);

--- a/packages/claude-plugin/skills/migration/SKILL.md
+++ b/packages/claude-plugin/skills/migration/SKILL.md
@@ -68,7 +68,7 @@ import { Result, NotFoundError, type Handler } from "@outfitter/contracts";
 
 const getUser: Handler<{ id: string }, User, NotFoundError> = async (input, ctx) => {
   const user = await db.users.findById(input.id);
-  if (!user) return Result.err(new NotFoundError("user", input.id));
+  if (!user) return Result.err(NotFoundError.create("user", input.id));
   return Result.ok(user);
 };
 ```
@@ -126,7 +126,7 @@ import { Result, InternalError } from "@outfitter/contracts";
 function wrapLegacy<T>(fn: () => Promise<T>): Promise<Result<T, InternalError>> {
   return fn()
     .then((value) => Result.ok(value))
-    .catch((error) => Result.err(new InternalError(error.message, { cause: error })));
+    .catch((error) => Result.err(InternalError.create(error.message, { cause: error })));
 }
 ```
 

--- a/packages/claude-plugin/skills/migration/templates/plan/02-handlers.md
+++ b/packages/claude-plugin/skills/migration/templates/plan/02-handlers.md
@@ -65,7 +65,7 @@ import { Result, NotFoundError, type Handler } from "@outfitter/contracts";
 
 const getUser: Handler<{ id: string }, User, NotFoundError> = async (input, ctx) => {
   const user = await db.users.findById(input.id);
-  if (!user) return Result.err(new NotFoundError("user", input.id));
+  if (!user) return Result.err(NotFoundError.create("user", input.id));
   return Result.ok(user);
 };
 

--- a/packages/claude-plugin/skills/migration/templates/plan/03-errors.md
+++ b/packages/claude-plugin/skills/migration/templates/plan/03-errors.md
@@ -18,7 +18,7 @@ Replace custom error classes with Outfitter error taxonomy.
 | `permission` | `PermissionError` | 4 | 403 | Forbidden action |
 | `timeout` | `TimeoutError` | 5 | 504 | Operation took too long |
 | `rate_limit` | `RateLimitError` | 6 | 429 | Too many requests |
-| `network` | `NetworkError` | 7 | 503 | Connection failures |
+| `network` | `NetworkError` | 7 | 502 | Connection failures |
 | `internal` | `InternalError` | 8 | 500 | Unexpected errors, bugs |
 | `auth` | `AuthError` | 9 | 401 | Authentication required |
 | `cancelled` | `CancelledError` | 130 | 499 | User interrupted |

--- a/packages/claude-plugin/skills/migration/templates/plan/04-paths.md
+++ b/packages/claude-plugin/skills/migration/templates/plan/04-paths.md
@@ -54,7 +54,9 @@ import { securePath } from "@outfitter/file-ops";
 const validatePath = (userPath: string, baseDir: string) => {
   const result = securePath(userPath, { base: baseDir });
   if (result.isErr()) {
-    return Result.err(new ValidationError("Invalid path", { path: userPath }));
+    return Result.err(
+      ValidationError.create("path", "invalid", { path: userPath })
+    );
   }
   return Result.ok(result.value);
 };

--- a/packages/claude-plugin/skills/outfitter-cli/SKILL.md
+++ b/packages/claude-plugin/skills/outfitter-cli/SKILL.md
@@ -56,7 +56,7 @@ export const myCommand = command("my-command")
 ```typescript
 import { output } from "@outfitter/cli";
 
-await output(data);  // Human for TTY, JSON for pipes
+await output(data);  // Human by default
 ```
 
 ### Mode Priority
@@ -65,7 +65,7 @@ await output(data);  // Human for TTY, JSON for pipes
 2. `OUTFITTER_JSONL=1` env var
 3. `OUTFITTER_JSON=1` env var
 4. `OUTFITTER_JSON=0` forces human
-5. TTY detection fallback
+5. Default fallback: human mode
 
 ### Forcing Modes
 

--- a/packages/claude-plugin/skills/outfitter-mcp/SKILL.md
+++ b/packages/claude-plugin/skills/outfitter-mcp/SKILL.md
@@ -183,12 +183,12 @@ server.registerPrompt({
 ```typescript
 handler: async (input) => {
   if (!input.query) {
-    return Result.err(new ValidationError("Query is required"));
+    return Result.err(ValidationError.create("query", "is required"));
   }
 
   const item = await findItem(input.id);
   if (!item) {
-    return Result.err(new NotFoundError("item", input.id));
+    return Result.err(NotFoundError.create("item", input.id));
   }
 
   return Result.ok(item);

--- a/packages/claude-plugin/skills/outfitter-testing/SKILL.md
+++ b/packages/claude-plugin/skills/outfitter-testing/SKILL.md
@@ -226,8 +226,8 @@ expect(result.isErr()).toBe(true);
 expect(result.error._tag).toBe("NotFoundError");
 expect(result.error.category).toBe("not_found");
 
-// Error details
-expect(result.error.details).toMatchObject({
+// Error context
+expect(result.error.context).toMatchObject({
   field: "email",
 });
 ```

--- a/packages/claude-plugin/skills/patterns/SKILL.md
+++ b/packages/claude-plugin/skills/patterns/SKILL.md
@@ -33,7 +33,7 @@ export const getUser: Handler<{ id: string }, User, NotFoundError> = async (inpu
   const user = await db.users.findById(input.id);
 
   if (!user) {
-    return Result.err(new NotFoundError("user", input.id));
+    return Result.err(NotFoundError.create("user", input.id));
   }
   return Result.ok(user);
 };
@@ -46,11 +46,11 @@ export const getUser: Handler<{ id: string }, User, NotFoundError> = async (inpu
 Uses `Result<T, E>` from `better-result` for explicit error handling.
 
 ```typescript
-import { Result } from "@outfitter/contracts";
+import { NotFoundError, Result } from "@outfitter/contracts";
 
 // Create
 const ok = Result.ok({ name: "Alice" });
-const err = Result.err(new NotFoundError("user", "123"));
+const err = Result.err(NotFoundError.create("user", "123"));
 
 // Check
 if (result.isOk()) {
@@ -81,7 +81,7 @@ Ten categories map to exit codes and HTTP status:
 | `permission` | 4 | 403 | Forbidden action |
 | `timeout` | 5 | 504 | Operation took too long |
 | `rate_limit` | 6 | 429 | Too many requests |
-| `network` | 7 | 503 | Connection failures |
+| `network` | 7 | 502 | Connection failures |
 | `internal` | 8 | 500 | Unexpected errors, bugs |
 | `auth` | 9 | 401 | Authentication required |
 | `cancelled` | 130 | 499 | User interrupted (Ctrl+C) |
@@ -89,8 +89,8 @@ Ten categories map to exit codes and HTTP status:
 ```typescript
 import { ValidationError, NotFoundError, getExitCode } from "@outfitter/contracts";
 
-new ValidationError("Invalid email", { field: "email" });
-new NotFoundError("user", "user-123");
+ValidationError.create("email", "invalid");
+NotFoundError.create("user", "user-123");
 
 getExitCode(error.category);   // 2 for not_found
 getStatusCode(error.category); // 404 for not_found

--- a/packages/claude-plugin/skills/patterns/references/handler-contract.md
+++ b/packages/claude-plugin/skills/patterns/references/handler-contract.md
@@ -65,7 +65,7 @@ export const getUser: Handler<unknown, UserOutput, ValidationError | NotFoundErr
   // Business logic
   const user = await db.users.findById(input.id);
   if (!user) {
-    return Result.err(new NotFoundError("user", input.id));
+    return Result.err(NotFoundError.create("user", input.id));
   }
 
   // Return success
@@ -110,7 +110,11 @@ const createOrder: Handler<CreateOrderInput, Order, OrderError> = async (input, 
   // Call another handler
   const userResult = await getUser({ id: input.userId }, ctx);
   if (userResult.isErr()) {
-    return Result.err(new ValidationError("Invalid user", { userId: input.userId }));
+    return Result.err(
+      ValidationError.create("userId", "invalid user", {
+        userId: input.userId,
+      })
+    );
   }
 
   // Continue with order creation
@@ -137,7 +141,7 @@ if (result.isOk()) {
   // result.error is ValidationError | NotFoundError
   switch (result.error._tag) {
     case "ValidationError":
-      console.log(result.error.details);
+      console.log(result.error.context);
       break;
     case "NotFoundError":
       console.log(result.error.resourceId);
@@ -178,7 +182,7 @@ const handler: Handler<Input, Output, Error> = async (input, ctx) => {
 
   // Cancellation
   if (ctx.signal.aborted) {
-    return Result.err(new CancelledError("Operation cancelled"));
+    return Result.err(CancelledError.create("Operation cancelled"));
   }
 
   // Workspace paths
@@ -195,7 +199,7 @@ Never throw in handlers. Return `Result.err()`:
 if (!user) throw new Error("Not found");
 
 // GOOD
-if (!user) return Result.err(new NotFoundError("user", id));
+if (!user) return Result.err(NotFoundError.create("user", id));
 ```
 
 Use taxonomy error classes for consistent categorization:

--- a/packages/claude-plugin/skills/patterns/references/result-utilities.md
+++ b/packages/claude-plugin/skills/patterns/references/result-utilities.md
@@ -11,7 +11,7 @@ import { Result } from "@outfitter/contracts";
 const ok = Result.ok({ name: "Alice", id: "1" });
 
 // Failure
-const err = Result.err(new NotFoundError("user", "123"));
+const err = Result.err(NotFoundError.create("user", "123"));
 ```
 
 ## Checking Results
@@ -209,11 +209,13 @@ const handler: Handler<Input, Output, Error> = async (input, ctx) => {
 ```typescript
 const errors: ValidationError[] = [];
 
-if (!input.name) errors.push(new ValidationError("Name required"));
-if (!input.email) errors.push(new ValidationError("Email required"));
+if (!input.name) errors.push(ValidationError.create("name", "required"));
+if (!input.email) errors.push(ValidationError.create("email", "required"));
 
 if (errors.length > 0) {
-  return Result.err(new ValidationError("Multiple errors", { errors }));
+  return Result.err(
+    ValidationError.create("input", "multiple validation errors", { errors })
+  );
 }
 ```
 
@@ -224,7 +226,7 @@ function wrapThrowable<T>(fn: () => T): Result<T, InternalError> {
   try {
     return Result.ok(fn());
   } catch (error) {
-    return Result.err(new InternalError("Unexpected error", { cause: error }));
+    return Result.err(InternalError.create("Unexpected error", { cause: error }));
   }
 }
 
@@ -232,7 +234,7 @@ async function wrapAsync<T>(fn: () => Promise<T>): Promise<Result<T, InternalErr
   try {
     return Result.ok(await fn());
   } catch (error) {
-    return Result.err(new InternalError("Unexpected error", { cause: error }));
+    return Result.err(InternalError.create("Unexpected error", { cause: error }));
   }
 }
 ```

--- a/packages/claude-plugin/skills/review/SKILL.md
+++ b/packages/claude-plugin/skills/review/SKILL.md
@@ -38,7 +38,7 @@ rg "Handler<" --type ts -A 2
 if (!user) throw new Error("Not found");
 
 // GOOD: Result.err
-if (!user) return Result.err(new NotFoundError("user", id));
+if (!user) return Result.err(NotFoundError.create("user", id));
 
 // BAD: try/catch for control flow
 try { await handler(input, ctx); } catch (e) { ... }

--- a/packages/claude-plugin/skills/scaffold/SKILL.md
+++ b/packages/claude-plugin/skills/scaffold/SKILL.md
@@ -61,7 +61,7 @@ export const myHandler: Handler<unknown, Output, ValidationError | NotFoundError
 
   const resource = await fetchResource(input.id);
   if (!resource) {
-    return Result.err(new NotFoundError("resource", input.id));
+    return Result.err(NotFoundError.create("resource", input.id));
   }
 
   return Result.ok(resource);

--- a/packages/claude-plugin/skills/scaffold/templates/handler.md
+++ b/packages/claude-plugin/skills/scaffold/templates/handler.md
@@ -79,7 +79,7 @@ export const myHandler: Handler<unknown, Output, HandlerErrors> = async (
   });
 
   if (!resource) {
-    return Result.err(new NotFoundError("resource", input.id));
+    return Result.err(NotFoundError.create("resource", input.id));
   }
 
   // 4. Log success

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,7 +36,7 @@ if (cursor) {
 
 Output data to the console with automatic mode selection.
 
-Defaults to human-friendly output for TTY, JSON for non-TTY. Override via `mode` option or `OUTFITTER_JSON`/`OUTFITTER_JSONL` environment variables.
+Defaults to human-friendly output. Override via `mode` option or `OUTFITTER_JSON`/`OUTFITTER_JSONL` environment variables.
 
 ```typescript
 import { output } from "@outfitter/cli/output";
@@ -401,7 +401,7 @@ const isVerbose = resolveVerbose(cliFlags.verbose);
 2. `OUTFITTER_JSONL=1` environment variable (highest env priority)
 3. `OUTFITTER_JSON=1` environment variable
 4. `OUTFITTER_JSON=0` or `OUTFITTER_JSONL=0` forces human mode
-5. TTY detection: `json` for non-TTY, `human` for TTY
+5. Default fallback: `human`
 
 ## Error Handling
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -4,7 +4,7 @@ Result/Error patterns, error taxonomy, handler contracts, and shared interfaces 
 
 ## Status
 
-**Scaffold** - Types and interfaces defined, implementations pending.
+**Active** - Stable core contracts with active feature development.
 
 ## Installation
 
@@ -36,7 +36,7 @@ import {
 // Define a handler
 const getNote: Handler<{ id: string }, Note, NotFoundError> = async (input, ctx) => {
   const note = await db.notes.find(input.id);
-  if (!note) return Result.err(new NotFoundError("note", input.id));
+  if (!note) return Result.err(NotFoundError.create("note", input.id));
   return Result.ok(note);
 };
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -190,7 +190,7 @@ const getUserTool = defineTool({
   handler: async (input, ctx) => {
     const user = await db.users.find(input.userId);
     if (!user) {
-      return Result.err(new NotFoundError("user", input.userId));
+      return Result.err(NotFoundError.create("user", input.userId));
     }
     return Result.ok(user);
   },

--- a/plugins/kit/commands/create-outfitter.md
+++ b/plugins/kit/commands/create-outfitter.md
@@ -21,7 +21,7 @@ ls package.json 2>/dev/null
 Follow the skill's **New Project Scaffolding** section:
 1. Check for context files (CLAUDE.md, SPEC.md, PLAN.md)
 2. Use AskUserQuestion to clarify template and name
-3. Run `outfitter init <template> . --name <name>`
+3. Run `outfitter init <cli|mcp|daemon> . --name <name>` (or `outfitter init . --template <template> --name <name>`)
 
 If $ARGUMENTS is provided, use it as the project name.
 

--- a/plugins/kit/skills/debug-outfitter/SKILL.md
+++ b/plugins/kit/skills/debug-outfitter/SKILL.md
@@ -95,7 +95,7 @@ const result = await getUser(id);  // ✅
 // Check: Validation failing?
 const validated = validate(input);
 if (validated.isErr()) {
-  console.log("Validation failed:", validated.error.details);
+  console.log("Validation failed:", validated.error.context);
 }
 ```
 
@@ -119,7 +119,7 @@ const updateResult = await updateUser(getResult.value);
 if (result.isErr()) {
   switch (result.error._tag) {
     case "ValidationError":
-      console.log(result.error.details);
+      console.log(result.error.context);
       break;
     case "NotFoundError":
       console.log(result.error.resourceId);
@@ -167,7 +167,7 @@ await output(data, { mode: "json" });
 
 // Check environment
 // OUTFITTER_JSON=1 forces JSON
-// OUTFITTER_JSON=0 forces human (even with --json flag)
+// OUTFITTER_JSON=0 forces human when no explicit mode is set
 
 // Await output before exit
 await output(data);  // ✅

--- a/plugins/kit/skills/outfitter-fieldguide/SKILL.md
+++ b/plugins/kit/skills/outfitter-fieldguide/SKILL.md
@@ -17,7 +17,7 @@ We kept solving the same problems across projects: config loading, error handlin
 The patterns assume you're building tools that **agents will consume**—structured output, typed errors, predictable behavior. Humans benefit too; agents just make the stakes clearer.
 
 When an AI agent calls your CLI or MCP tool, it needs:
-- **Structured output** it can parse (JSON when piped, human-readable otherwise)
+- **Structured output** it can parse (JSON when explicitly requested)
 - **Typed errors** with categories it can reason about (retry? abort? ask user?)
 - **Predictable exit codes** for scripting and automation
 - **Consistent behavior** across transport surfaces
@@ -29,7 +29,7 @@ The stack enforces these properties by design, not discipline.
 Traditional error handling (`throw`/`catch`) loses context, breaks type safety, and makes control flow unpredictable. We treat errors as first-class data:
 
 ```typescript
-const error = new NotFoundError("user", "user-123");
+const error = NotFoundError.create("user", "user-123");
 error._tag;        // "NotFoundError" — for pattern matching
 error.category;    // "not_found" — maps to exit code 2, HTTP 404
 error.message;     // Human-readable
@@ -182,7 +182,7 @@ Ten categories. Memorize the exit codes—you'll use them.
 | `permission` | 4 | 403 | `PermissionError` | Forbidden action |
 | `timeout` | 5 | 504 | `TimeoutError` | Took too long |
 | `rate_limit` | 6 | 429 | `RateLimitError` | Too many requests |
-| `network` | 7 | 503 | `NetworkError` | Connection failures |
+| `network` | 7 | 502 | `NetworkError` | Connection failures |
 | `internal` | 8 | 500 | `InternalError` | Bugs, unexpected errors |
 | `auth` | 9 | 401 | `AuthError` | Authentication required |
 | `cancelled` | 130 | 499 | `CancelledError` | User hit Ctrl+C |

--- a/plugins/kit/skills/outfitter-fieldguide/guides/architecture.md
+++ b/plugins/kit/skills/outfitter-fieldguide/guides/architecture.md
@@ -82,7 +82,7 @@ Every domain error maps to one of ten categories:
 | Can't modify other users | `permission` | `PermissionError` | 4 | 403 |
 | Database query timed out | `timeout` | `TimeoutError` | 5 | 504 |
 | API rate limit hit | `rate_limit` | `RateLimitError` | 6 | 429 |
-| Can't reach external API | `network` | `NetworkError` | 7 | 503 |
+| Can't reach external API | `network` | `NetworkError` | 7 | 502 |
 | Unexpected null pointer | `internal` | `InternalError` | 8 | 500 |
 | Token expired | `auth` | `AuthError` | 9 | 401 |
 | User pressed Ctrl+C | `cancelled` | `CancelledError` | 130 | 499 |
@@ -289,7 +289,11 @@ export const createUser: Handler<
   // Check for existing user
   const existing = await ctx.db.findByEmail(validated.value.email);
   if (existing) {
-    return Result.err(new ConflictError("user", validated.value.email));
+    return Result.err(
+      ConflictError.create("User already exists", {
+        email: validated.value.email,
+      })
+    );
   }
 
   // Create user

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/cli.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/cli.md
@@ -49,7 +49,7 @@ export const myCommand = command("my-command")
 ```typescript
 import { output } from "@outfitter/cli";
 
-await output(data);  // Human for TTY, JSON for pipes
+await output(data);  // Human by default
 ```
 
 ### Mode Priority
@@ -58,7 +58,7 @@ await output(data);  // Human for TTY, JSON for pipes
 2. `OUTFITTER_JSONL=1` env var
 3. `OUTFITTER_JSON=1` env var
 4. `OUTFITTER_JSON=0` forces human
-5. TTY detection fallback
+5. Default fallback: human mode
 
 ### Forcing Modes
 
@@ -78,15 +78,10 @@ for await (const item of items) {
 await output(errorData, { stream: process.stderr });
 ```
 
-### Custom Formatters
+For custom formatting, transform data before calling `output()`:
 
 ```typescript
-await output(data, {
-  formatters: {
-    human: (data) => formatTable(data),
-    json: (data) => JSON.stringify(data, null, 2),
-  },
-});
+await output(formatTable(data));
 ```
 
 ## Error Handling

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/conversion.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/conversion.md
@@ -21,7 +21,7 @@ import { Result, NotFoundError, type Handler } from "@outfitter/contracts";
 
 const getUser: Handler<{ id: string }, User, NotFoundError> = async (input, ctx) => {
   const user = await db.users.findById(input.id);
-  if (!user) return Result.err(new NotFoundError("user", input.id));
+  if (!user) return Result.err(NotFoundError.create("user", input.id));
   return Result.ok(user);
 };
 ```
@@ -131,10 +131,12 @@ function wrapSync<T>(fn: () => T): Result<T, InternalError> {
   try {
     return Result.ok(fn());
   } catch (error) {
-    return Result.err(new InternalError(
-      error instanceof Error ? error.message : "Unknown error",
-      { cause: error }
-    ));
+    return Result.err(
+      InternalError.create(
+        error instanceof Error ? error.message : "Unknown error",
+        { cause: error }
+      )
+    );
   }
 }
 
@@ -145,10 +147,12 @@ async function wrapAsync<T>(fn: () => Promise<T>): Promise<Result<T, InternalErr
   try {
     return Result.ok(await fn());
   } catch (error) {
-    return Result.err(new InternalError(
-      error instanceof Error ? error.message : "Unknown error",
-      { cause: error }
-    ));
+    return Result.err(
+      InternalError.create(
+        error instanceof Error ? error.message : "Unknown error",
+        { cause: error }
+      )
+    );
   }
 }
 ```

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/errors.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/errors.md
@@ -13,7 +13,7 @@ Ten error categories that map to exit codes (CLI) and HTTP status codes (API).
 | `permission` | 4 | 403 | `PermissionError` | Forbidden action, insufficient privileges |
 | `timeout` | 5 | 504 | `TimeoutError` | Operation took too long |
 | `rate_limit` | 6 | 429 | `RateLimitError` | Too many requests, quota exceeded |
-| `network` | 7 | 503 | `NetworkError` | Connection failures, DNS errors, unreachable hosts |
+| `network` | 7 | 502 | `NetworkError` | Connection failures, DNS errors, unreachable hosts |
 | `internal` | 8 | 500 | `InternalError` | Unexpected errors, bugs, unhandled cases |
 | `internal` | 8 | 500 | `AssertionError` | Invariant violations, programming bugs |
 | `auth` | 9 | 401 | `AuthError` | Authentication required, invalid credentials |
@@ -285,7 +285,7 @@ Use `_tag` for type-safe error handling:
 if (result.isErr()) {
   switch (result.error._tag) {
     case "ValidationError":
-      console.log("Invalid input:", result.error.details);
+      console.log("Invalid input:", result.error.context);
       break;
     case "NotFoundError":
       console.log(`${result.error.resourceType} not found`);

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/handler.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/handler.md
@@ -65,7 +65,7 @@ export const getUser: Handler<unknown, UserOutput, ValidationError | NotFoundErr
   // Business logic
   const user = await db.users.findById(input.id);
   if (!user) {
-    return Result.err(new NotFoundError("user", input.id));
+    return Result.err(NotFoundError.create("user", input.id));
   }
 
   // Return success
@@ -110,7 +110,11 @@ const createOrder: Handler<CreateOrderInput, Order, OrderError> = async (input, 
   // Call another handler
   const userResult = await getUser({ id: input.userId }, ctx);
   if (userResult.isErr()) {
-    return Result.err(new ValidationError("Invalid user", { userId: input.userId }));
+    return Result.err(
+      ValidationError.create("userId", "invalid user", {
+        userId: input.userId,
+      })
+    );
   }
 
   // Continue with order creation
@@ -137,7 +141,7 @@ if (result.isOk()) {
   // result.error is ValidationError | NotFoundError
   switch (result.error._tag) {
     case "ValidationError":
-      console.log(result.error.details);
+      console.log(result.error.context);
       break;
     case "NotFoundError":
       console.log(result.error.resourceId);
@@ -178,7 +182,7 @@ const handler: Handler<Input, Output, Error> = async (input, ctx) => {
 
   // Cancellation
   if (ctx.signal.aborted) {
-    return Result.err(new CancelledError("Operation cancelled"));
+    return Result.err(CancelledError.create("Operation cancelled"));
   }
 
   // Workspace paths
@@ -195,7 +199,7 @@ Never throw in handlers. Return `Result.err()`:
 if (!user) throw new Error("Not found");
 
 // GOOD
-if (!user) return Result.err(new NotFoundError("user", id));
+if (!user) return Result.err(NotFoundError.create("user", id));
 ```
 
 Use taxonomy error classes for consistent categorization:

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/mcp.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/mcp.md
@@ -178,12 +178,12 @@ server.registerPrompt({
 ```typescript
 handler: async (input) => {
   if (!input.query) {
-    return Result.err(new ValidationError("Query is required"));
+    return Result.err(ValidationError.create("query", "is required"));
   }
 
   const item = await findItem(input.id);
   if (!item) {
-    return Result.err(new NotFoundError("item", input.id));
+    return Result.err(NotFoundError.create("item", input.id));
   }
 
   return Result.ok(item);

--- a/plugins/kit/skills/outfitter-fieldguide/patterns/testing.md
+++ b/plugins/kit/skills/outfitter-fieldguide/patterns/testing.md
@@ -219,8 +219,8 @@ expect(result.isErr()).toBe(true);
 expect(result.error._tag).toBe("NotFoundError");
 expect(result.error.category).toBe("not_found");
 
-// Error details
-expect(result.error.details).toMatchObject({
+// Error context
+expect(result.error.context).toMatchObject({
   field: "email",
 });
 ```

--- a/plugins/kit/skills/outfitter-fieldguide/templates/handler-test.md
+++ b/plugins/kit/skills/outfitter-fieldguide/templates/handler-test.md
@@ -142,8 +142,8 @@ expect(result.error.resourceId).toBe("123");
 // Check error message
 expect(result.error.message).toContain("not found");
 
-// Check error details
-expect(result.error.details).toMatchObject({
+// Check error context
+expect(result.error.context).toMatchObject({
   field: "email",
 });
 ```

--- a/plugins/kit/skills/outfitter-fieldguide/templates/handler.md
+++ b/plugins/kit/skills/outfitter-fieldguide/templates/handler.md
@@ -79,7 +79,7 @@ export const myHandler: Handler<unknown, Output, HandlerErrors> = async (
   });
 
   if (!resource) {
-    return Result.err(new NotFoundError("resource", input.id));
+    return Result.err(NotFoundError.create("resource", input.id));
   }
 
   // 4. Log success

--- a/plugins/kit/skills/outfitter-init/SKILL.md
+++ b/plugins/kit/skills/outfitter-init/SKILL.md
@@ -56,7 +56,8 @@ Use AskUserQuestion to clarify before running commands. See [references/new-proj
 ### Step 3: Run the CLI
 
 ```bash
-outfitter init <template> . --name <name>
+outfitter init <cli|mcp|daemon> . --name <name>
+# Or: outfitter init . --template <template> --name <name>
 ```
 
 **Options:**

--- a/plugins/kit/skills/outfitter-init/migration/patterns-quick-ref.md
+++ b/plugins/kit/skills/outfitter-init/migration/patterns-quick-ref.md
@@ -22,7 +22,7 @@ Quick lookup for conversion patterns. All details are in `outfitter-fieldguide`.
 | `permission` | 4 | 403 | Forbidden |
 | `timeout` | 5 | 504 | Too slow |
 | `rate_limit` | 6 | 429 | Too many requests |
-| `network` | 7 | 503 | Connection failed |
+| `network` | 7 | 502 | Connection failed |
 | `internal` | 8 | 500 | Unexpected |
 | `auth` | 9 | 401 | Unauthenticated |
 | `cancelled` | 130 | 499 | User cancelled |

--- a/plugins/kit/skills/outfitter-init/references/new-project-scaffolding.md
+++ b/plugins/kit/skills/outfitter-init/references/new-project-scaffolding.md
@@ -100,13 +100,16 @@ After gathering answers, run the appropriate command:
 
 ```bash
 # Full scaffolding (default)
-outfitter init <template> . --name <name>
+outfitter init <cli|mcp|daemon> . --name <name>
+# Or: outfitter init . --template <template> --name <name>
 
 # Without tooling
-outfitter init <template> . --name <name> --no-tooling
+outfitter init <cli|mcp|daemon> . --name <name> --no-tooling
+# Or: outfitter init . --template <template> --name <name> --no-tooling
 
 # With specific blocks
-outfitter init <template> . --name <name> --with claude,biome
+outfitter init <cli|mcp|daemon> . --name <name> --with claude,biome
+# Or: outfitter init . --template <template> --name <name> --with claude,biome
 ```
 
 ### Available Templates

--- a/plugins/kit/skills/outfitter-init/templates/stages/errors.md
+++ b/plugins/kit/skills/outfitter-init/templates/stages/errors.md
@@ -18,7 +18,7 @@ Replace custom error classes with Outfitter error taxonomy.
 | `permission` | `PermissionError` | 4 | 403 | Forbidden action |
 | `timeout` | `TimeoutError` | 5 | 504 | Operation took too long |
 | `rate_limit` | `RateLimitError` | 6 | 429 | Too many requests |
-| `network` | `NetworkError` | 7 | 503 | Connection failures |
+| `network` | `NetworkError` | 7 | 502 | Connection failures |
 | `internal` | `InternalError` | 8 | 500 | Unexpected errors, bugs |
 | `auth` | `AuthError` | 9 | 401 | Authentication required |
 | `cancelled` | `CancelledError` | 130 | 499 | User interrupted |

--- a/plugins/kit/skills/outfitter-init/templates/stages/handlers.md
+++ b/plugins/kit/skills/outfitter-init/templates/stages/handlers.md
@@ -67,7 +67,7 @@ import { Result, NotFoundError, type Handler } from "@outfitter/contracts";
 
 const getUser: Handler<{ id: string }, User, NotFoundError> = async (input, ctx) => {
   const user = await db.users.findById(input.id);
-  if (!user) return Result.err(new NotFoundError("user", input.id));
+  if (!user) return Result.err(NotFoundError.create("user", input.id));
   return Result.ok(user);
 };
 

--- a/plugins/kit/skills/outfitter-init/templates/stages/paths.md
+++ b/plugins/kit/skills/outfitter-init/templates/stages/paths.md
@@ -54,7 +54,9 @@ import { securePath } from "@outfitter/file-ops";
 const validatePath = (userPath: string, baseDir: string) => {
   const result = securePath(userPath, { base: baseDir });
   if (result.isErr()) {
-    return Result.err(new ValidationError("Invalid path", { path: userPath }));
+    return Result.err(
+      ValidationError.create("path", "invalid", { path: userPath })
+    );
   }
   return Result.ok(result.value);
 };


### PR DESCRIPTION
## Summary
Full documentation consistency pass across core docs, package READMEs, and plugin/skill docs to align wording and examples with current Outfitter APIs and behavior.

## What Changed
- Synced root and app docs to current CLI/runtime semantics.
- Updated package docs (`@outfitter/cli`, `@outfitter/contracts`, `@outfitter/mcp`) for current API surface.
- Cleaned stale guidance in `packages/claude-plugin/**` and `plugins/kit/**` docs.
- Normalized contracts terminology and examples (constructor/factory usage, error context semantics).
- Fixed taxonomy/documentation mismatches (including network HTTP mapping references where stale).

## Scope Notes
- Documentation-only changes.
- No runtime/source implementation changes.

## Validation
- `bun run check`
- Stack submit pre-push verification (`bun run verify:ci`): typecheck, check, build, and test passed.

## Review Checklist
- [ ] Docs reflect current behavior and naming conventions.
- [ ] Example snippets match current package exports and patterns.
- [ ] No remaining stale references to deprecated/older command shapes.
- [ ] Ready for downstack merge before PR #301.

## Stack Context
- Base PR in stack.
- Upstack follow-up: #301 (migration docs + non-Outfitter framework examples).
