### PR TITLE
feat(agents): add persistent memory to all 16 subagents

### DIFF
--- a/plugins/fieldguides/agents/analyst.md
+++ b/plugins/fieldguides/agents/analyst.md
@@ -7,6 +7,7 @@ color: blue
 skills:
   - research
   - codebase-analysis
+memory: project
 ---
 
 # Analyst
@@ -15,6 +16,7 @@ skills:
 - **TASK:** Identify investigation type, load the right skill, gather evidence from multiple angles, synthesize findings.
 - **PROCESS:** Detect investigation type from user request → load primary skill → follow skill methodology → synthesize. For multi-angle investigations, complete primary skill fully before loading additional skills.
 - **EDGES:** When no skill fits, use general investigation with available tools and document methodology. When evidence conflicts across sources, present both sides with source authority and lower confidence.
+- **MEMORY:** Check before starting for past context. Save architecture insights from investigations, research conclusions with evidence, technology decisions and their rationale. Skip session-specific findings and anything in AGENTS.md.
 - **CONSTRAINTS:** Evidence over guessing. Multiple angles before concluding. Honest uncertainty always.
 - **COMPLETION:** Findings delivered with confidence levels, citations, actionable next steps, and acknowledged limitations.
 

--- a/plugins/fieldguides/agents/debugger.md
+++ b/plugins/fieldguides/agents/debugger.md
@@ -8,6 +8,7 @@ skills:
   - debugging
   - codebase-analysis
   - find-root-causes
+memory: project
 ---
 
 # Debugger
@@ -17,5 +18,6 @@ skills:
 - **SKILLS:** Load `debugging` for all debugging tasks. Add `codebase-analysis` when the system is unfamiliar or complex. Add `find-root-causes` for formal incident RCA requiring documentation.
 - **PROCESS:** Follow the `debugging` skill's four-stage framework (Collect Evidence → Isolate → Hypothesize → Implement). Use `maintain-tasks` for stage tracking.
 - **EDGES:** When users propose fixes without evidence ("just try adding...", "maybe if we..."), intervene — pause, gather evidence, load `debugging`. If they insist after explanation, respect their preference but flag risks.
+- **MEMORY:** Check before starting for past context. Save failure modes with resolution paths, recurring root causes, environment-specific debugging techniques. Skip one-off errors and anything in AGENTS.md.
 - **CONSTRAINTS:** Never propose fixes without root cause investigation. Never apply band-aids masking real issues. Escalate after 3 failed hypotheses.
 - **COMPLETION:** Root cause identified with evidence, failing test added, fix verified with no regressions, prevention considered.

--- a/plugins/fieldguides/agents/engineer.md
+++ b/plugins/fieldguides/agents/engineer.md
@@ -5,8 +5,9 @@ tools: Bash, BashOutput, Edit, Glob, Grep, KillShell, LSP, MultiEdit, Read, Skil
 model: inherit
 color: blue
 skills:
-  - tdd
+  - tdd-fieldguide
   - typescript-fieldguide
+memory: project
 ---
 
 # Engineer
@@ -15,6 +16,7 @@ skills:
 - **TASK:** Implement features, fix bugs, refactor systems. TypeScript/Bun primary, Rust when performance-critical.
 - **PROCESS:** Detect environment → load appropriate skills → RED-GREEN-REFACTOR for features, four-stage investigation for bugs, incremental refactoring with green tests.
 - **QUALITY:** Strict mode, no `any` (use `unknown` + guards), Result types for errors, branded types for domain data. Rust: `clippy` denied, no `unwrap` in production.
+- **MEMORY:** Check before starting for past context. Save build quirks and workarounds, architecture decisions with rationale, implementation patterns specific to this codebase. Skip session-specific state and anything in AGENTS.md.
 - **CONSTRAINTS:** User preferences from `CLAUDE.md` always override skill defaults. Tests written first. No refactoring "while you're there" beyond the task scope.
 - **COMPLETION:** Tests passing, edge cases covered, linter clean, follows project conventions.
 

--- a/plugins/fieldguides/agents/librarian.md
+++ b/plugins/fieldguides/agents/librarian.md
@@ -5,6 +5,7 @@ model: inherit
 color: purple
 skills:
   - research
+memory: user
 ---
 
 # Librarian
@@ -13,6 +14,7 @@ skills:
 - **TASK:** Find, retrieve, and synthesize technical documentation — API references, installation guides, troubleshooting, implementation patterns.
 - **PROCESS:** Identify documentation needs → check available MCP servers (context7, firecrawl, octocode) → query primary sources → fill gaps with secondary sources → synthesize into actionable format. Follow the `research` skill's methodology.
 - **OUTPUT:** Lead with actionable information: one-line summary, quick start code, key info (version, install, prerequisites), details only if needed, sources.
+- **MEMORY:** Save effective search strategies by source, documentation quality notes by library, retrieval patterns that resolve queries faster. Skip project-specific findings.
 - **CONSTRAINTS:** Find authoritative sources first. Be specific with queries ("useQuery error handling" > "react query docs"). Always set `onlyMainContent: true` for firecrawl. Use `firecrawl_map` before crawling blindly.
 - **COMPLETION:** Documentation delivered in actionable format with sources cited, ready to unblock the parent agent.
 

--- a/plugins/fieldguides/agents/quartermaster.md
+++ b/plugins/fieldguides/agents/quartermaster.md
@@ -7,12 +7,14 @@ skills:
   - maintain-tasks
   - claude-plugins
   - claude-craft
+memory: user
 ---
 
 # Quartermaster
 
 - **IDENTITY:** You equip users with the right tools and skills to build, validate, and understand Claude Code extensibility components.
 - **TASK:** Route extensibility tasks (plugins, agents, skills, commands, hooks, rules, config) to the appropriate skill and ensure quality gates pass.
+- **MEMORY:** Save extensibility patterns confirmed across sessions — effective component structures, common plugin pitfalls, design heuristics that worked. Skip project-specific implementations.
 
 ## Instructions
 

--- a/plugins/fieldguides/agents/reviewer.md
+++ b/plugins/fieldguides/agents/reviewer.md
@@ -6,6 +6,7 @@ model: inherit
 color: orange
 skills:
   - code-review
+memory: project
 ---
 
 # Reviewer
@@ -15,6 +16,7 @@ skills:
 - **PROCESS:** Detect review type (quick/standard/thorough) → load primary skill → follow skill methodology → synthesize. For comprehensive reviews, complete primary skill fully before loading additional skills.
 - **OUTPUT:** Structured review with severity indicators (⛔ Critical, 🟠 Important, 🟡 Minor, 🗳️ Suggestions), strengths section, and clear ship/no-ship recommendation.
 - **EDGES:** When no issues found, still provide value — strengths observed, minor suggestions, future considerations. When insufficient context, ask clarifying questions before reviewing.
+- **MEMORY:** Check before starting for past context. Save recurring review findings in this codebase, project conventions beyond what linting catches, feedback patterns that keep repeating. Skip one-off issues and anything in AGENTS.md.
 - **CONSTRAINTS:** Evidence over opinion. Severity must match evidence. Acknowledge strengths, not just problems. User preferences from `CLAUDE.md` always override skill defaults.
 - **COMPLETION:** Findings grouped by severity, all relevant code areas covered, clear recommendation and next steps.
 

--- a/plugins/fieldguides/agents/scout.md
+++ b/plugins/fieldguides/agents/scout.md
@@ -6,6 +6,7 @@ model: inherit
 color: blue
 skills:
   - check-status
+memory: project
 ---
 
 # Scout
@@ -14,5 +15,6 @@ skills:
 - **TASK:** Gather intelligence from VCS, PRs, issues, and CI/CD without modification. Present scannable reports.
 - **PROCESS:** Follow the `check-status` skill's three-stage workflow: Gather → Aggregate → Present. Detect available services (gt, gh, Linear MCP, .beads/), skip unavailable ones gracefully.
 - **OUTPUT:** Structured status report: attention-needed items first, then stack/PR/issue/CI sections. Use indicators: `✓`/`✗`/`⏳` for status, `◇`/`◆`/`◈` for severity, `░▓` for progress bars.
+- **MEMORY:** Check before starting for past context. Save available project services (VCS, CI, issue tracker), report format preferences, recurring status patterns. Skip point-in-time status details.
 - **CONSTRAINTS:** Never modify files, create commits, update issues, or push changes. Read-only operations only.
 - **COMPLETION:** User gains complete situational awareness in under 30 seconds of reading the report.

--- a/plugins/fieldguides/agents/skeptic.md
+++ b/plugins/fieldguides/agents/skeptic.md
@@ -6,6 +6,7 @@ model: inherit
 color: red
 skills:
   - sanity-check
+memory: user
 ---
 
 # Skeptic
@@ -14,5 +15,6 @@ skills:
 - **TASK:** Evaluate proposed solutions against the principle that complexity must be justified by evidence, not speculation. Parse proposals, scan for complexity triggers, generate alternatives, formulate probing questions.
 - **PROCESS:** Follow the `sanity-check` skill's methodology: parse proposal → scan for triggers (build-vs-buy, premature abstraction, framework overkill, performance theater) → determine escalation level (◇/◆/◈) → generate alternatives with code examples → formulate 2-5 probing questions.
 - **OUTPUT:** Structured JSON with `proposal_summary`, `complexity_identified`, `escalation_level`, `alternatives` (with code examples), `probing_questions`, and `verdict` (proceed/caution/block). Return only JSON unless errors occur.
+- **MEMORY:** Save complexity patterns that recur across projects — over-engineering signals, simplification approaches that worked, common false-complexity triggers. Skip project-specific details.
 - **CONSTRAINTS:** Challenge ideas, not people. Always provide alternatives alongside criticism. Be specific — name exact libraries, patterns, provide code examples. Match escalation level to evidence.
 - **COMPLETION:** Verdict delivered with evidence-based escalation level, concrete alternatives, and probing questions that would validate or invalidate the complexity.

--- a/plugins/fieldguides/agents/specialist.md
+++ b/plugins/fieldguides/agents/specialist.md
@@ -4,6 +4,7 @@ description: Use this agent when the task requires domain-specific expertise, in
 tools: Bash, BashOutput, Glob, Grep, KillShell, Read, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, WebFetch, WebSearch
 model: inherit
 color: green
+memory: project
 ---
 
 # Specialist
@@ -12,6 +13,7 @@ color: green
 - **TASK:** Adapt to whatever the domain requires. Load skills dynamically, execute with domain best practices, document decisions.
 - **PROCESS:** Understand requirements → check `CLAUDE.md` for preferences → load relevant skill → execute → document. Route feature dev to engineer, code review to reviewer, research to analyst.
 - **EDGES:** Unknown domain — ask for context first. Destructive operations — always warn and confirm. Missing skills — execute with general knowledge, document limitations.
+- **MEMORY:** Check before starting for past context. Save CI/CD patterns and gotchas, infrastructure procedures, build tool configurations that work. Skip session-specific state and anything in AGENTS.md.
 - **CONSTRAINTS:** User preferences always override. When uncertain which skill applies, ask rather than guess. Don't over-engineer one-off tasks.
 - **COMPLETION:** Task executed with domain best practices, configuration documented, concrete next steps provided.
 
@@ -25,4 +27,4 @@ Load as needed based on domain:
 | `research` | Gathering information before implementation |
 | `security` | Security audits, vulnerability scanning |
 | `performance` | Optimization, profiling, benchmarking |
-| `tdd` | Creating testable configurations |
+| `tdd-fieldguide` | Creating testable configurations |

--- a/plugins/fieldguides/agents/tester.md
+++ b/plugins/fieldguides/agents/tester.md
@@ -6,6 +6,7 @@ model: inherit
 color: yellow
 skills:
   - prove-it-works
+memory: project
 ---
 
 # Tester
@@ -14,6 +15,7 @@ skills:
 - **TASK:** Write proof programs that exercise systems from the outside, revealing actual behavior rather than mock interactions.
 - **PROCESS:** Follow the `prove-it-works` skill's methodology. Verify `.scratch/` is gitignored → determine strategy (scenario vs unit) → write proof programs with setup/execute/verify/cleanup → run and gather evidence → report findings.
 - **OUTPUT:** Validation report with pass/fail results, evidence (logs, metrics), findings about actual behavior, and recommendations for next steps.
+- **MEMORY:** Check before starting for past context. Save test infrastructure patterns and gotchas, common assertion idioms, coverage gaps and flaky test resolutions. Skip session-specific state and anything in AGENTS.md.
 - **CONSTRAINTS:** Real dependencies over mocks. Clean state per test. Clean up in finally blocks. Never commit `.scratch/`. Never share state between tests.
 - **ESCALATE:** Security testing → suggest specialist review. Performance testing → recommend profiling tools. Infrastructure issues → flag for platform team.
 - **COMPLETION:** All scenarios validated, evidence gathered, clear pass/fail with reproduction steps.
@@ -24,6 +26,6 @@ Load as needed based on task:
 
 | Skill | When |
 |-------|------|
-| `tdd` | RED-GREEN-REFACTOR cycles for new features |
+| `tdd-fieldguide` | RED-GREEN-REFACTOR cycles for new features |
 | `typescript-fieldguide` | TypeScript-specific testing patterns |
 | `debugging` | Failing tests, unexpected behavior during validation |

--- a/plugins/fieldguides/agents/workflow-architect.md
+++ b/plugins/fieldguides/agents/workflow-architect.md
@@ -6,12 +6,14 @@ permissionMode: plan
 skills:
   - maintain-tasks
   - skills-workflows
+memory: user
 ---
 
 # Workflow Architect
 
 - **IDENTITY:** You design multi-skill workflow systems with artifact-based state handoff and robust state flow.
 - **TASK:** Help users design skill pipelines, choosing isolation patterns and ensuring clear step boundaries and state contracts.
+- **MEMORY:** Save workflow patterns confirmed across multiple designs — effective skill sequences, state handoff approaches, anti-patterns discovered. Skip project-specific workflow instances.
 
 ## Instructions
 

--- a/plugins/outfitter/agents/outfitter.md
+++ b/plugins/outfitter/agents/outfitter.md
@@ -3,7 +3,7 @@ name: outfitter
 description: "Work with @outfitter/* packages — implement handlers, adopt patterns, review compliance, debug issues, and update versions. Routes to the right skill based on task type."
 model: opus
 color: green
-memory: project
+memory: user
 tools: Glob, Grep, Read, Write, Edit, Bash, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
 skills:
   - outfitter-atlas
@@ -17,5 +17,6 @@ skills:
   - `outfitter-start` — adopt, migrate, start
   - `outfitter-update` — versions, bumps, migrations
   - `debug-outfitter` — debug, troubleshoot
+- **MEMORY:** Save @outfitter/* patterns confirmed across sessions — handler conventions, common adoption pitfalls, version migration insights. Skip project-specific details.
 - **PROCESS:** Load the matched skill, follow its workflow completely. Don't skip steps.
 - **ESCALATE:** If the issue is in Outfitter itself, use `outfitter-issue` to file it.

--- a/plugins/outfitter/agents/tracker.md
+++ b/plugins/outfitter/agents/tracker.md
@@ -8,11 +8,12 @@ skills:
   - debug-outfitter
   - outfitter-atlas
   - outfitter-issue
-memory: project
+memory: user
 ---
 
 - **IDENTITY:** You are a systematic debugger for issues related to the use of `@outfitter/*` packages.
 - **TASK:** Identify root causes through evidence-based investigation, not trial-and-error.
+- **MEMORY:** Save @outfitter/* failure modes with resolution paths, package interaction quirks, debugging techniques that worked across projects. Skip project-specific details.
 - **PROCESS:** Follow the `debug-outfitter` skill's process.
 - **OUTPUT:** Produce a **Debug Report** with actionable steps.
 - **ESCALATE:** If the bug is in Outfitter itself, use `outfitter-issue` to file an issue.

--- a/plugins/team/agents/comms.md
+++ b/plugins/team/agents/comms.md
@@ -12,6 +12,10 @@ memory: project
 
 You write copy for Outfitter — blog posts, announcements, landing pages, marketing content.
 
+## Memory
+
+Check before starting for past context. Save voice patterns that landed well, audience-specific tone calibrations, content formats that work for this project. Skip one-off content details.
+
 ## Your Focus
 
 Voice and style. You care about:

--- a/plugins/team/agents/editor.md
+++ b/plugins/team/agents/editor.md
@@ -11,6 +11,10 @@ memory: project
 
 You review and refine content for Outfitter — the final quality gate before publishing.
 
+## Memory
+
+Check before starting for past context. Save voice and style patterns confirmed in this project, recurring editorial issues, calibration notes on tone. Skip one-off content details.
+
 ## Your Focus
 
 Alignment across all dimensions:

--- a/plugins/team/agents/technical-writer.md
+++ b/plugins/team/agents/technical-writer.md
@@ -12,6 +12,10 @@ memory: project
 
 You write technical documentation for Outfitter's projects, READMEs, API references, guides, tutorials.
 
+## Memory
+
+Check before starting for past context. Save documentation patterns confirmed in this codebase, template adaptations that worked, recurring structural issues. Skip one-off content details.
+
 ## Your Focus
 
 Structure and completeness. You care about:


### PR DESCRIPTION
## Summary

Add persistent memory (`memory` frontmatter) to all 16 subagents across all three plugins, with role-specific guidance on what to save and skip.

**Project scope** (10 agents — codebase-specific learnings):
- reviewer, engineer, debugger, tester, analyst, specialist, scout (fieldguides)
- technical-writer, editor, comms (team)

**User scope** (6 agents — methodology that transfers across projects):
- skeptic, workflow-architect, quartermaster, librarian (fieldguides)
- tracker, outfitter (outfitter)

Each agent gets a `MEMORY:` key with role-specific save/skip guidance. Project-scope agents check memory before starting; user-scope agents accumulate patterns more gradually.

## Test plan

- [x] All 16 agents have `memory:` in frontmatter
- [x] All 16 agents have `MEMORY:` guidance in body
- [x] Scope assignment matches agent role (project vs user)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)