### PR TITLE
chore: bump all plugin and skill versions

### DIFF
--- a/plugins/fieldguides/.claude-plugin/plugin.json
+++ b/plugins/fieldguides/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldguides",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Development methodology fieldguides for Claude Code. TDD, debugging, architecture, research, multi-agent coordination, plus authoring skills for plugins, agents, commands, and hooks.",
   "author": {
     "name": "Outfitter",

--- a/plugins/fieldguides/skills/bun-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/bun-fieldguide/SKILL.md
@@ -2,7 +2,7 @@
 name: bun-fieldguide
 description: "This skill should be used when working with Bun runtime, bun:sqlite, Bun.serve, bun:test, or when Bun, bun:test, or Bun-specific patterns are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Bun Development

--- a/plugins/fieldguides/skills/bun-first/SKILL.md
+++ b/plugins/fieldguides/skills/bun-first/SKILL.md
@@ -2,7 +2,7 @@
 name: bun-first
 description: "Bun-first development: prefer native APIs over npm packages, audit for migration opportunities, eliminate unnecessary dependencies. Use when evaluating packages, starting projects, or migrating from Node.js."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   author: outfitter
   category: development
 ---

--- a/plugins/fieldguides/skills/check-status/SKILL.md
+++ b/plugins/fieldguides/skills/check-status/SKILL.md
@@ -2,7 +2,7 @@
 name: check-status
 description: "This skill should be used when checking project status, starting sessions, reviewing activity, or when sitrep, status report, or what's changed are mentioned."
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # Status Reporting

--- a/plugins/fieldguides/skills/claude-craft/SKILL.md
+++ b/plugins/fieldguides/skills/claude-craft/SKILL.md
@@ -2,7 +2,7 @@
 name: claude-craft
 description: "Claude Code extensibility — agents, commands, hooks, skills, rules, and configuration. Use when creating, configuring, or troubleshooting Claude Code components, or when agent.md, /command, hooks.json, SKILL.md, .claude/rules, settings.json, MCP server, PreToolUse, or create agent/command/hook are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - skillcraft
     - claude-plugins

--- a/plugins/fieldguides/skills/claude-plugins/SKILL.md
+++ b/plugins/fieldguides/skills/claude-plugins/SKILL.md
@@ -2,7 +2,7 @@
 name: claude-plugins
 description: "This skill should be used when creating plugins, publishing to marketplaces, or when plugin.json, marketplace, create plugin, or distribute plugin are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - claude-craft
     - skillcraft

--- a/plugins/fieldguides/skills/cli-craft/SKILL.md
+++ b/plugins/fieldguides/skills/cli-craft/SKILL.md
@@ -4,7 +4,7 @@ description: "This skill should be used when designing, implementing, or reviewi
 license: CC-BY-SA-4.0 (docs, adapted from clig.dev); MIT (scripts)
 compatibility: Scripts use Python 3.10+ (scripts/cli_audit.py).
 metadata:
-  version: "0.1.0"
+  version: "0.1.1"
   upstream: "clig.dev + POSIX/GNU/Heroku/12-factor + Agent Skills spec"
 ---
 # CLI Development Guidelines

--- a/plugins/fieldguides/skills/code-review/SKILL.md
+++ b/plugins/fieldguides/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 description: "This skill should be used when reviewing code before commit, conducting quality gates, or when review, fresh eyes, pre-commit review, or quality gate are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Fresh Eyes Review

--- a/plugins/fieldguides/skills/codebase-analysis/SKILL.md
+++ b/plugins/fieldguides/skills/codebase-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: codebase-analysis
 description: "This skill should be used when analyzing codebases, understanding architecture, or when analyze, investigate, explore code, or understand architecture are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Codebase Analysis

--- a/plugins/fieldguides/skills/codex-config/SKILL.md
+++ b/plugins/fieldguides/skills/codex-config/SKILL.md
@@ -2,7 +2,7 @@
 name: codex-config
 description: "This skill should be used when configuring Codex CLI, setting up profiles, or when config.toml, sandbox mode, Codex config, or approval policy are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - claude-craft
     - skillcraft

--- a/plugins/fieldguides/skills/codify/SKILL.md
+++ b/plugins/fieldguides/skills/codify/SKILL.md
@@ -4,7 +4,7 @@ description: "This skill should be used when implementing patterns as Claude Cod
 agent: analyst
 context: fork
 metadata:
-  version: "1.3.0"
+  version: "1.3.1"
   related-skills:
     - find-patterns
     - claude-craft

--- a/plugins/fieldguides/skills/context-management/SKILL.md
+++ b/plugins/fieldguides/skills/context-management/SKILL.md
@@ -3,7 +3,7 @@ name: context-management
 description: "Manage context window, survive compaction, persist state. Use when planning long tasks, coordinating agents, approaching context limits, or when context, compaction, tasks, or persist state are mentioned."
 user-invocable: false
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - use-subagents
     - pathfinding

--- a/plugins/fieldguides/skills/debugging/SKILL.md
+++ b/plugins/fieldguides/skills/debugging/SKILL.md
@@ -2,7 +2,7 @@
 name: debugging
 description: "This skill should be used when encountering bugs, errors, failing tests, or unexpected behavior. Provides systematic debugging with evidence-based root cause investigation using a four-stage framework."
 metadata:
-  version: "2.2.0"
+  version: "2.2.1"
   related-skills:
     - maintain-tasks
     - find-root-causes

--- a/plugins/fieldguides/skills/find-patterns/SKILL.md
+++ b/plugins/fieldguides/skills/find-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: find-patterns
 description: "This skill should be used when recognizing recurring themes, identifying patterns in work or data, or when pattern, recurring, or repeated are mentioned. For implementation, see codify skill."
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   related-skills:
     - codify
     - codebase-analysis

--- a/plugins/fieldguides/skills/find-root-causes/SKILL.md
+++ b/plugins/fieldguides/skills/find-root-causes/SKILL.md
@@ -4,7 +4,7 @@ description: "This skill should be used when diagnosing failures, investigating 
 agent: debugger
 context: fork
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   related-skills:
     - debugging
     - codebase-analysis

--- a/plugins/fieldguides/skills/hono-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/hono-fieldguide/SKILL.md
@@ -2,7 +2,7 @@
 name: hono-fieldguide
 description: "This skill should be used when building APIs with Hono, using hc client, implementing OpenAPI, or when Hono, RPC, or type-safe API are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Hono API Development

--- a/plugins/fieldguides/skills/pathfinding/SKILL.md
+++ b/plugins/fieldguides/skills/pathfinding/SKILL.md
@@ -2,7 +2,7 @@
 name: pathfinding
 description: "This skill should be used when requirements are unclear, brainstorming ideas, or when pathfind, brainstorm, figure out, clarify requirements, or work through are mentioned."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 # Pathfinding

--- a/plugins/fieldguides/skills/performance/SKILL.md
+++ b/plugins/fieldguides/skills/performance/SKILL.md
@@ -2,7 +2,7 @@
 name: performance
 description: "This skill should be used when profiling code, optimizing bottlenecks, benchmarking, or when performance, profiling, optimization, or --perf are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Performance Engineering

--- a/plugins/fieldguides/skills/prove-it-works/SKILL.md
+++ b/plugins/fieldguides/skills/prove-it-works/SKILL.md
@@ -2,7 +2,7 @@
 name: prove-it-works
 description: "This skill should be used when validating features end-to-end without mocks, testing integrations, or when scenario test, e2e test, or no mocks are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Scenario Testing

--- a/plugins/fieldguides/skills/react-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/react-fieldguide/SKILL.md
@@ -2,7 +2,7 @@
 name: react-fieldguide
 description: "This skill should be used when building React components with TypeScript, typing hooks, handling events, or when React TypeScript, React 19, Server Components are mentioned. Covers type-safe patterns for React 18-19 including generic components, proper event typing, and TanStack Router integration."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # React TypeScript

--- a/plugins/fieldguides/skills/report-findings/SKILL.md
+++ b/plugins/fieldguides/skills/report-findings/SKILL.md
@@ -2,7 +2,7 @@
 name: report-findings
 description: "This skill should be used when synthesizing multi-source research, presenting findings with attribution, or when report, findings, or synthesis are mentioned."
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   related-skills:
     - research
     - codebase-analysis

--- a/plugins/fieldguides/skills/research/SKILL.md
+++ b/plugins/fieldguides/skills/research/SKILL.md
@@ -2,7 +2,7 @@
 name: research
 description: "This skill should be used when researching best practices, evaluating technologies, comparing approaches, or when research, evaluation, or comparison are mentioned."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
   related-skills:
     - report-findings
     - codebase-analysis

--- a/plugins/fieldguides/skills/sanity-check/SKILL.md
+++ b/plugins/fieldguides/skills/sanity-check/SKILL.md
@@ -2,7 +2,7 @@
 name: sanity-check
 description: "This skill should be used when evaluating complexity, planning features, or when over-engineering, simpler, is this overkill, or keep it simple are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Challenge Complexity

--- a/plugins/fieldguides/skills/security/SKILL.md
+++ b/plugins/fieldguides/skills/security/SKILL.md
@@ -2,7 +2,7 @@
 name: security
 description: "This skill should be used when auditing code for security issues, reviewing authentication/authorization, evaluating input validation, analyzing cryptographic usage, or reviewing dependency security. Provides OWASP patterns, CWE analysis, and threat modeling guidance."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Security Engineering

--- a/plugins/fieldguides/skills/session-analysis/SKILL.md
+++ b/plugins/fieldguides/skills/session-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: session-analysis
 description: "This skill should be used when analyzing conversation patterns, identifying frustration or success signals, or when analyze conversation, what went wrong, or patterns are mentioned."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
 ---
 
 # Conversation Analysis

--- a/plugins/fieldguides/skills/skill-distillery/SKILL.md
+++ b/plugins/fieldguides/skills/skill-distillery/SKILL.md
@@ -2,7 +2,7 @@
 name: skill-distillery
 description: "Distills tool patterns from external repositories into teachable skills and plugins. Use when build plugin for, create skills for CLI, package as plugin, repo to plugin, or turn into plugin are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - research
     - codebase-analysis

--- a/plugins/fieldguides/skills/skillcraft/SKILL.md
+++ b/plugins/fieldguides/skills/skillcraft/SKILL.md
@@ -2,7 +2,7 @@
 name: skillcraft
 description: "Creates and validates Agent Skills (SKILL.md). Use when creating skills, writing frontmatter, or validating skill structure."
 metadata:
-  version: "2.2.0"
+  version: "2.2.1"
   author: outfitter
   related-skills:
     - claude-craft

--- a/plugins/fieldguides/skills/skills-workflows/SKILL.md
+++ b/plugins/fieldguides/skills/skills-workflows/SKILL.md
@@ -2,7 +2,7 @@
 name: skills-workflows
 description: "Design multi-skill workflow systems with artifact-based state handoff. Use when building skill pipelines, sequenced workflows, or when workflow system, skill pipeline, state handoff, or artifacts are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   related-skills:
     - skillcraft
     - claude-craft

--- a/plugins/fieldguides/skills/software-craft/SKILL.md
+++ b/plugins/fieldguides/skills/software-craft/SKILL.md
@@ -2,7 +2,7 @@
 name: software-craft
 description: "This skill should be used when making design decisions, evaluating trade-offs, assessing code quality, or when engineering judgment or code quality are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Software Engineering

--- a/plugins/fieldguides/skills/systems-design/SKILL.md
+++ b/plugins/fieldguides/skills/systems-design/SKILL.md
@@ -2,7 +2,7 @@
 name: systems-design
 description: "This skill should be used when designing systems, evaluating architectures, making technology decisions, or planning for scale. Provides technology selection frameworks, scalability planning, and architectural tradeoff analysis."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 # Software Architecture

--- a/plugins/fieldguides/skills/tdd-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/tdd-fieldguide/SKILL.md
@@ -2,7 +2,7 @@
 name: tdd-fieldguide
 description: "This skill should be used when implementing features with TDD, writing tests first, or refactoring with test coverage. Applies disciplined Red-Green-Refactor cycles with TypeScript/Bun and Rust tooling."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 # Test-Driven Development

--- a/plugins/fieldguides/skills/trails/SKILL.md
+++ b/plugins/fieldguides/skills/trails/SKILL.md
@@ -2,7 +2,7 @@
 name: trails
 description: "This skill should be used when creating session handoffs, logging research findings, or reading previous trail notes. Triggers include handoff, session continuity, log note, trail notes, or when ending a session."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Trail

--- a/plugins/fieldguides/skills/typescript-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/typescript-fieldguide/SKILL.md
@@ -2,7 +2,7 @@
 name: typescript-fieldguide
 description: "This skill should be used when writing TypeScript, eliminating any types, implementing Zod validation, or when strict type safety is needed. Covers modern TS 5.5+ features and runtime validation patterns."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # TypeScript Development

--- a/plugins/fieldguides/skills/use-subagents/SKILL.md
+++ b/plugins/fieldguides/skills/use-subagents/SKILL.md
@@ -2,7 +2,7 @@
 name: use-subagents
 description: "This skill should be used when coordinating agents, delegating tasks to specialists, or when dispatch agents, which agent, or multi-agent are mentioned."
 metadata:
-  version: "2.2.0"
+  version: "2.2.1"
   related-skills:
     - context-management
     - pathfinding

--- a/plugins/fieldguides/skills/which-tool/SKILL.md
+++ b/plugins/fieldguides/skills/which-tool/SKILL.md
@@ -2,7 +2,7 @@
 name: which-tool
 description: "This skill should be used when choosing CLI tools, a tool seems slow, or when best tool, which tool, or tool alternatives are mentioned."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
 ---
 
 # Use the Best Tool

--- a/plugins/outfitter/.claude-plugin/plugin.json
+++ b/plugins/outfitter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "outfitter",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Skills and workflows for working with @outfitter/* packages. Patterns, templates, compliance checking, and debugging for the Outfitter Stack.",
   "author": {
     "name": "Outfitter",

--- a/plugins/outfitter/skills/debug-outfitter/SKILL.md
+++ b/plugins/outfitter/skills/debug-outfitter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-outfitter
-version: 0.2.0
+version: 0.2.1
 description: "Systematic debugging process for @outfitter/* package issues. Use when debugging Result handling, MCP problems, CLI output, exit codes, logging, or unexpected behavior. Produces structured investigation reports with root cause analysis."
 allowed-tools: Read, Grep, Glob, Bash(bun *), Bash(rg *)
 ---

--- a/plugins/outfitter/skills/outfitter-atlas/SKILL.md
+++ b/plugins/outfitter/skills/outfitter-atlas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outfitter-atlas
-version: 0.2.0
+version: 0.2.1
 description: "Generates patterns, templates, and guides for @outfitter/* packages. Covers transport-agnostic handler systems, Result types, error taxonomy, and package APIs. Use when working with @outfitter/*, Result types, Handler contract, error taxonomy, or when Result, Handler, ValidationError, NotFoundError, OutfitterError, or package names like contracts, cli, mcp, daemon, config, logging are mentioned."
 ---
 

--- a/plugins/outfitter/skills/outfitter-check/SKILL.md
+++ b/plugins/outfitter/skills/outfitter-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outfitter-check
-version: 0.1.0
+version: 0.1.1
 description: "Verify Outfitter Stack compliance in a codebase. Scans for anti-patterns (throws, console, hardcoded paths) and produces a severity-ranked compliance report. Use for pre-commit checks, code review, or migration validation."
 allowed-tools: Read, Grep, Glob, Bash(rg *), Bash(bun *)
 ---

--- a/plugins/outfitter/skills/outfitter-issue/SKILL.md
+++ b/plugins/outfitter/skills/outfitter-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outfitter-issue
-version: 0.4.0
+version: 0.4.1
 description: "Submit feedback to the Outfitter team via GitHub issues. Use after discovering bugs, missing features, unclear docs, or improvement opportunities in @outfitter/* packages."
 allowed-tools: Bash(gh *), Bash(bun *), Bash(./scripts/*), Read
 user-invocable: true

--- a/plugins/outfitter/skills/outfitter-start/SKILL.md
+++ b/plugins/outfitter/skills/outfitter-start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outfitter-start
-version: 1.0.0
+version: 1.0.1
 description: "Start with Outfitter Stack — scaffold new projects or adopt patterns in existing codebases. Detects context, scans for adoption candidates, and orchestrates phased conversion."
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, AskUserQuestion
 ---

--- a/plugins/outfitter/skills/outfitter-update/SKILL.md
+++ b/plugins/outfitter/skills/outfitter-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outfitter-update
-version: 1.0.0
+version: 1.0.1
 description: "Update @outfitter/* packages to latest versions with migration guidance. Detects installed versions, surfaces breaking changes, and applies migration steps."
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Skill, AskUserQuestion
 ---

--- a/plugins/team/.claude-plugin/plugin.json
+++ b/plugins/team/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Internal Outfitter team skills for docs, voice, and conventions",
   "author": {
     "name": "Outfitter",

--- a/plugins/team/skills/outfitter-agents-check/SKILL.md
+++ b/plugins/team/skills/outfitter-agents-check/SKILL.md
@@ -2,7 +2,7 @@
 name: outfitter-agents-check
 description: "Checks and configures Outfitter marketplaces and plugins. Use when setting up projects or checking plugin configuration."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   author: outfitter
   category: setup
 ---

--- a/plugins/team/skills/outfitter-agents-setup/SKILL.md
+++ b/plugins/team/skills/outfitter-agents-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: outfitter-agents-setup
 description: "Documentation patterns for AI agents — AGENTS.md, CLAUDE.md, and agent-readable content. Use when creating agent entry points or structuring .claude/ directories."
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   author: outfitter
   category: documentation
 ---

--- a/plugins/team/skills/outfitter-documentation/SKILL.md
+++ b/plugins/team/skills/outfitter-documentation/SKILL.md
@@ -2,7 +2,7 @@
 name: outfitter-documentation
 description: "Documentation structure and templates for READMEs, API docs, guides, and CLI references. Use when creating docs, writing READMEs, or structuring a docs/ directory."
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   author: outfitter
   category: documentation
 ---

--- a/plugins/team/skills/outfitter-editorial/SKILL.md
+++ b/plugins/team/skills/outfitter-editorial/SKILL.md
@@ -4,7 +4,7 @@ description: "Complete editorial review for Outfitter documentation — voice, s
 context: fork
 agent: editor
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   author: outfitter
   category: documentation
 ---

--- a/plugins/team/skills/outfitter-styleguide/SKILL.md
+++ b/plugins/team/skills/outfitter-styleguide/SKILL.md
@@ -2,7 +2,7 @@
 name: outfitter-styleguide
 description: "Writing craft and style patterns for Outfitter content — sentence rhythm, metaphors, enthusiasm calibration. Use when drafting or reviewing blog posts, docs, announcements, or READMEs."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
   author: outfitter
   category: content
 ---

--- a/plugins/team/skills/outfitter-voice/SKILL.md
+++ b/plugins/team/skills/outfitter-voice/SKILL.md
@@ -2,7 +2,7 @@
 name: outfitter-voice
 description: "Outfitter's philosophical voice and values — opinionated stance, agent-first design, earned confidence. Use when writing content, reviewing drafts, or establishing tone."
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   author: outfitter
   category: content
 ---


### PR DESCRIPTION
## Summary

Version bumps for all plugins and skills to mark the refactoring milestone.

**Plugins (minor bump):**
- fieldguides: 1.3.1 → 1.4.0
- outfitter: 1.5.0 → 1.6.0
- team: 0.5.0 → 0.6.0

**Skills (patch bump):**
- All 46 skills with version fields incremented (34 fieldguides, 6 outfitter, 6 team)

## Test plan

- [x] All version fields follow semver
- [x] No skills missed

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)