### PR TITLE
feat(outfitter): define manifest schema and read/write utilities

### DIFF
--- a/apps/outfitter/src/__tests__/manifest.test.ts
+++ b/apps/outfitter/src/__tests__/manifest.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  type Manifest,
+  ManifestSchema,
+  readManifest,
+  stampBlock,
+  writeManifest,
+} from "../manifest.js";
+
+describe("manifest", () => {
+  const testDir = join(import.meta.dirname, ".test-manifest-output");
+
+  beforeEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true });
+    }
+  });
+
+  // =========================================================================
+  // readManifest
+  // =========================================================================
+
+  describe("readManifest", () => {
+    test("returns null for missing manifest", async () => {
+      const result = await readManifest(testDir);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBeNull();
+      }
+    });
+
+    test("returns parsed manifest for valid file", async () => {
+      const manifest: Manifest = {
+        version: 1,
+        blocks: {
+          biome: {
+            installedFrom: "0.2.1",
+            installedAt: "2026-02-10T00:00:00.000Z",
+          },
+        },
+      };
+      mkdirSync(join(testDir, ".outfitter"), { recursive: true });
+      writeFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        JSON.stringify(manifest)
+      );
+
+      const result = await readManifest(testDir);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).not.toBeNull();
+        expect(result.value?.version).toBe(1);
+        expect(result.value?.blocks["biome"]?.installedFrom).toBe("0.2.1");
+      }
+    });
+
+    test("returns error for invalid JSON", async () => {
+      mkdirSync(join(testDir, ".outfitter"), { recursive: true });
+      writeFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        "not valid json {{{"
+      );
+
+      const result = await readManifest(testDir);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("manifest");
+      }
+    });
+
+    test("returns error for invalid schema", async () => {
+      mkdirSync(join(testDir, ".outfitter"), { recursive: true });
+      writeFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        JSON.stringify({ version: 99, blocks: "not-an-object" })
+      );
+
+      const result = await readManifest(testDir);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("manifest");
+      }
+    });
+  });
+
+  // =========================================================================
+  // writeManifest
+  // =========================================================================
+
+  describe("writeManifest", () => {
+    test("creates .outfitter/ directory if missing", async () => {
+      const manifest: Manifest = {
+        version: 1,
+        blocks: {},
+      };
+
+      const result = await writeManifest(testDir, manifest);
+
+      expect(result.isOk()).toBe(true);
+      expect(existsSync(join(testDir, ".outfitter"))).toBe(true);
+      expect(existsSync(join(testDir, ".outfitter/manifest.json"))).toBe(true);
+    });
+
+    test("produces valid JSON matching schema", async () => {
+      const manifest: Manifest = {
+        version: 1,
+        blocks: {
+          lefthook: {
+            installedFrom: "0.2.1",
+            installedAt: "2026-02-10T12:00:00.000Z",
+          },
+        },
+      };
+
+      await writeManifest(testDir, manifest);
+
+      const raw = readFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        "utf-8"
+      );
+      const parsed = JSON.parse(raw);
+
+      // Validate against schema
+      const validated = ManifestSchema.parse(parsed);
+      expect(validated.version).toBe(1);
+      expect(validated.blocks["lefthook"]?.installedFrom).toBe("0.2.1");
+    });
+  });
+
+  // =========================================================================
+  // stampBlock
+  // =========================================================================
+
+  describe("stampBlock", () => {
+    test("creates manifest if missing", async () => {
+      const result = await stampBlock(testDir, "biome", "0.2.1");
+
+      expect(result.isOk()).toBe(true);
+      expect(existsSync(join(testDir, ".outfitter/manifest.json"))).toBe(true);
+
+      // Verify contents
+      const raw = readFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        "utf-8"
+      );
+      const parsed = JSON.parse(raw) as Manifest;
+      expect(parsed.version).toBe(1);
+      expect(parsed.blocks["biome"]?.installedFrom).toBe("0.2.1");
+      expect(parsed.blocks["biome"]?.installedAt).toBeDefined();
+    });
+
+    test("adds new block to existing manifest", async () => {
+      // Write initial manifest with one block
+      const initial: Manifest = {
+        version: 1,
+        blocks: {
+          biome: {
+            installedFrom: "0.2.0",
+            installedAt: "2026-02-09T00:00:00.000Z",
+          },
+        },
+      };
+      mkdirSync(join(testDir, ".outfitter"), { recursive: true });
+      writeFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        JSON.stringify(initial)
+      );
+
+      const result = await stampBlock(testDir, "lefthook", "0.2.1");
+
+      expect(result.isOk()).toBe(true);
+
+      const raw = readFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        "utf-8"
+      );
+      const parsed = JSON.parse(raw) as Manifest;
+      // Original block should still be there
+      expect(parsed.blocks["biome"]?.installedFrom).toBe("0.2.0");
+      // New block should be added
+      expect(parsed.blocks["lefthook"]?.installedFrom).toBe("0.2.1");
+    });
+
+    test("updates existing block entry", async () => {
+      // Write initial manifest
+      const initial: Manifest = {
+        version: 1,
+        blocks: {
+          biome: {
+            installedFrom: "0.2.0",
+            installedAt: "2026-02-09T00:00:00.000Z",
+          },
+        },
+      };
+      mkdirSync(join(testDir, ".outfitter"), { recursive: true });
+      writeFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        JSON.stringify(initial)
+      );
+
+      const result = await stampBlock(testDir, "biome", "0.3.0");
+
+      expect(result.isOk()).toBe(true);
+
+      const raw = readFileSync(
+        join(testDir, ".outfitter/manifest.json"),
+        "utf-8"
+      );
+      const parsed = JSON.parse(raw) as Manifest;
+      expect(parsed.blocks["biome"]?.installedFrom).toBe("0.3.0");
+      // installedAt should be updated (not the old timestamp)
+      expect(parsed.blocks["biome"]?.installedAt).not.toBe(
+        "2026-02-09T00:00:00.000Z"
+      );
+    });
+  });
+});

--- a/apps/outfitter/src/manifest.ts
+++ b/apps/outfitter/src/manifest.ts
@@ -1,0 +1,225 @@
+/**
+ * Manifest schema and read/write utilities.
+ *
+ * Tracks which config blocks were installed and from which tooling version.
+ * Stored at `.outfitter/manifest.json` in the project root.
+ *
+ * @packageDocumentation
+ */
+
+import { join } from "node:path";
+import {
+  InternalError,
+  type OutfitterError,
+  Result,
+  ValidationError,
+} from "@outfitter/contracts";
+import { type ZodType, z } from "zod";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Directory name for Outfitter metadata. */
+const OUTFITTER_DIR = ".outfitter";
+
+/** Manifest file name within the Outfitter directory. */
+const MANIFEST_FILE = "manifest.json";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** A single block entry in the manifest. */
+export interface BlockEntry {
+  /** Tooling version the block was installed from. */
+  installedFrom: string;
+  /** ISO 8601 timestamp of when the block was installed or last updated. */
+  installedAt: string;
+}
+
+/** The full manifest structure. */
+export interface Manifest {
+  /** Manifest format version. Currently always 1. */
+  version: 1;
+  /** Map of block name to install metadata. */
+  blocks: Record<string, BlockEntry>;
+}
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+/**
+ * Schema for a single block entry in the manifest.
+ */
+export const BlockEntrySchema: ZodType<BlockEntry> = z.object({
+  installedFrom: z.string(),
+  installedAt: z.string().datetime(),
+});
+
+/**
+ * Schema for the manifest file.
+ */
+export const ManifestSchema: ZodType<Manifest> = z.object({
+  version: z.literal(1),
+  blocks: z.record(z.string(), BlockEntrySchema),
+});
+
+// =============================================================================
+// Utilities
+// =============================================================================
+
+/**
+ * Returns the path to the manifest file for the given working directory.
+ */
+function manifestPath(cwd: string): string {
+  return join(cwd, OUTFITTER_DIR, MANIFEST_FILE);
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Reads and validates `.outfitter/manifest.json`.
+ *
+ * @param cwd - Working directory containing the `.outfitter/` folder
+ * @returns The parsed manifest, or `null` if the file does not exist
+ *
+ * @example
+ * ```typescript
+ * const result = await readManifest(process.cwd());
+ * if (result.isOk() && result.value) {
+ *   console.log(result.value.blocks);
+ * }
+ * ```
+ */
+export async function readManifest(
+  cwd: string
+): Promise<Result<Manifest | null, OutfitterError>> {
+  const path = manifestPath(cwd);
+  const file = Bun.file(path);
+
+  if (!(await file.exists())) {
+    return Result.ok(null);
+  }
+
+  let raw: string;
+  try {
+    raw = await file.text();
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to read manifest file", { path })
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return Result.err(
+      ValidationError.create("manifest", "Invalid JSON in manifest file")
+    );
+  }
+
+  const validated = ManifestSchema.safeParse(parsed);
+  if (!validated.success) {
+    return Result.err(
+      ValidationError.create(
+        "manifest",
+        "Manifest file does not match expected schema"
+      )
+    );
+  }
+
+  return Result.ok(validated.data);
+}
+
+/**
+ * Writes a manifest to `.outfitter/manifest.json`.
+ *
+ * Creates the `.outfitter/` directory if it does not exist.
+ * Writes atomically via `Bun.write`.
+ *
+ * @param cwd - Working directory to write the manifest into
+ * @param manifest - The manifest data to write
+ *
+ * @example
+ * ```typescript
+ * await writeManifest(process.cwd(), { version: 1, blocks: {} });
+ * ```
+ */
+export async function writeManifest(
+  cwd: string,
+  manifest: Manifest
+): Promise<Result<void, OutfitterError>> {
+  const dirPath = join(cwd, OUTFITTER_DIR);
+  const path = join(dirPath, MANIFEST_FILE);
+
+  try {
+    const { mkdirSync, existsSync, statSync } = await import("node:fs");
+    if (existsSync(dirPath)) {
+      if (!statSync(dirPath).isDirectory()) {
+        return Result.err(
+          ValidationError.create(
+            "manifest",
+            ".outfitter exists but is not a directory"
+          )
+        );
+      }
+    } else {
+      mkdirSync(dirPath, { recursive: true });
+    }
+
+    const content = JSON.stringify(manifest, null, "\t");
+    await Bun.write(path, `${content}\n`);
+    return Result.ok(undefined);
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to write manifest file", { path })
+    );
+  }
+}
+
+/**
+ * Adds or updates a block entry in the manifest (read-modify-write).
+ *
+ * If no manifest exists, creates a new one. If the block already exists,
+ * updates its `installedFrom` and `installedAt` fields.
+ *
+ * @param cwd - Working directory containing the project
+ * @param blockName - Name of the block to stamp
+ * @param toolingVersion - Version of the tooling package the block was installed from
+ *
+ * @example
+ * ```typescript
+ * await stampBlock(process.cwd(), "biome", "0.2.1");
+ * ```
+ */
+export async function stampBlock(
+  cwd: string,
+  blockName: string,
+  toolingVersion: string
+): Promise<Result<void, OutfitterError>> {
+  const readResult = await readManifest(cwd);
+  if (readResult.isErr()) {
+    return readResult;
+  }
+
+  const existing = readResult.value;
+  const manifest: Manifest = existing ?? { version: 1, blocks: {} };
+
+  const updated: Manifest = {
+    ...manifest,
+    blocks: {
+      ...manifest.blocks,
+      [blockName]: {
+        installedFrom: toolingVersion,
+        installedAt: new Date().toISOString(),
+      },
+    },
+  };
+
+  return writeManifest(cwd, updated);
+}


### PR DESCRIPTION
## Summary

- Adds `Manifest` type with Zod schema for `.outfitter/manifest.json`
- Implements `readManifest()`, `writeManifest()`, and `stampBlock()` utilities
- 9 tests covering read/write/stamp operations

Closes OS-102

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)