### PR TITLE
feat(outfitter): add monorepo workspace scanning to outfitter update

### DIFF
--- a/apps/outfitter/src/__tests__/update-workspace.test.ts
+++ b/apps/outfitter/src/__tests__/update-workspace.test.ts
@@ -1,0 +1,642 @@
+/**
+ * Tests for workspace-aware scanning in `outfitter update`.
+ *
+ * Validates workspace root detection, manifest collection,
+ * cross-workspace dependency deduplication, and multi-manifest apply.
+ *
+ * @packageDocumentation
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { runUpdate } from "../commands/update.js";
+import {
+  collectWorkspaceManifests,
+  detectWorkspaceRoot,
+  getInstalledPackagesFromWorkspace,
+} from "../commands/update-workspace.js";
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+function createTempDir(): string {
+  const tempDir = join(
+    tmpdir(),
+    `outfitter-update-ws-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  return tempDir;
+}
+
+function cleanupTempDir(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+// =============================================================================
+// Test Setup/Teardown
+// =============================================================================
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = createTempDir();
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+  mock.restore();
+});
+
+// =============================================================================
+// detectWorkspaceRoot
+// =============================================================================
+
+describe("detectWorkspaceRoot", () => {
+  test("returns root when package.json has workspaces field", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    const result = detectWorkspaceRoot(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(resolve(tempDir));
+    }
+  });
+
+  test("detects workspace root from nested directory", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+    const nested = join(tempDir, "packages", "my-app");
+    mkdirSync(nested, { recursive: true });
+    writeJson(join(nested, "package.json"), {
+      name: "my-app",
+      version: "1.0.0",
+    });
+
+    const result = detectWorkspaceRoot(nested);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(resolve(tempDir));
+    }
+  });
+
+  test("returns null result when no workspace root found", () => {
+    // Create a simple package.json without workspaces
+    writeJson(join(tempDir, "package.json"), {
+      name: "standalone",
+      version: "1.0.0",
+    });
+
+    const result = detectWorkspaceRoot(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test("detects pnpm-workspace.yaml as workspace marker", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "pnpm-monorepo",
+    });
+    writeFileSync(
+      join(tempDir, "pnpm-workspace.yaml"),
+      "packages:\n  - packages/*\n"
+    );
+
+    const result = detectWorkspaceRoot(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(resolve(tempDir));
+    }
+  });
+
+  test("detects yarn workspaces object format", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "yarn-monorepo",
+      workspaces: {
+        packages: ["packages/*"],
+      },
+    });
+
+    const result = detectWorkspaceRoot(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(resolve(tempDir));
+    }
+  });
+});
+
+// =============================================================================
+// collectWorkspaceManifests
+// =============================================================================
+
+describe("collectWorkspaceManifests", () => {
+  test("collects package.json files matching workspace patterns", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      devDependencies: { "@outfitter/testing": "^0.1.0" },
+    });
+
+    const result = collectWorkspaceManifests(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const paths = result.value;
+      expect(paths).toHaveLength(3); // root + 2 packages
+      expect(paths).toContain(
+        resolve(tempDir, "packages", "pkg-a", "package.json")
+      );
+      expect(paths).toContain(
+        resolve(tempDir, "packages", "pkg-b", "package.json")
+      );
+      expect(paths).toContain(resolve(tempDir, "package.json"));
+    }
+  });
+
+  test("handles multiple workspace patterns", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*", "apps/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "lib", "package.json"), {
+      name: "lib",
+    });
+    writeJson(join(tempDir, "apps", "web", "package.json"), {
+      name: "web",
+    });
+
+    const result = collectWorkspaceManifests(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(3); // root + 2
+    }
+  });
+
+  test("returns only root when no workspace patterns match", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+    // No packages directory created
+
+    const result = collectWorkspaceManifests(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toBe(resolve(tempDir, "package.json"));
+    }
+  });
+
+  test("results are sorted deterministically", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "zebra", "package.json"), {
+      name: "zebra",
+    });
+    writeJson(join(tempDir, "packages", "alpha", "package.json"), {
+      name: "alpha",
+    });
+
+    const result = collectWorkspaceManifests(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const paths = result.value;
+      // Should be sorted: root first (package.json), then alphabetically
+      expect(paths[0]).toBe(resolve(tempDir, "package.json"));
+      expect(paths[1]).toContain("alpha");
+      expect(paths[2]).toContain("zebra");
+    }
+  });
+});
+
+// =============================================================================
+// getInstalledPackagesFromWorkspace
+// =============================================================================
+
+describe("getInstalledPackagesFromWorkspace", () => {
+  test("deduplicates @outfitter/* deps across workspace members", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    const result = getInstalledPackagesFromWorkspace(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const { packages } = result.value;
+      const cliEntries = packages.filter((p) => p.name === "@outfitter/cli");
+      // Deduplicated: same version appears once
+      expect(cliEntries).toHaveLength(1);
+      expect(cliEntries[0]?.version).toBe("0.1.0");
+    }
+  });
+
+  test("collects packages from all dependency sections", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+      devDependencies: { "@outfitter/testing": "^0.1.0" },
+    });
+
+    const result = getInstalledPackagesFromWorkspace(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const names = result.value.packages.map((p) => p.name);
+      expect(names).toContain("@outfitter/cli");
+      expect(names).toContain("@outfitter/testing");
+    }
+  });
+
+  test("reports version conflicts across workspace members", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      dependencies: { "@outfitter/cli": "^0.2.0" },
+    });
+
+    const result = getInstalledPackagesFromWorkspace(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.conflicts).toHaveLength(1);
+      expect(result.value.conflicts[0]?.name).toBe("@outfitter/cli");
+      expect(result.value.conflicts[0]?.versions).toHaveLength(2);
+    }
+  });
+
+  test("skips workspace:* protocol versions", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+      dependencies: { "@outfitter/contracts": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/contracts": "workspace:*" },
+    });
+
+    const result = getInstalledPackagesFromWorkspace(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const contractsEntries = result.value.packages.filter(
+        (p) => p.name === "@outfitter/contracts"
+      );
+      // Only the root's version should appear, workspace:* is skipped
+      expect(contractsEntries).toHaveLength(1);
+      expect(contractsEntries[0]?.version).toBe("0.1.0");
+    }
+  });
+
+  test("returns manifest paths for each package occurrence", () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    const result = getInstalledPackagesFromWorkspace(tempDir);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const { manifestsByPackage } = result.value;
+      const cliManifests = manifestsByPackage.get("@outfitter/cli");
+      expect(cliManifests).toBeDefined();
+      expect(cliManifests).toHaveLength(2);
+    }
+  });
+});
+
+// =============================================================================
+// runUpdate with workspace awareness (--apply)
+// =============================================================================
+
+// Track Bun.spawn calls for verification
+let spawnCalls: Array<{ cmd: string[]; cwd?: string }> = [];
+const originalSpawn = Bun.spawn;
+
+function mockNpmAndInstall(versionMap: Record<string, string>): void {
+  const mockSpawn = (
+    cmd: string[],
+    opts?: { cwd?: string; stdout?: string; stderr?: string }
+  ) => {
+    const cmdArray = Array.isArray(cmd) ? cmd : [cmd];
+
+    if (
+      cmdArray[0] === "npm" &&
+      cmdArray[1] === "view" &&
+      cmdArray[3] === "version"
+    ) {
+      const pkgName = cmdArray[2] ?? "";
+      const version = versionMap[pkgName];
+
+      spawnCalls.push({ cmd: cmdArray, cwd: opts?.cwd });
+
+      if (version) {
+        return {
+          stdout: new Response(version).body,
+          stderr: new Response("").body,
+          exited: Promise.resolve(0),
+        };
+      }
+      return {
+        stdout: new Response("").body,
+        stderr: new Response("Not found").body,
+        exited: Promise.resolve(1),
+      };
+    }
+
+    if (cmdArray[0] === "bun" && cmdArray[1] === "install") {
+      spawnCalls.push({ cmd: cmdArray, cwd: opts?.cwd });
+      return {
+        stdout: new Response("").body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(0),
+      };
+    }
+
+    return originalSpawn(cmd, opts as Parameters<typeof Bun.spawn>[1]);
+  };
+
+  Object.assign(Bun, { spawn: mockSpawn });
+}
+
+describe("runUpdate with workspace --apply", () => {
+  beforeEach(() => {
+    spawnCalls = [];
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("updates all manifests in a workspace when --apply is used", async () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    mockNpmAndInstall({
+      "@outfitter/cli": "0.1.5",
+    });
+
+    const result = await runUpdate({ cwd: tempDir, apply: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.applied).toBe(true);
+    expect(result.value.appliedPackages).toContain("@outfitter/cli");
+
+    // Both manifests should be updated
+    const pkgA = readJson(
+      join(tempDir, "packages", "pkg-a", "package.json")
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+    const pkgB = readJson(
+      join(tempDir, "packages", "pkg-b", "package.json")
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(pkgA.dependencies?.["@outfitter/cli"]).toBe("^0.1.5");
+    expect(pkgB.dependencies?.["@outfitter/cli"]).toBe("^0.1.5");
+  });
+
+  test("runs bun install once at workspace root", async () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      version: "1.0.0",
+      devDependencies: { "@outfitter/testing": "^0.1.0" },
+    });
+
+    mockNpmAndInstall({
+      "@outfitter/cli": "0.1.5",
+      "@outfitter/testing": "0.1.2",
+    });
+
+    await runUpdate({ cwd: tempDir, apply: true });
+
+    const installCalls = spawnCalls.filter(
+      (c) => c.cmd[0] === "bun" && c.cmd[1] === "install"
+    );
+    // Should only run once at the root
+    expect(installCalls).toHaveLength(1);
+    expect(installCalls[0]?.cwd).toBe(resolve(tempDir));
+  });
+
+  test("non-workspace single package behavior unchanged", async () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "standalone",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    mockNpmAndInstall({
+      "@outfitter/cli": "0.1.5",
+    });
+
+    const result = await runUpdate({ cwd: tempDir, apply: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.applied).toBe(true);
+
+    const pkg = readJson(join(tempDir, "package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies?.["@outfitter/cli"]).toBe("^0.1.5");
+
+    // Install should run at cwd (the standalone package root)
+    const installCalls = spawnCalls.filter(
+      (c) => c.cmd[0] === "bun" && c.cmd[1] === "install"
+    );
+    expect(installCalls).toHaveLength(1);
+  });
+
+  test("detects workspace from nested cwd", async () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    const nestedDir = join(tempDir, "packages", "pkg-a");
+    writeJson(join(nestedDir, "package.json"), {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-b", "package.json"), {
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    mockNpmAndInstall({
+      "@outfitter/cli": "0.1.5",
+    });
+
+    // Run from nested package directory
+    const result = await runUpdate({ cwd: nestedDir, apply: true });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.applied).toBe(true);
+
+    // Both manifests should still be updated (workspace-wide)
+    const pkgA = readJson(join(nestedDir, "package.json")) as {
+      dependencies?: Record<string, string>;
+    };
+    const pkgB = readJson(
+      join(tempDir, "packages", "pkg-b", "package.json")
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(pkgA.dependencies?.["@outfitter/cli"]).toBe("^0.1.5");
+    expect(pkgB.dependencies?.["@outfitter/cli"]).toBe("^0.1.5");
+  });
+
+  test("read-only mode scans workspace but does not write", async () => {
+    writeJson(join(tempDir, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+
+    writeJson(join(tempDir, "packages", "pkg-a", "package.json"), {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "@outfitter/cli": "^0.1.0" },
+    });
+
+    mockNpmAndInstall({
+      "@outfitter/cli": "0.1.5",
+    });
+
+    // No --apply
+    const result = await runUpdate({ cwd: tempDir });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.applied).toBe(false);
+    expect(result.value.updatesAvailable).toBe(1);
+
+    // package.json should be unchanged
+    const pkgA = readJson(
+      join(tempDir, "packages", "pkg-a", "package.json")
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkgA.dependencies?.["@outfitter/cli"]).toBe("^0.1.0");
+  });
+});

--- a/apps/outfitter/src/commands/update-workspace.ts
+++ b/apps/outfitter/src/commands/update-workspace.ts
@@ -1,0 +1,559 @@
+/**
+ * Workspace-aware scanning for `outfitter update`.
+ *
+ * Detects monorepo workspace roots, collects all package.json manifests
+ * matching workspace patterns, and extracts @outfitter/* dependencies
+ * across all workspace members with deduplication and conflict reporting.
+ *
+ * @packageDocumentation
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import type { OutfitterError } from "@outfitter/contracts";
+import { InternalError, Result } from "@outfitter/contracts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** A package dependency found across workspace manifests. */
+export interface WorkspacePackageEntry {
+  /** Full package name (e.g. "@outfitter/cli") */
+  readonly name: string;
+  /** Cleaned semver version (without range prefix) */
+  readonly version: string;
+}
+
+/** Version conflict: same package at different versions in different manifests. */
+export interface VersionConflict {
+  /** Full package name */
+  readonly name: string;
+  /** All distinct versions found, with their manifest paths */
+  readonly versions: ReadonlyArray<{
+    readonly version: string;
+    readonly manifests: readonly string[];
+  }>;
+}
+
+/** Result of scanning a workspace for @outfitter/* packages. */
+export interface WorkspaceScanResult {
+  /** Deduplicated @outfitter/* packages (uses lowest version for conflicts) */
+  readonly packages: readonly WorkspacePackageEntry[];
+  /** Version conflicts found across manifests */
+  readonly conflicts: readonly VersionConflict[];
+  /** Maps package name to the manifest paths that contain it */
+  readonly manifestsByPackage: ReadonlyMap<string, readonly string[]>;
+  /** All manifest paths scanned */
+  readonly manifestPaths: readonly string[];
+  /** Workspace root directory (null if not a workspace) */
+  readonly workspaceRoot: string | null;
+}
+
+// =============================================================================
+// Internal Types
+// =============================================================================
+
+interface PackageDeps {
+  workspaces?: unknown;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+// =============================================================================
+// Workspace Detection
+// =============================================================================
+
+/**
+ * Walk up from `cwd` looking for a workspace root.
+ *
+ * Workspace root is identified by:
+ * - `package.json` with a `workspaces` field (npm/yarn/bun)
+ * - `pnpm-workspace.yaml` file
+ *
+ * Returns `null` (as Ok) if no workspace root found — this is not an error,
+ * it means the project is a standalone package.
+ */
+export function detectWorkspaceRoot(
+  cwd: string
+): Result<string | null, OutfitterError> {
+  let current = resolve(cwd);
+  const root = resolve("/");
+
+  while (true) {
+    // Check for pnpm-workspace.yaml
+    if (existsSync(join(current, "pnpm-workspace.yaml"))) {
+      return Result.ok(current);
+    }
+
+    // Check for package.json with workspaces field
+    const pkgPath = join(current, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const raw = readFileSync(pkgPath, "utf-8");
+        const pkg = JSON.parse(raw) as PackageDeps;
+
+        if (hasWorkspacesField(pkg)) {
+          return Result.ok(current);
+        }
+      } catch {
+        // Invalid JSON, skip and keep searching
+      }
+    }
+
+    // Stop at filesystem root
+    if (current === root) {
+      break;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return Result.ok(null);
+}
+
+/**
+ * Check if a parsed package.json has a `workspaces` field
+ * in either array or object format.
+ */
+function hasWorkspacesField(pkg: PackageDeps): boolean {
+  const workspaces = pkg.workspaces;
+
+  if (Array.isArray(workspaces) && workspaces.length > 0) {
+    return true;
+  }
+
+  if (
+    workspaces &&
+    typeof workspaces === "object" &&
+    !Array.isArray(workspaces)
+  ) {
+    const packages = (workspaces as { packages?: unknown }).packages;
+    if (Array.isArray(packages) && packages.length > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// =============================================================================
+// Manifest Collection
+// =============================================================================
+
+/**
+ * Resolve workspace patterns from a root package.json into
+ * a list of glob patterns targeting package.json files.
+ */
+function resolveWorkspacePatterns(pkg: PackageDeps): string[] {
+  const workspaces = pkg.workspaces;
+
+  let patterns: unknown[];
+  if (Array.isArray(workspaces)) {
+    patterns = workspaces;
+  } else if (
+    workspaces &&
+    typeof workspaces === "object" &&
+    !Array.isArray(workspaces)
+  ) {
+    const packages = (workspaces as { packages?: unknown }).packages;
+    if (Array.isArray(packages)) {
+      patterns = packages;
+    } else {
+      return [];
+    }
+  } else {
+    return [];
+  }
+
+  return patterns
+    .filter((p): p is string => typeof p === "string")
+    .map(normalizeWorkspacePattern);
+}
+
+/**
+ * Normalize a workspace pattern to always end with `/package.json`.
+ */
+function normalizeWorkspacePattern(pattern: string): string {
+  let value = pattern.trim().replaceAll("\\", "/");
+  if (value.length === 0) return value;
+  if (value.endsWith("/")) {
+    value = value.slice(0, -1);
+  }
+  if (value.endsWith("package.json")) {
+    return value;
+  }
+  return `${value}/package.json`;
+}
+
+/**
+ * Collect all package.json files from a workspace root directory.
+ *
+ * Reads workspace patterns from the root package.json, resolves globs,
+ * and returns sorted absolute paths to all matching package.json files.
+ * Always includes the root package.json itself.
+ */
+export function collectWorkspaceManifests(
+  rootDir: string
+): Result<string[], OutfitterError> {
+  const resolvedRoot = resolve(rootDir);
+  const rootPackageJson = join(resolvedRoot, "package.json");
+
+  if (!existsSync(rootPackageJson)) {
+    return Result.err(
+      InternalError.create("No package.json found at workspace root", {
+        rootDir: resolvedRoot,
+      })
+    );
+  }
+
+  let pkg: PackageDeps;
+  try {
+    const raw = readFileSync(rootPackageJson, "utf-8");
+    pkg = JSON.parse(raw);
+  } catch {
+    return Result.err(
+      InternalError.create("Invalid JSON in root package.json", {
+        rootDir: resolvedRoot,
+      })
+    );
+  }
+
+  const workspacePatterns = resolveWorkspacePatterns(pkg);
+  const files = new Set<string>([rootPackageJson]);
+
+  for (const pattern of workspacePatterns) {
+    if (pattern.length === 0) continue;
+
+    const glob = new Bun.Glob(pattern);
+    for (const entry of glob.scanSync({ cwd: resolvedRoot })) {
+      const absolute = resolve(resolvedRoot, entry);
+      if (existsSync(absolute) && basename(absolute) === "package.json") {
+        files.add(absolute);
+      }
+    }
+  }
+
+  return Result.ok(Array.from(files).sort((a, b) => a.localeCompare(b)));
+}
+
+// =============================================================================
+// Dependency Extraction
+// =============================================================================
+
+/**
+ * Extract @outfitter/* packages from a single manifest file.
+ * Returns entries with cleaned semver versions (range prefixes stripped).
+ */
+function extractOutfitterDeps(
+  manifestPath: string
+): Result<{ name: string; version: string }[], OutfitterError> {
+  let pkg: PackageDeps;
+  try {
+    const raw = readFileSync(manifestPath, "utf-8");
+    pkg = JSON.parse(raw);
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to parse package.json", {
+        path: manifestPath,
+      })
+    );
+  }
+
+  const deps = {
+    ...(pkg.dependencies ?? {}),
+    ...(pkg.devDependencies ?? {}),
+  };
+
+  const packages: { name: string; version: string }[] = [];
+
+  for (const [name, version] of Object.entries(deps)) {
+    if (!name.startsWith("@outfitter/")) continue;
+
+    // Handle workspace protocol
+    if (version.startsWith("workspace:")) {
+      const wsVersion = version.slice("workspace:".length);
+      if (wsVersion === "*" || wsVersion === "~" || wsVersion === "^") {
+        continue;
+      }
+      const wsClean = wsVersion.replace(/^[\^~>=<]+/, "");
+      try {
+        if (!Bun.semver.satisfies(wsClean, "*")) continue;
+      } catch {
+        continue;
+      }
+      packages.push({ name, version: wsClean });
+      continue;
+    }
+
+    const cleaned = version.replace(/^[\^~>=<]+/, "");
+    try {
+      if (!Bun.semver.satisfies(cleaned, "*")) continue;
+    } catch {
+      continue;
+    }
+
+    packages.push({ name, version: cleaned });
+  }
+
+  return Result.ok(packages);
+}
+
+/**
+ * Scan all workspace manifests, collect @outfitter/* deps,
+ * deduplicate, and detect version conflicts.
+ *
+ * For deduplication: when the same package appears at the same version
+ * in multiple manifests, it appears once in the result.
+ * When versions differ, the lowest version is used and a conflict is reported.
+ */
+export function getInstalledPackagesFromWorkspace(
+  rootDir: string
+): Result<WorkspaceScanResult, OutfitterError> {
+  const resolvedRoot = resolve(rootDir);
+
+  const wsRootResult = detectWorkspaceRoot(resolvedRoot);
+  if (wsRootResult.isErr()) return wsRootResult;
+
+  const effectiveRoot = wsRootResult.value ?? resolvedRoot;
+
+  let manifestPaths: string[];
+  if (wsRootResult.value !== null) {
+    const manifestsResult = collectWorkspaceManifests(effectiveRoot);
+    if (manifestsResult.isErr()) return manifestsResult;
+    manifestPaths = manifestsResult.value;
+  } else {
+    // Standalone: only the root package.json
+    const rootPkg = join(resolvedRoot, "package.json");
+    if (!existsSync(rootPkg)) {
+      return Result.err(
+        InternalError.create("No package.json found", { cwd: resolvedRoot })
+      );
+    }
+    manifestPaths = [rootPkg];
+  }
+
+  // Collect all @outfitter/* deps across all manifests
+  // Track: package name -> version -> list of manifest paths
+  const packageVersionMap = new Map<string, Map<string, string[]>>();
+  const manifestsByPackage = new Map<string, string[]>();
+
+  for (const manifestPath of manifestPaths) {
+    const depsResult = extractOutfitterDeps(manifestPath);
+    if (depsResult.isErr()) return depsResult;
+    const deps = depsResult.value;
+
+    for (const dep of deps) {
+      // Track version -> manifests
+      let versionMap = packageVersionMap.get(dep.name);
+      if (!versionMap) {
+        versionMap = new Map();
+        packageVersionMap.set(dep.name, versionMap);
+      }
+
+      let manifests = versionMap.get(dep.version);
+      if (!manifests) {
+        manifests = [];
+        versionMap.set(dep.version, manifests);
+      }
+      manifests.push(manifestPath);
+
+      // Track package -> all manifests
+      let pkgManifests = manifestsByPackage.get(dep.name);
+      if (!pkgManifests) {
+        pkgManifests = [];
+        manifestsByPackage.set(dep.name, pkgManifests);
+      }
+      pkgManifests.push(manifestPath);
+    }
+  }
+
+  // Deduplicate and detect conflicts
+  const packages: WorkspacePackageEntry[] = [];
+  const conflicts: VersionConflict[] = [];
+
+  for (const [name, versionMap] of packageVersionMap) {
+    const versions = Array.from(versionMap.entries())
+      .map(([version, manifests]) => ({ version, manifests }))
+      .sort((a, b) => {
+        try {
+          return Bun.semver.order(a.version, b.version);
+        } catch {
+          return a.version.localeCompare(b.version);
+        }
+      });
+
+    if (versions.length > 1) {
+      conflicts.push({ name, versions });
+    }
+
+    // Use the lowest version for the deduplicated entry
+    const lowest = versions[0];
+    if (lowest) {
+      packages.push({ name, version: lowest.version });
+    }
+  }
+
+  // Sort packages by name for deterministic output
+  packages.sort((a, b) => a.name.localeCompare(b.name));
+
+  return Result.ok({
+    packages,
+    conflicts,
+    manifestsByPackage,
+    manifestPaths,
+    workspaceRoot: wsRootResult.value,
+  });
+}
+
+// =============================================================================
+// Apply Updates to All Manifests
+// =============================================================================
+
+/**
+ * Apply version updates to all manifests in a workspace that contain
+ * the specified @outfitter/* packages.
+ *
+ * Preserves the existing version range prefix (^, ~, >=, etc.) in each manifest.
+ * Does NOT run `bun install` — the caller is responsible for that.
+ */
+export async function applyUpdatesToWorkspace(
+  manifestPaths: readonly string[],
+  manifestsByPackage: ReadonlyMap<string, readonly string[]>,
+  updates: readonly { name: string; latestVersion: string }[]
+): Promise<Result<void, OutfitterError>> {
+  // Build lookup: package name -> new version
+  const updateMap = new Map<string, string>();
+  for (const u of updates) {
+    updateMap.set(u.name, u.latestVersion);
+  }
+
+  // Collect all manifests that need updating
+  const manifestsToUpdate = new Set<string>();
+  for (const u of updates) {
+    const manifests = manifestsByPackage.get(u.name);
+    if (manifests) {
+      for (const m of manifests) {
+        manifestsToUpdate.add(m);
+      }
+    }
+  }
+
+  // Update each manifest
+  for (const manifestPath of manifestPaths) {
+    if (!manifestsToUpdate.has(manifestPath)) continue;
+
+    let raw: string;
+    try {
+      raw = readFileSync(manifestPath, "utf-8");
+    } catch {
+      return Result.err(
+        InternalError.create("Failed to read package.json for apply", {
+          path: manifestPath,
+        })
+      );
+    }
+
+    let pkg: PackageDeps;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      return Result.err(
+        InternalError.create("Invalid JSON in package.json", {
+          path: manifestPath,
+        })
+      );
+    }
+
+    let changed = false;
+
+    for (const section of ["dependencies", "devDependencies"] as const) {
+      const deps = pkg[section];
+      if (!deps) continue;
+
+      for (const name of Object.keys(deps)) {
+        const newVersion = updateMap.get(name);
+        if (newVersion === undefined) continue;
+
+        const currentSpecifier = deps[name];
+        if (currentSpecifier === undefined) continue;
+
+        // Skip workspace:* protocol
+        if (
+          currentSpecifier.startsWith("workspace:") &&
+          ["*", "~", "^"].includes(currentSpecifier.slice("workspace:".length))
+        ) {
+          continue;
+        }
+
+        const prefix = getVersionPrefix(currentSpecifier);
+        deps[name] = `${prefix}${newVersion}`;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      try {
+        const updated = `${JSON.stringify(pkg, null, 2)}\n`;
+        await Bun.write(manifestPath, updated);
+      } catch {
+        return Result.err(
+          InternalError.create("Failed to write updated package.json", {
+            path: manifestPath,
+          })
+        );
+      }
+    }
+  }
+
+  return Result.ok(undefined);
+}
+
+/**
+ * Determine the version range prefix used for a dependency specifier.
+ */
+function getVersionPrefix(specifier: string): string {
+  if (specifier.startsWith("workspace:")) {
+    const inner = specifier.slice("workspace:".length);
+    return `workspace:${getVersionPrefix(inner)}`;
+  }
+  const match = specifier.match(/^([\^~>=<]+)/);
+  return match?.[1] ?? "";
+}
+
+/**
+ * Run `bun install` at the given directory.
+ */
+export async function runInstall(
+  cwd: string
+): Promise<Result<void, OutfitterError>> {
+  try {
+    const proc = Bun.spawn(["bun", "install"], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return Result.err(
+        InternalError.create("bun install failed", {
+          cwd,
+          exitCode,
+          stderr: stderr.trim(),
+        })
+      );
+    }
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to run bun install", { cwd })
+    );
+  }
+
+  return Result.ok(undefined);
+}


### PR DESCRIPTION
## Summary

- Adds workspace-aware scanning for `outfitter update` in monorepos
- Detects workspace roots, collects all `package.json` files, deduplicates dependencies
- `--apply` updates all manifests in one pass with single `bun install` at workspace root
- 19 tests covering detection, collection, deduplication, and integration

Closes OS-113

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)