### PR TITLE
feat(outfitter): add --breaking flag for outfitter update

### DIFF
--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -585,6 +585,7 @@ interface UpdateActionInput {
   cwd: string;
   guide: boolean;
   apply: boolean;
+  breaking: boolean;
   outputMode?: OutputMode;
 }
 
@@ -592,6 +593,7 @@ const updateInputSchema = z.object({
   cwd: z.string(),
   guide: z.boolean(),
   apply: z.boolean(),
+  breaking: z.boolean(),
   outputMode: outputModeSchema,
 }) as z.ZodType<UpdateActionInput>;
 
@@ -617,6 +619,11 @@ const updateAction = defineAction({
         defaultValue: false,
       },
       {
+        flags: "--breaking",
+        description: "Include breaking updates when used with --apply",
+        defaultValue: false,
+      },
+      {
         flags: "--cwd <path>",
         description: "Working directory (defaults to current directory)",
       },
@@ -631,6 +638,7 @@ const updateAction = defineAction({
         cwd,
         guide: Boolean(context.flags["guide"]),
         apply: Boolean(context.flags["apply"]),
+        breaking: Boolean(context.flags["breaking"]),
         ...(outputMode ? { outputMode } : {}),
       };
     },
@@ -653,6 +661,7 @@ const updateAction = defineAction({
       guide: updateInput.guide,
       cwd: updateInput.cwd,
       applied: updateInput.apply ? result.value.applied : undefined,
+      breaking: updateInput.breaking,
     });
 
     return Result.ok(result.value);


### PR DESCRIPTION
## Summary

- Adds `--breaking` flag that includes breaking updates when combined with `--apply`
- `--breaking` alone is a no-op (must pair with `--apply`)
- Breaking applied packages are rendered distinctly with version transition info
- 7 new tests for breaking behavior (apply+breaking, apply-only, breaking-only)

Closes OS-114

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)