### PR TITLE
fix(tooling): replace hardcoded version strings with dynamic resolution

### DIFF
--- a/packages/tooling/src/__tests__/version.test.ts
+++ b/packages/tooling/src/__tests__/version.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { VERSION } from "../version.js";
+
+const PACKAGE_ROOT = join(import.meta.dir, "../..");
+
+describe("VERSION", () => {
+	test("matches package.json version", () => {
+		const packageJson = JSON.parse(
+			readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"),
+		) as { version: string };
+
+		expect(VERSION).toBe(packageJson.version);
+	});
+
+	test("is a non-empty string", () => {
+		expect(typeof VERSION).toBe("string");
+		expect(VERSION.length).toBeGreaterThan(0);
+	});
+
+	test("is a valid semver-like string", () => {
+		expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	test("is not the fallback version", () => {
+		// The actual package always has a real version set
+		expect(VERSION).not.toBe("0.0.0");
+	});
+});

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { Command } from "commander";
+import { VERSION } from "../version.js";
 import { runCheck } from "./check.js";
 import { runFix } from "./fix.js";
 import { runInit } from "./init.js";
@@ -19,7 +20,7 @@ const program = new Command();
 program
 	.name("tooling")
 	.description("Dev tooling configuration management for Outfitter projects")
-	.version("0.1.0-rc.1");
+	.version(VERSION);
 
 program
 	.command("init")

--- a/packages/tooling/src/index.ts
+++ b/packages/tooling/src/index.ts
@@ -30,9 +30,6 @@
  * @packageDocumentation
  */
 
-/** Package version */
-export const VERSION = "0.1.0-rc.1";
-
 // Re-export registry types for convenience
 export type {
 	AddBlockOptions,
@@ -43,9 +40,10 @@ export type {
 	Registry,
 	RegistryBuildConfig,
 } from "./registry/index.js";
-
 export {
 	BlockSchema,
 	FileEntrySchema,
 	RegistrySchema,
 } from "./registry/index.js";
+/** Package version, read dynamically from package.json. */
+export { VERSION } from "./version.js";

--- a/packages/tooling/src/version.ts
+++ b/packages/tooling/src/version.ts
@@ -1,0 +1,48 @@
+/**
+ * @outfitter/tooling - Version
+ *
+ * Reads the package version from package.json at runtime to avoid
+ * hardcoded version strings drifting out of sync.
+ *
+ * Uses `createRequire` to resolve the package's own `package.json` export,
+ * which works regardless of where bundler code splitting places the chunk.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+/** Fallback version when package.json cannot be read. */
+const DEFAULT_VERSION = "0.0.0";
+
+/**
+ * Reads the package version from package.json.
+ *
+ * Resolves the package's own `./package.json` export via `createRequire`,
+ * which works correctly in both source (`src/`) and built output (`dist/`)
+ * regardless of code-splitting chunk depth.
+ */
+function readPackageVersion(): string {
+	try {
+		const require = createRequire(import.meta.url);
+		const pkgPath = require.resolve("@outfitter/tooling/package.json");
+		const packageJson = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+			version?: unknown;
+		};
+
+		if (
+			typeof packageJson.version === "string" &&
+			packageJson.version.length > 0
+		) {
+			return packageJson.version;
+		}
+	} catch {
+		// Fall through to default.
+	}
+
+	return DEFAULT_VERSION;
+}
+
+/** Package version, read from package.json at load time. */
+export const VERSION: string = readPackageVersion();


### PR DESCRIPTION
## Summary

- Creates `version.ts` that reads package version from `package.json` at runtime via `createRequire`
- Replaces stale hardcoded `"0.1.0-rc.1"` in CLI and index exports (actual version is `0.2.2`)
- Uses `createRequire` to handle bunup code splitting placing chunks at arbitrary depths
- Cleans up scaffolding template settings (removes baked-in plugin references)
- 4 new tests ensuring VERSION stays in sync with package.json

Closes OS-73

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)