### PR TITLE
fix(fieldguides): use double backticks for bang references in SKILL.md files

### DIFF
--- a/.claude/rules/agents/skills.md
+++ b/.claude/rules/agents/skills.md
@@ -143,13 +143,13 @@ Claude Code's preprocessor executes `` !`command` `` syntax in SKILL.md files â€
 
 ### The `<bang>` convention
 
-Use `<bang>` as a stand-in for `!` when referencing the preprocessing syntax in `SKILL.md` files as examples. Agents should interpret `<bang>` as `!` in context.
+Use `` <bang> `` as a stand-in for ``!`` when referencing the preprocessing syntax in `SKILL.md` files as examples. Agents should interpret `` <bang> `` as ``!`` in context.
 
 | File type | Preprocessing | Convention |
 |-----------|--------------|------------|
 | SKILL.md | Active (always) | Use `` !`command` `` |
-| References, EXAMPLES.md | None | Literal `!` encouraged (good demos) |
-| Command files (`commands/*.md`) | Intentional | Literal `!` required |
+| References, EXAMPLES.md | None | Literal ``!`` encouraged (good demos) |
+| Command files (`commands/*.md`) | Intentional | Literal ``!`` required |
 
 ### `metadata.preprocess: true`
 

--- a/plugins/fieldguides/skills/claude-craft/SKILL.md
+++ b/plugins/fieldguides/skills/claude-craft/SKILL.md
@@ -174,7 +174,7 @@ See [commands/frontmatter.md](references/commands/frontmatter.md) for complete s
 
 ### Core Features
 
-<!-- <bang> represents ! — literal !`command` in SKILL.md triggers preprocessing -->
+<!-- <bang> = exclamation mark; used as stand-in to avoid triggering preprocessing -->
 
 | Feature | Syntax | Purpose |
 |---------|--------|---------|
@@ -472,7 +472,7 @@ See [skills/context-modes.md](references/skills/context-modes.md) for patterns.
 
 ## Preprocessing
 
-<!-- <bang> represents ! — literal !`command` in SKILL.md triggers preprocessing -->
+<!-- <bang> = exclamation mark; used as stand-in to avoid triggering preprocessing -->
 
 Claude Code preprocesses `` <bang>`command` `` syntax — executing shell commands and injecting output before content reaches Claude. This powers live context in commands (git state, PR details, environment info).
 
@@ -480,35 +480,35 @@ Claude Code preprocesses `` <bang>`command` `` syntax — executing shell comman
 
 ### Where preprocessing runs
 
-| Context | Preprocessed | Safe to use literal `!`? |
+| Context | Preprocessed | Safe to use literal ``!``? |
 |---------|-------------|--------------------------|
 | Command files (`commands/*.md`) | Yes | Yes — intentional |
-| SKILL.md | Yes | No — use `<bang>` instead |
+| SKILL.md | Yes | No — use `` <bang> `` instead |
 | References, EXAMPLES.md | No | Yes — great for copy-paste demos |
 | Rules, CLAUDE.md, agents | No | Yes |
 
 ### Writing SKILL.md files
 
-When documenting or referencing the preprocessing syntax in a SKILL.md, use `<bang>` as a stand-in for `!`. Agents interpret `<bang>` as `!`.
+When documenting or referencing the preprocessing syntax in a SKILL.md, use `` <bang> `` as a stand-in for ``!``. Agents interpret `` <bang> `` as ``!``.
 
 Add an HTML comment explaining the convention:
 
 ```html
-<!-- <bang> represents ! — literal !`command` in SKILL.md triggers preprocessing -->
+<!-- <bang> = exclamation mark; used as stand-in to avoid triggering preprocessing -->
 ```
 
-Then use `<bang>` for any inline references:
+Then use `` <bang> `` for any inline references:
 
 - `` <bang>`git status` `` — injects current git status
 - `` <bang>`gh pr view --json title` `` — injects PR details
 
-Move real copy-paste examples with literal `!` to reference files — those are not preprocessed.
+Move real copy-paste examples with literal ``!`` to reference files — those are not preprocessed.
 
 ### Writing reference files
 
-Reference files (`references/`, `EXAMPLES.md`) are not preprocessed. Use literal `!` freely — these serve as copy-paste sources for command authors:
+Reference files (`references/`, `EXAMPLES.md`) are not preprocessed. Use literal ``!`` freely — these serve as copy-paste sources for command authors:
 
-See [commands/bash-execution.md](references/commands/bash-execution.md) for the full reference with real `!` syntax.
+See [commands/bash-execution.md](references/commands/bash-execution.md) for the full reference with real ``!`` syntax.
 
 ### Intentional preprocessing in skills
 

--- a/plugins/fieldguides/skills/skillcheck/SKILL.md
+++ b/plugins/fieldguides/skills/skillcheck/SKILL.md
@@ -34,16 +34,16 @@ The linter reports:
 
 | Finding | Fix |
 |---------|-----|
-| Unintentional `` <bang>`command` `` in SKILL.md | Replace `!` with `<bang>` |
+| Unintentional `` <bang>`command` `` in SKILL.md | Replace ``!`` with `` <bang> `` |
 | Intentional preprocessing | Add `metadata.preprocess: true` to frontmatter |
 
 ### The `<bang>` Convention
 
 SKILL.md files are preprocessed by Claude Code — any `` <bang>`command` `` syntax executes when the skill loads. To safely document or reference the syntax:
 
-- In SKILL.md: use `<bang>` as a stand-in for `!`
-- In reference files (references/, EXAMPLES.md): literal `!` is fine and encouraged
-- In command files (commands/*.md): literal `!` is required (that's the feature)
+- In SKILL.md: use `` <bang> `` as a stand-in for ``!``
+- In reference files (references/, EXAMPLES.md): literal ``!`` is fine and encouraged
+- In command files (commands/*.md): literal ``!`` is required (that's the feature)
 
 Skills that intentionally preprocess (running scripts at load time) should declare it:
 

--- a/plugins/fieldguides/skills/skillcraft/SKILL.md
+++ b/plugins/fieldguides/skills/skillcraft/SKILL.md
@@ -148,7 +148,7 @@ description: "Extracts text and tables from PDF files, fills forms, merges docum
 - [ ] All referenced files exist
 - [ ] No TODO/placeholder markers
 - [ ] Progressive disclosure (details in `references/`)
-- [ ] No `` <bang>`command` `` preprocessing patterns (use `<bang>` instead of `!`)
+- [ ] No `` <bang>`command` `` preprocessing patterns (use `` <bang> `` instead of literal ``!``)
 
 ### Report Format
 
@@ -189,7 +189,7 @@ Keep SKILL.md under 500 lines. Move details to:
 
 ### Preprocessing safety
 
-SKILL.md files are preprocessed by Claude Code — `` <bang>`command` `` syntax executes at load time, even inside code fences. When documenting this syntax in SKILL.md, use `<bang>` as a stand-in for `!`. Reference files and EXAMPLES.md are not preprocessed, so literal `!` is safe there.
+SKILL.md files are preprocessed by Claude Code — `` <bang>`command` `` syntax executes at load time, even inside code fences. When documenting this syntax in SKILL.md, use `` <bang> `` as a stand-in for ``!``. Reference files and EXAMPLES.md are not preprocessed, so literal ``!`` is safe there.
 
 Skills that intentionally preprocess should declare `metadata.preprocess: true`. Run `/skillcheck` to lint for unintentional preprocessing patterns.
 

--- a/plugins/fieldguides/skills/typescript-fieldguide/SKILL.md
+++ b/plugins/fieldguides/skills/typescript-fieldguide/SKILL.md
@@ -413,7 +413,7 @@ NEVER:
 - `any` (use `unknown` + guards)
 - `@ts-ignore` (fix types or document)
 - TypeScript enums (use const assertions or z.enum)
-- Non-null assertions `!` (use guards)
+- Non-null assertions ``!`` (use guards)
 - Loose state (use discriminated unions)
 - Hidden errors (use Result)
 


### PR DESCRIPTION
## Summary

- Replace all single-backtick `` `!` `` with double-backtick `` ``!`` `` across SKILL.md files and guidance docs to prevent Claude Code's preprocessor from triggering shell execution on load
- Update the preprocessing linter to detect the `` `!` `` pattern (backtick-bang-backtick adjacency) that the previous regex missed
- Remove HTML comment skip from linter — preprocessor operates on raw text, so HTML comments are not safe either
- Fix 3 HTML comments in claude-craft that contained literal `` !`command` ``

## Context

Claude Code's preprocessor scans SKILL.md files for `!` immediately followed by a backtick and interprets it as a shell command to execute. The pattern `` `!` `` (single backticks around `!`) is dangerous because the closing backtick creates `!`+backtick adjacency. Double backticks `` ``!`` `` are safe.

## Files changed

| File | Changes |
|------|---------|
| `skillcheck/SKILL.md` | 4 instances fixed |
| `claude-craft/SKILL.md` | 5 inline + 3 HTML comments fixed |
| `skillcraft/SKILL.md` | 2 instances fixed |
| `typescript-fieldguide/SKILL.md` | 1 instance fixed |
| `.claude/rules/agents/skills.md` | 3 instances fixed (consistency) |
| `skillcheck/scripts/lint-preprocessing.ts` | Added `!` detection, removed HTML comment skip |

## Test plan

- [x] Updated linter catches all known dangerous patterns
- [x] Linter passes clean on all 49 SKILL.md files
- [x] Double-backtick `!` patterns correctly excluded via regex lookaround
- [x] Full verify:ci passes (typecheck, lint, build, test)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)