### PR TITLE
feat(contracts): add ValidationError.fromMessage() for freeform validation errors

### DIFF
--- a/packages/contracts/src/__tests__/errors.test.ts
+++ b/packages/contracts/src/__tests__/errors.test.ts
@@ -671,6 +671,32 @@ describe("static create() methods", () => {
     expect(error.context).toEqual({ min: 0, max: 150 });
   });
 
+  it("ValidationError.fromMessage() creates freeform error without field", () => {
+    const error = ValidationError.fromMessage("Invalid pipeline configuration");
+    expect(error._tag).toBe("ValidationError");
+    expect(error.category).toBe("validation");
+    expect(error.message).toBe("Invalid pipeline configuration");
+    expect(error.field).toBeUndefined();
+  });
+
+  it("ValidationError.fromMessage() preserves context", () => {
+    const error = ValidationError.fromMessage("Config invalid", {
+      path: "/etc/app.toml",
+    });
+    expect(error.context).toEqual({ path: "/etc/app.toml" });
+  });
+
+  it("ValidationError.fromMessage() has correct exit and status codes", () => {
+    const error = ValidationError.fromMessage("Bad input");
+    expect(error.exitCode()).toBe(1);
+    expect(error.statusCode()).toBe(400);
+  });
+
+  it("ValidationError.fromMessage() omits context when not provided", () => {
+    const error = ValidationError.fromMessage("Bad input");
+    expect(error.context).toBeUndefined();
+  });
+
   it("NotFoundError.create() generates message from type and id", () => {
     const error = NotFoundError.create("PR", "outfitter#123");
     expect(error.message).toBe("PR not found: outfitter#123");

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -345,6 +345,25 @@ export class ValidationError extends ValidationErrorBase {
     });
   }
 
+  /**
+   * Create a freeform ValidationError without a specific field.
+   *
+   * Use when the validation failure applies to the input as a whole
+   * rather than a single field (e.g., "Invalid pipeline configuration").
+   *
+   * @param message - Human-readable validation error message
+   * @param context - Optional structured context for debugging
+   */
+  static fromMessage(
+    message: string,
+    context?: Record<string, unknown>
+  ): ValidationError {
+    return new ValidationError({
+      message,
+      ...(context != null && { context }),
+    });
+  }
+
   exitCode(): number {
     return getExitCode(this.category);
   }


### PR DESCRIPTION
## Summary

Adds `ValidationError.fromMessage(message, context?)` static factory for freeform validation errors that don't decompose into field/reason pairs (e.g., "Invalid pipeline configuration").

- New static method on `ValidationError` — no `field` property set (freeform path)
- `create(field, reason)` unchanged for backward compat
- Tests for correct `_tag`, `category`, `message`, undefined `field`, `exitCode()`/`statusCode()`, and context preservation

## Test plan

- [x] `bun test --filter=@outfitter/contracts` — all 319 tests pass
- [x] `bun run typecheck` — clean

Closes: OS-142