### PR TITLE
feat(logging): make LoggerInstance explicitly extend Logger from contracts

### DIFF
--- a/packages/logging/src/__tests__/logging.test.ts
+++ b/packages/logging/src/__tests__/logging.test.ts
@@ -15,6 +15,7 @@
  * Total: 40 tests
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Logger } from "@outfitter/contracts";
 import {
   configureRedaction,
   createChildLogger,
@@ -110,6 +111,13 @@ describe("Logger Creation", () => {
 
     expect(records.length).toBe(1);
     expect(records[0].message).toBe("hello");
+  });
+
+  it("LoggerInstance satisfies contracts Logger interface", () => {
+    // Compile-time test: LoggerInstance extends Logger from contracts
+    const logger: Logger = createLogger({ name: "test" });
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.child).toBe("function");
   });
 });
 

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -19,6 +19,7 @@ import {
   getEnvironmentDefaults as _getEnvironmentDefaults,
 } from "@outfitter/config";
 import {
+  type Logger as ContractLogger,
   type LoggerAdapter as ContractLoggerAdapter,
   type LoggerFactory as ContractLoggerFactory,
   type LoggerFactoryConfig as ContractLoggerFactoryConfig,
@@ -287,7 +288,7 @@ export interface OutfitterLoggerFactoryOptions {
  * logger.debug("Debug info", { details: "..." });
  * ```
  */
-export interface LoggerInstance {
+export interface LoggerInstance extends ContractLogger {
   /**
    * Log at trace level (most verbose, for detailed debugging).
    * @param message - Human-readable log message


### PR DESCRIPTION
## Summary

Changes `LoggerInstance` to explicitly `extends Logger` from `@outfitter/contracts`, providing compile-time guarantees against version skew between the two packages.

- `child()` return type stays `LoggerInstance` (covariant with `Logger`)
- `getContext()`, `setLevel()`, `addSink()` remain as extensions
- Compile-time test: `const logger: Logger = createLogger(...)` verifies compatibility

## Test plan

- [x] `bun test --filter=@outfitter/logging` — all tests pass
- [x] `bun run typecheck` — clean (compile-time verification)

Closes: OS-128