### PR TITLE
fix(cli): bridge --json to OUTFITTER_JSON without env leakage

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -395,6 +395,21 @@ const isVerbose = resolveVerbose();
 const isVerbose = resolveVerbose(cliFlags.verbose);
 ```
 
+### JSON Output
+
+`createCLI()` registers a global `--json` flag that bridges to `OUTFITTER_JSON=1` via a `preAction` hook. This means `output()` auto-detects JSON mode — no manual `if (json)` branching needed:
+
+```typescript
+// No need for this:
+if (opts.json) output(data, { mode: "json" });
+else output(data);
+
+// Just use output() directly — it reads OUTFITTER_JSON:
+output(data);
+```
+
+The bridge uses `optsWithGlobals()` so global and subcommand `--json` flags both work and coalesce into a single env var. Subcommands should **not** define their own `--json` — use the global flag. If they do, both coalesce safely.
+
 ### Output Mode Priority
 
 1. Explicit `mode` option in `output()` call


### PR DESCRIPTION
## Summary

Fixes silent `--json` flag shadowing between global and subcommand levels by bridging all `--json` usage into `OUTFITTER_JSON` in `createCLI()`. Also fixes process-wide env leakage by restoring the previous env value after each parse lifecycle.

- Global `--json` and subcommand `--json` coalesce into the same env bridge
- `optsWithGlobals()` prevents local/global flag shadowing
- Bridge now restores prior env state after parse (`postAction` + `finally` fallback)
- Prevents JSON mode from persisting across repeated programmatic `cli.parse()` calls

## Test plan

- [x] Global `--json` sets env var for the current action
- [x] No-flag parse keeps env unset
- [x] Existing env value is restored after parse
- [x] `--json` does not leak into subsequent parse calls
- [x] `cd packages/cli && bun test src/__tests__/core.test.ts`

Closes: OS-136, OS-138, OS-144
