### PR TITLE
feat(mcp): export wrapToolResult and wrapToolError from transport

### DIFF
--- a/packages/mcp/src/__tests__/wrap-helpers.test.ts
+++ b/packages/mcp/src/__tests__/wrap-helpers.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for wrapToolResult and wrapToolError exports.
+ */
+import { describe, expect, it } from "bun:test";
+import { wrapToolError, wrapToolResult } from "../index.js";
+
+describe("wrapToolResult()", () => {
+  it("wraps a plain string into a text content block", () => {
+    const result = wrapToolResult("hello");
+    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("wraps a plain object with structuredContent", () => {
+    const data = { id: "123", name: "test" };
+    const result = wrapToolResult(data);
+    expect(result.content[0]?.type).toBe("text");
+    expect(result.structuredContent).toEqual(data);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("passes through an existing McpToolResponse unchanged", () => {
+    const existing = {
+      content: [{ type: "text" as const, text: "already wrapped" }],
+    };
+    const result = wrapToolResult(existing);
+    expect(result).toBe(existing);
+  });
+
+  it("wraps an array as JSON text without structuredContent", () => {
+    const result = wrapToolResult([1, 2, 3]);
+    expect(result.content[0]?.type).toBe("text");
+    expect(result.structuredContent).toBeUndefined();
+  });
+});
+
+describe("wrapToolError()", () => {
+  it("wraps an Error into an isError response", () => {
+    const error = new Error("something broke");
+    const result = wrapToolError(error);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.type).toBe("text");
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.message).toBe("something broke");
+  });
+
+  it("wraps a tagged error preserving _tag", () => {
+    const error = { _tag: "NotFoundError", message: "not found", code: 2001 };
+    const result = wrapToolError(error);
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed._tag).toBe("NotFoundError");
+    expect(parsed.message).toBe("not found");
+  });
+
+  it("wraps a string error", () => {
+    const result = wrapToolError("string error");
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed._tag).toBe("McpError");
+    expect(parsed.message).toBe("string error");
+  });
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -77,6 +77,8 @@ export {
   connectStdio,
   createSdkServer,
   type McpToolResponse,
+  wrapToolError,
+  wrapToolResult,
 } from "./transport.js";
 // Types
 export {

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -70,7 +70,15 @@ function serializeError(error: unknown): Record<string, unknown> {
   };
 }
 
-function wrapToolResult(value: unknown): McpToolResponse {
+/**
+ * Wrap a handler success value into an MCP CallToolResult.
+ *
+ * If the value is already a valid McpToolResponse (has a `content` array),
+ * it is returned as-is. Otherwise it is wrapped in a text content block.
+ * Plain objects are also attached as `structuredContent` for SDK clients
+ * that support structured output.
+ */
+export function wrapToolResult(value: unknown): McpToolResponse {
   if (isMcpToolResponse(value)) {
     return value;
   }
@@ -91,7 +99,13 @@ function wrapToolResult(value: unknown): McpToolResponse {
   };
 }
 
-function wrapToolError(error: unknown): McpToolResponse {
+/**
+ * Wrap an error into an MCP CallToolResult with `isError: true`.
+ *
+ * Serializes the error (preserving `_tag`, `message`, `code`, `context` if
+ * present) and wraps it as a text content block.
+ */
+export function wrapToolError(error: unknown): McpToolResponse {
   return {
     content: [
       {


### PR DESCRIPTION
## Summary

Exports `wrapToolResult()` and `wrapToolError()` from `@outfitter/mcp` — internal transport helpers that previously required ~40 lines of reverse-engineering to replicate.

- Adds `export` keyword to existing functions in `transport.ts`
- Adds JSDoc documentation
- Re-exports from package barrel (`index.ts`)
- Unit tests for both functions (wraps plain values, passes through McpToolResponse, wraps errors with isError)

## Test plan

- [x] `bun test --filter=@outfitter/mcp` — all tests pass
- [x] `bun run typecheck` — clean

Closes: OS-145