### PR TITLE
fix(build): normalize package.json export key order to prevent stacked branch conflicts

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -10,34 +10,46 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./actions": {
+      "import": {
+        "types": "./dist/actions.d.ts",
+        "default": "./dist/actions.js"
+      }
+    },
+    "./commands/add": {
+      "import": {
+        "types": "./dist/commands/add.d.ts",
+        "default": "./dist/commands/add.js"
+      }
+    },
     "./commands/check": {
       "import": {
         "types": "./dist/commands/check.d.ts",
         "default": "./dist/commands/check.js"
       }
     },
-    "./commands/update-workspace": {
+    "./commands/create": {
       "import": {
-        "types": "./dist/commands/update-workspace.d.ts",
-        "default": "./dist/commands/update-workspace.js"
-      }
-    },
-    "./commands/update": {
-      "import": {
-        "types": "./dist/commands/update.d.ts",
-        "default": "./dist/commands/update.js"
-      }
-    },
-    "./commands/demo/errors": {
-      "import": {
-        "types": "./dist/commands/demo/errors.d.ts",
-        "default": "./dist/commands/demo/errors.js"
+        "types": "./dist/commands/create.d.ts",
+        "default": "./dist/commands/create.js"
       }
     },
     "./commands/demo": {
       "import": {
         "types": "./dist/commands/demo.d.ts",
         "default": "./dist/commands/demo.js"
+      }
+    },
+    "./commands/demo/errors": {
+      "import": {
+        "types": "./dist/commands/demo/errors.d.ts",
+        "default": "./dist/commands/demo/errors.js"
       }
     },
     "./commands/doctor": {
@@ -52,22 +64,22 @@
         "default": "./dist/commands/init.js"
       }
     },
-    "./commands/shared-deps": {
-      "import": {
-        "types": "./dist/commands/shared-deps.d.ts",
-        "default": "./dist/commands/shared-deps.js"
-      }
-    },
     "./commands/migrate-kit": {
       "import": {
         "types": "./dist/commands/migrate-kit.d.ts",
         "default": "./dist/commands/migrate-kit.js"
       }
     },
-    "./commands/create": {
+    "./commands/shared-deps": {
       "import": {
-        "types": "./dist/commands/create.d.ts",
-        "default": "./dist/commands/create.js"
+        "types": "./dist/commands/shared-deps.d.ts",
+        "default": "./dist/commands/shared-deps.js"
+      }
+    },
+    "./commands/update": {
+      "import": {
+        "types": "./dist/commands/update.d.ts",
+        "default": "./dist/commands/update.js"
       }
     },
     "./commands/update-planner": {
@@ -76,40 +88,10 @@
         "default": "./dist/commands/update-planner.js"
       }
     },
-    "./commands/add": {
+    "./commands/update-workspace": {
       "import": {
-        "types": "./dist/commands/add.d.ts",
-        "default": "./dist/commands/add.js"
-      }
-    },
-    "./actions": {
-      "import": {
-        "types": "./dist/actions.d.ts",
-        "default": "./dist/actions.js"
-      }
-    },
-    "./manifest": {
-      "import": {
-        "types": "./dist/manifest.d.ts",
-        "default": "./dist/manifest.js"
-      }
-    },
-    ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "./create/types": {
-      "import": {
-        "types": "./dist/create/types.d.ts",
-        "default": "./dist/create/types.js"
-      }
-    },
-    "./create/presets": {
-      "import": {
-        "types": "./dist/create/presets.d.ts",
-        "default": "./dist/create/presets.js"
+        "types": "./dist/commands/update-workspace.d.ts",
+        "default": "./dist/commands/update-workspace.js"
       }
     },
     "./create": {
@@ -122,6 +104,24 @@
       "import": {
         "types": "./dist/create/planner.d.ts",
         "default": "./dist/create/planner.js"
+      }
+    },
+    "./create/presets": {
+      "import": {
+        "types": "./dist/create/presets.d.ts",
+        "default": "./dist/create/presets.js"
+      }
+    },
+    "./create/types": {
+      "import": {
+        "types": "./dist/create/types.d.ts",
+        "default": "./dist/create/types.js"
+      }
+    },
+    "./manifest": {
+      "import": {
+        "types": "./dist/manifest.d.ts",
+        "default": "./dist/manifest.js"
       }
     },
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
     "verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
-    "build": "bunup",
-    "build:local": "bunup && cd apps/outfitter && bun link",
+    "build": "bunup && bun scripts/normalize-exports.ts",
+    "build:local": "bunup && bun scripts/normalize-exports.ts && cd apps/outfitter && bun link",
     "build:turbo": "turbo run build",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -11,28 +11,28 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./init": {
-      "import": {
-        "types": "./dist/init.d.ts",
-        "default": "./dist/init.js"
-      }
-    },
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
     },
-    "./merge": {
-      "import": {
-        "types": "./dist/merge.d.ts",
-        "default": "./dist/merge.js"
-      }
-    },
     "./bootstrap": {
       "import": {
         "types": "./dist/bootstrap.d.ts",
         "default": "./dist/bootstrap.js"
+      }
+    },
+    "./init": {
+      "import": {
+        "types": "./dist/init.d.ts",
+        "default": "./dist/init.js"
+      }
+    },
+    "./merge": {
+      "import": {
+        "types": "./dist/merge.d.ts",
+        "default": "./dist/merge.js"
       }
     },
     "./package.json": "./package.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,10 +9,40 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./output": {
+    ".": {
       "import": {
-        "types": "./dist/output.d.ts",
-        "default": "./dist/output.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./actions": {
+      "import": {
+        "types": "./dist/actions.d.ts",
+        "default": "./dist/actions.js"
+      }
+    },
+    "./borders": {
+      "import": {
+        "types": "./dist/borders/index.d.ts",
+        "default": "./dist/borders/index.js"
+      }
+    },
+    "./box": {
+      "import": {
+        "types": "./dist/box/index.d.ts",
+        "default": "./dist/box/index.js"
+      }
+    },
+    "./colors": {
+      "import": {
+        "types": "./dist/colors/index.d.ts",
+        "default": "./dist/colors/index.js"
+      }
+    },
+    "./command": {
+      "import": {
+        "types": "./dist/command.d.ts",
+        "default": "./dist/command.js"
       }
     },
     "./demo": {
@@ -21,10 +51,35 @@
         "default": "./dist/demo/index.js"
       }
     },
-    "./borders": {
+    "./demo/section": {
       "import": {
-        "types": "./dist/borders/index.d.ts",
-        "default": "./dist/borders/index.js"
+        "types": "./dist/demo/section.d.ts",
+        "default": "./dist/demo/section.js"
+      }
+    },
+    "./input": {
+      "import": {
+        "types": "./dist/input.d.ts",
+        "default": "./dist/input.js"
+      }
+    },
+    "./list": {
+      "import": {
+        "types": "./dist/list/index.d.ts",
+        "default": "./dist/list/index.js"
+      }
+    },
+    "./output": {
+      "import": {
+        "types": "./dist/output.d.ts",
+        "default": "./dist/output.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./pagination": {
+      "import": {
+        "types": "./dist/pagination.d.ts",
+        "default": "./dist/pagination.js"
       }
     },
     "./preset/full": {
@@ -39,40 +94,28 @@
         "default": "./dist/preset/standard.js"
       }
     },
-    "./box": {
+    "./prompt": {
       "import": {
-        "types": "./dist/box/index.d.ts",
-        "default": "./dist/box/index.js"
+        "types": "./dist/prompt/index.d.ts",
+        "default": "./dist/prompt/index.js"
       }
     },
-    "./tree": {
+    "./prompt/confirm": {
       "import": {
-        "types": "./dist/tree/index.d.ts",
-        "default": "./dist/tree/index.js"
+        "types": "./dist/prompt/confirm.d.ts",
+        "default": "./dist/prompt/confirm.js"
       }
     },
-    "./demo/section": {
+    "./prompt/group": {
       "import": {
-        "types": "./dist/demo/section.d.ts",
-        "default": "./dist/demo/section.js"
+        "types": "./dist/prompt/group.d.ts",
+        "default": "./dist/prompt/group.js"
       }
     },
-    "./render": {
+    "./prompt/select": {
       "import": {
-        "types": "./dist/render/index.d.ts",
-        "default": "./dist/render/index.js"
-      }
-    },
-    "./terminal": {
-      "import": {
-        "types": "./dist/terminal/index.d.ts",
-        "default": "./dist/terminal/index.js"
-      }
-    },
-    "./terminal/detection": {
-      "import": {
-        "types": "./dist/terminal/detection.d.ts",
-        "default": "./dist/terminal/detection.js"
+        "types": "./dist/prompt/select.d.ts",
+        "default": "./dist/prompt/select.js"
       }
     },
     "./prompt/text": {
@@ -93,28 +136,10 @@
         "default": "./dist/prompt/validators.js"
       }
     },
-    "./prompt": {
+    "./render": {
       "import": {
-        "types": "./dist/prompt/index.d.ts",
-        "default": "./dist/prompt/index.js"
-      }
-    },
-    "./streaming/spinner": {
-      "import": {
-        "types": "./dist/streaming/spinner.d.ts",
-        "default": "./dist/streaming/spinner.js"
-      }
-    },
-    "./streaming/ansi": {
-      "import": {
-        "types": "./dist/streaming/ansi.d.ts",
-        "default": "./dist/streaming/ansi.js"
-      }
-    },
-    "./streaming/writer": {
-      "import": {
-        "types": "./dist/streaming/writer.d.ts",
-        "default": "./dist/streaming/writer.js"
+        "types": "./dist/render/index.d.ts",
+        "default": "./dist/render/index.js"
       }
     },
     "./streaming": {
@@ -123,64 +148,22 @@
         "default": "./dist/streaming/index.js"
       }
     },
-    "./theme/presets/rounded": {
+    "./streaming/ansi": {
       "import": {
-        "types": "./dist/theme/presets/rounded.d.ts",
-        "default": "./dist/theme/presets/rounded.js"
+        "types": "./dist/streaming/ansi.d.ts",
+        "default": "./dist/streaming/ansi.js"
       }
     },
-    "./theme/presets/bold": {
+    "./streaming/spinner": {
       "import": {
-        "types": "./dist/theme/presets/bold.d.ts",
-        "default": "./dist/theme/presets/bold.js"
+        "types": "./dist/streaming/spinner.d.ts",
+        "default": "./dist/streaming/spinner.js"
       }
     },
-    "./theme/presets/minimal": {
+    "./streaming/writer": {
       "import": {
-        "types": "./dist/theme/presets/minimal.d.ts",
-        "default": "./dist/theme/presets/minimal.js"
-      }
-    },
-    "./theme/presets/default": {
-      "import": {
-        "types": "./dist/theme/presets/default.d.ts",
-        "default": "./dist/theme/presets/default.js"
-      }
-    },
-    "./theme/presets": {
-      "import": {
-        "types": "./dist/theme/presets/index.d.ts",
-        "default": "./dist/theme/presets/index.js"
-      }
-    },
-    "./prompt/confirm": {
-      "import": {
-        "types": "./dist/prompt/confirm.d.ts",
-        "default": "./dist/prompt/confirm.js"
-      }
-    },
-    "./prompt/select": {
-      "import": {
-        "types": "./dist/prompt/select.d.ts",
-        "default": "./dist/prompt/select.js"
-      }
-    },
-    "./prompt/group": {
-      "import": {
-        "types": "./dist/prompt/group.d.ts",
-        "default": "./dist/prompt/group.js"
-      }
-    },
-    "./list": {
-      "import": {
-        "types": "./dist/list/index.d.ts",
-        "default": "./dist/list/index.js"
-      }
-    },
-    "./colors": {
-      "import": {
-        "types": "./dist/colors/index.d.ts",
-        "default": "./dist/colors/index.js"
+        "types": "./dist/streaming/writer.d.ts",
+        "default": "./dist/streaming/writer.js"
       }
     },
     "./table": {
@@ -189,16 +172,16 @@
         "default": "./dist/table/index.js"
       }
     },
-    "./theme/context": {
+    "./terminal": {
       "import": {
-        "types": "./dist/theme/context.d.ts",
-        "default": "./dist/theme/context.js"
+        "types": "./dist/terminal/index.d.ts",
+        "default": "./dist/terminal/index.js"
       }
     },
-    "./theme/types": {
+    "./terminal/detection": {
       "import": {
-        "types": "./dist/theme/types.d.ts",
-        "default": "./dist/theme/types.js"
+        "types": "./dist/terminal/detection.d.ts",
+        "default": "./dist/terminal/detection.js"
       }
     },
     "./theme": {
@@ -207,10 +190,46 @@
         "default": "./dist/theme/index.js"
       }
     },
+    "./theme/context": {
+      "import": {
+        "types": "./dist/theme/context.d.ts",
+        "default": "./dist/theme/context.js"
+      }
+    },
     "./theme/create": {
       "import": {
         "types": "./dist/theme/create.d.ts",
         "default": "./dist/theme/create.js"
+      }
+    },
+    "./theme/presets": {
+      "import": {
+        "types": "./dist/theme/presets/index.d.ts",
+        "default": "./dist/theme/presets/index.js"
+      }
+    },
+    "./theme/presets/bold": {
+      "import": {
+        "types": "./dist/theme/presets/bold.d.ts",
+        "default": "./dist/theme/presets/bold.js"
+      }
+    },
+    "./theme/presets/default": {
+      "import": {
+        "types": "./dist/theme/presets/default.d.ts",
+        "default": "./dist/theme/presets/default.js"
+      }
+    },
+    "./theme/presets/minimal": {
+      "import": {
+        "types": "./dist/theme/presets/minimal.d.ts",
+        "default": "./dist/theme/presets/minimal.js"
+      }
+    },
+    "./theme/presets/rounded": {
+      "import": {
+        "types": "./dist/theme/presets/rounded.d.ts",
+        "default": "./dist/theme/presets/rounded.js"
       }
     },
     "./theme/resolve": {
@@ -219,16 +238,16 @@
         "default": "./dist/theme/resolve.js"
       }
     },
-    "./pagination": {
+    "./theme/types": {
       "import": {
-        "types": "./dist/pagination.d.ts",
-        "default": "./dist/pagination.js"
+        "types": "./dist/theme/types.d.ts",
+        "default": "./dist/theme/types.js"
       }
     },
-    "./input": {
+    "./tree": {
       "import": {
-        "types": "./dist/input.d.ts",
-        "default": "./dist/input.js"
+        "types": "./dist/tree/index.d.ts",
+        "default": "./dist/tree/index.js"
       }
     },
     "./types": {
@@ -236,26 +255,7 @@
         "types": "./dist/types.d.ts",
         "default": "./dist/types.js"
       }
-    },
-    "./actions": {
-      "import": {
-        "types": "./dist/actions.d.ts",
-        "default": "./dist/actions.js"
-      }
-    },
-    ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "./command": {
-      "import": {
-        "types": "./dist/command.d.ts",
-        "default": "./dist/command.js"
-      }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,12 +9,6 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./environment": {
-      "import": {
-        "types": "./dist/environment.d.ts",
-        "default": "./dist/environment.js"
-      }
-    },
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
@@ -25,6 +19,12 @@
       "import": {
         "types": "./dist/env.d.ts",
         "default": "./dist/env.js"
+      }
+    },
+    "./environment": {
+      "import": {
+        "types": "./dist/environment.d.ts",
+        "default": "./dist/environment.js"
       }
     },
     "./package.json": "./package.json"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,16 +9,10 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./validation": {
+    ".": {
       "import": {
-        "types": "./dist/validation.d.ts",
-        "default": "./dist/validation.js"
-      }
-    },
-    "./result": {
-      "import": {
-        "types": "./dist/result/index.d.ts",
-        "default": "./dist/result/index.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     },
     "./actions": {
@@ -27,34 +21,10 @@
         "default": "./dist/actions.js"
       }
     },
-    "./redactor": {
+    "./adapters": {
       "import": {
-        "types": "./dist/redactor.d.ts",
-        "default": "./dist/redactor.js"
-      }
-    },
-    ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "./handler": {
-      "import": {
-        "types": "./dist/handler.d.ts",
-        "default": "./dist/handler.js"
-      }
-    },
-    "./recovery": {
-      "import": {
-        "types": "./dist/recovery.d.ts",
-        "default": "./dist/recovery.js"
-      }
-    },
-    "./logging": {
-      "import": {
-        "types": "./dist/logging.d.ts",
-        "default": "./dist/logging.js"
+        "types": "./dist/adapters.d.ts",
+        "default": "./dist/adapters.js"
       }
     },
     "./assert": {
@@ -63,40 +33,10 @@
         "default": "./dist/assert/index.js"
       }
     },
-    "./result/utilities": {
+    "./capabilities": {
       "import": {
-        "types": "./dist/result/utilities.d.ts",
-        "default": "./dist/result/utilities.js"
-      }
-    },
-    "./adapters": {
-      "import": {
-        "types": "./dist/adapters.d.ts",
-        "default": "./dist/adapters.js"
-      }
-    },
-    "./envelope": {
-      "import": {
-        "types": "./dist/envelope.d.ts",
-        "default": "./dist/envelope.js"
-      }
-    },
-    "./resilience": {
-      "import": {
-        "types": "./dist/resilience.d.ts",
-        "default": "./dist/resilience.js"
-      }
-    },
-    "./serialization": {
-      "import": {
-        "types": "./dist/serialization.d.ts",
-        "default": "./dist/serialization.js"
-      }
-    },
-    "./errors": {
-      "import": {
-        "types": "./dist/errors.d.ts",
-        "default": "./dist/errors.js"
+        "types": "./dist/capabilities.d.ts",
+        "default": "./dist/capabilities.js"
       }
     },
     "./context": {
@@ -105,13 +45,73 @@
         "default": "./dist/context.js"
       }
     },
-    "./capabilities": {
+    "./envelope": {
       "import": {
-        "types": "./dist/capabilities.d.ts",
-        "default": "./dist/capabilities.js"
+        "types": "./dist/envelope.d.ts",
+        "default": "./dist/envelope.js"
       }
     },
-    "./package.json": "./package.json"
+    "./errors": {
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      }
+    },
+    "./handler": {
+      "import": {
+        "types": "./dist/handler.d.ts",
+        "default": "./dist/handler.js"
+      }
+    },
+    "./logging": {
+      "import": {
+        "types": "./dist/logging.d.ts",
+        "default": "./dist/logging.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./recovery": {
+      "import": {
+        "types": "./dist/recovery.d.ts",
+        "default": "./dist/recovery.js"
+      }
+    },
+    "./redactor": {
+      "import": {
+        "types": "./dist/redactor.d.ts",
+        "default": "./dist/redactor.js"
+      }
+    },
+    "./resilience": {
+      "import": {
+        "types": "./dist/resilience.d.ts",
+        "default": "./dist/resilience.js"
+      }
+    },
+    "./result": {
+      "import": {
+        "types": "./dist/result/index.d.ts",
+        "default": "./dist/result/index.js"
+      }
+    },
+    "./result/utilities": {
+      "import": {
+        "types": "./dist/result/utilities.d.ts",
+        "default": "./dist/result/utilities.js"
+      }
+    },
+    "./serialization": {
+      "import": {
+        "types": "./dist/serialization.d.ts",
+        "default": "./dist/serialization.js"
+      }
+    },
+    "./validation": {
+      "import": {
+        "types": "./dist/validation.d.ts",
+        "default": "./dist/validation.js"
+      }
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -9,22 +9,10 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./migrations": {
-      "import": {
-        "types": "./dist/migrations.d.ts",
-        "default": "./dist/migrations.js"
-      }
-    },
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      }
-    },
-    "./types": {
-      "import": {
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
       }
     },
     "./fts5": {
@@ -33,13 +21,25 @@
         "default": "./dist/fts5.js"
       }
     },
+    "./migrations": {
+      "import": {
+        "types": "./dist/migrations.d.ts",
+        "default": "./dist/migrations.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./types": {
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      }
+    },
     "./version": {
       "import": {
         "types": "./dist/version.d.ts",
         "default": "./dist/version.js"
       }
-    },
-    "./package.json": "./package.json"
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -16,6 +16,12 @@
         "default": "./dist/index.js"
       }
     },
+    "./foundation": {
+      "import": {
+        "types": "./dist/foundation/index.d.ts",
+        "default": "./dist/foundation/index.js"
+      }
+    },
     "./foundation/contracts": {
       "import": {
         "types": "./dist/foundation/contracts.d.ts",
@@ -26,12 +32,6 @@
       "import": {
         "types": "./dist/foundation/types.d.ts",
         "default": "./dist/foundation/types.js"
-      }
-    },
-    "./foundation": {
-      "import": {
-        "types": "./dist/foundation/index.d.ts",
-        "default": "./dist/foundation/index.js"
       }
     },
     "./package.json": "./package.json"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,19 +15,19 @@
         "default": "./dist/index.js"
       }
     },
-    "./types": {
-      "import": {
-        "types": "./dist/types.d.ts",
-        "default": "./dist/types.js"
-      }
-    },
+    "./package.json": "./package.json",
     "./server": {
       "import": {
         "types": "./dist/server.d.ts",
         "default": "./dist/server.js"
       }
     },
-    "./package.json": "./package.json"
+    "./types": {
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      }
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,40 +9,10 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./deep": {
-      "import": {
-        "types": "./dist/deep.d.ts",
-        "default": "./dist/deep.js"
-      }
-    },
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
-      }
-    },
-    "./utilities": {
-      "import": {
-        "types": "./dist/utilities.d.ts",
-        "default": "./dist/utilities.js"
-      }
-    },
-    "./collections": {
-      "import": {
-        "types": "./dist/collections.d.ts",
-        "default": "./dist/collections.js"
-      }
-    },
-    "./short-id": {
-      "import": {
-        "types": "./dist/short-id.d.ts",
-        "default": "./dist/short-id.js"
-      }
-    },
-    "./hash-id": {
-      "import": {
-        "types": "./dist/hash-id.d.ts",
-        "default": "./dist/hash-id.js"
       }
     },
     "./branded": {
@@ -51,13 +21,43 @@
         "default": "./dist/branded.js"
       }
     },
+    "./collections": {
+      "import": {
+        "types": "./dist/collections.d.ts",
+        "default": "./dist/collections.js"
+      }
+    },
+    "./deep": {
+      "import": {
+        "types": "./dist/deep.d.ts",
+        "default": "./dist/deep.js"
+      }
+    },
     "./guards": {
       "import": {
         "types": "./dist/guards.d.ts",
         "default": "./dist/guards.js"
       }
     },
-    "./package.json": "./package.json"
+    "./hash-id": {
+      "import": {
+        "types": "./dist/hash-id.d.ts",
+        "default": "./dist/hash-id.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./short-id": {
+      "import": {
+        "types": "./dist/short-id.d.ts",
+        "default": "./dist/short-id.js"
+      }
+    },
+    "./utilities": {
+      "import": {
+        "types": "./dist/utilities.d.ts",
+        "default": "./dist/utilities.js"
+      }
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/scripts/normalize-exports.ts
+++ b/scripts/normalize-exports.ts
@@ -1,0 +1,81 @@
+/**
+ * Normalizes the `exports` field in package.json files to alphabetical key order.
+ *
+ * Bunup auto-generates exports from filesystem discovery, which produces
+ * non-deterministic key ordering. This causes spurious merge conflicts in
+ * stacked branches where the semantic exports are identical but key order differs.
+ *
+ * Runs as a post-build step after bunup writes exports.
+ */
+
+import { resolve } from "node:path";
+
+/** Auto-discover workspace packages from root package.json workspace globs */
+async function discoverWorkspaceRoots(): Promise<string[]> {
+  const rootPkg = await Bun.file("package.json").json();
+  const workspaces: string[] = rootPkg.workspaces ?? [];
+  const roots: string[] = [];
+
+  for (const pattern of workspaces) {
+    const glob = new Bun.Glob(`${pattern}/package.json`);
+    for await (const match of glob.scan({ dot: false })) {
+      roots.push(match.replace("/package.json", ""));
+    }
+  }
+
+  return roots.sort();
+}
+
+const WORKSPACE_ROOTS = await discoverWorkspaceRoots();
+
+function sortExports(
+  exports: Record<string, unknown>
+): Record<string, unknown> {
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(exports).sort()) {
+    sorted[key] = exports[key];
+  }
+  return sorted;
+}
+
+/** Detect indentation from file content (tab vs spaces) */
+function detectIndent(content: string): string {
+  const match = content.match(/^(\s+)"/m);
+  return match?.[1] ?? "  ";
+}
+
+let changed = 0;
+
+for (const root of WORKSPACE_ROOTS) {
+  const pkgPath = resolve(root, "package.json");
+  const file = Bun.file(pkgPath);
+
+  if (!(await file.exists())) continue;
+
+  const content = await file.text();
+  const indent = detectIndent(content);
+  const pkg = JSON.parse(content) as Record<string, unknown>;
+
+  if (
+    !pkg.exports ||
+    typeof pkg.exports !== "object" ||
+    Array.isArray(pkg.exports)
+  ) {
+    continue;
+  }
+
+  const sorted = sortExports(pkg.exports as Record<string, unknown>);
+  const keys = Object.keys(pkg.exports as Record<string, unknown>);
+  const sortedKeys = Object.keys(sorted);
+
+  // Check if already sorted
+  if (keys.every((k, i) => k === sortedKeys[i])) continue;
+
+  pkg.exports = sorted;
+  await Bun.write(pkgPath, `${JSON.stringify(pkg, null, indent)}\n`);
+  changed += 1;
+}
+
+if (changed > 0) {
+  console.log(`[normalize-exports] Sorted exports in ${changed} package(s)`);
+}


### PR DESCRIPTION
## Summary

Bunup auto-generates the `exports` field from filesystem discovery in non-deterministic order, causing spurious merge conflicts in stacked branches where semantic exports are identical but key order differs. This was especially painful for `@outfitter/cli` with 42 exports.

Adds `scripts/normalize-exports.ts` as a post-build step that sorts all package.json export keys alphabetically. Chains into the build command: `bunup && bun scripts/normalize-exports.ts`.

- Auto-discovers workspace packages from root `package.json` workspace globs (no hardcoded list)
- Preserves existing indentation (detects tab vs spaces)
- Deterministic output across builds and machines
- Idempotent — re-running produces zero diff

## Test plan

- [x] `bun run build` twice — second run produces no changes
- [x] `bun run check` — lint clean after normalization
- [x] Full test suite passes
- [x] `bun run typecheck` — clean

Closes: OS-120