### PR TITLE
refactor(config): replace json5 dependency with Bun.JSON5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "outfitter",
       "dependencies": {
-        "json5": "^2.2.3",
         "smol-toml": "^1.6.0",
         "yaml": "^2.8.2",
       },
@@ -675,8 +674,6 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
-
-    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@biomejs/biome"
   ],
   "dependencies": {
-    "json5": "^2.2.3",
     "smol-toml": "^1.6.0",
     "yaml": "^2.8.2"
   }

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -550,6 +550,30 @@ server:
         expect(parsed.server.port).toBe(3000);
       }
     });
+
+    it("uses Bun.JSON5 parser for jsonc/json5 files", () => {
+      const originalParse = Bun.JSON5.parse;
+      const parseCalls: string[] = [];
+
+      Bun.JSON5.parse = ((input: string) => {
+        parseCalls.push(input);
+        return { mocked: true };
+      }) as typeof Bun.JSON5.parse;
+
+      try {
+        const jsoncResult = parseConfigFile(
+          '{ // comment\n"a": 1\n}',
+          "config.jsonc"
+        );
+        const json5Result = parseConfigFile('{"b": 2,}', "config.json5");
+
+        expect(jsoncResult.isOk()).toBe(true);
+        expect(json5Result.isOk()).toBe(true);
+        expect(parseCalls).toHaveLength(2);
+      } finally {
+        Bun.JSON5.parse = originalParse;
+      }
+    });
   });
 });
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -56,7 +56,6 @@ import {
   TaggedError,
   ValidationError,
 } from "@outfitter/contracts";
-import JSON5 from "json5";
 import { parse as parseToml } from "smol-toml";
 import { parse as parseYaml } from "yaml";
 import type { ZodSchema } from "zod";
@@ -420,7 +419,7 @@ export function parseConfigFile(
 
       case "jsonc":
       case "json5": {
-        const parsed = JSON5.parse(content);
+        const parsed = Bun.JSON5.parse(content);
         return Result.ok(parsed as Record<string, unknown>);
       }
 

--- a/plugins/fieldguides/skills/bun-first/replacements.json
+++ b/plugins/fieldguides/skills/bun-first/replacements.json
@@ -582,6 +582,17 @@
       }
     },
     {
+      "id": "json5",
+      "name": "JSON5 Parsing",
+      "category": "utilities",
+      "bunApi": "Bun.JSON5.parse()",
+      "docs": "https://bun.sh/docs/api/utils",
+      "detectors": {
+        "packages": ["json5"],
+        "imports": ["json5"]
+      }
+    },
+    {
       "id": "inspect",
       "name": "Object Inspection",
       "category": "utilities",
@@ -864,10 +875,6 @@
     {
       "pattern": "p-map",
       "reason": "No native concurrent map API"
-    },
-    {
-      "pattern": "json5",
-      "reason": "No native JSON5 parsing - consider standard JSON"
     },
     {
       "pattern": "ini",


### PR DESCRIPTION
## Summary

- Replace `json5` dependency usage in config flows with Bun-native `Bun.JSON5`
- Remove external JSON5 parsing dependency from this package path while keeping behavior equivalent for supported input
- Reduce dependency surface and align with the monorepo Bun-first principle

## Test plan

- [x] Existing config package tests pass
- [x] Monorepo verification in stack submit passed (typecheck/check/build/test)
