### PR TITLE
fix(tooling): check sync exports without mutating package.json

### DIFF
--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -21,16 +21,14 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./registry": {
+		"./.markdownlint-cli2": "./.markdownlint-cli2.jsonc",
+		"./.markdownlint-cli2.jsonc": "./.markdownlint-cli2.jsonc",
+		"./biome": "./biome.json",
+		"./biome.json": "./biome.json",
+		"./cli/check": {
 			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
-		"./cli/init": {
-			"import": {
-				"types": "./dist/cli/init.d.ts",
-				"default": "./dist/cli/init.js"
+				"types": "./dist/cli/check.d.ts",
+				"default": "./dist/cli/check.js"
 			}
 		},
 		"./cli/fix": {
@@ -39,23 +37,25 @@
 				"default": "./dist/cli/fix.js"
 			}
 		},
-		"./cli/check": {
+		"./cli/init": {
 			"import": {
-				"types": "./dist/cli/check.d.ts",
-				"default": "./dist/cli/check.js"
+				"types": "./dist/cli/init.d.ts",
+				"default": "./dist/cli/init.js"
 			}
 		},
-		"./package.json": "./package.json",
-		"./biome": "./biome.json",
-		"./biome.json": "./biome.json",
-		"./tsconfig": "./tsconfig.preset.json",
-		"./tsconfig.preset.json": "./tsconfig.preset.json",
-		"./tsconfig-bun": "./tsconfig.preset.bun.json",
-		"./tsconfig.preset.bun.json": "./tsconfig.preset.bun.json",
 		"./lefthook": "./lefthook.yml",
 		"./lefthook.yml": "./lefthook.yml",
-		"./.markdownlint-cli2": "./.markdownlint-cli2.jsonc",
-		"./.markdownlint-cli2.jsonc": "./.markdownlint-cli2.jsonc"
+		"./package.json": "./package.json",
+		"./registry": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
+		"./tsconfig": "./tsconfig.preset.json",
+		"./tsconfig-bun": "./tsconfig.preset.bun.json",
+		"./tsconfig.preset.bun.json": "./tsconfig.preset.bun.json",
+		"./tsconfig.preset.json": "./tsconfig.preset.json"
 	},
 	"bin": {
 		"tooling": "./dist/cli/index.js"
@@ -64,7 +64,8 @@
 	"scripts": {
 		"build:registry": "bun run src/registry/build.ts",
 		"sync:exports": "bun run scripts/sync-exports.ts",
-		"prebuild": "bun run build:registry && bun run sync:exports",
+		"sync:exports:check": "bun run scripts/sync-exports.ts --check",
+		"prebuild": "bun run build:registry && bun run sync:exports:check",
 		"build": "bunup --filter @outfitter/tooling",
 		"prepack": "bun run sync:exports",
 		"lint": "biome lint ./src",

--- a/packages/tooling/scripts/__tests__/sync-exports.test.ts
+++ b/packages/tooling/scripts/__tests__/sync-exports.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { shortAlias } from "../sync-exports";
+import { buildSyncedExports, shortAlias, sortExports } from "../sync-exports";
 
 describe("shortAlias", () => {
 	test("biome.json returns biome", () => {
@@ -24,5 +24,74 @@ describe("shortAlias", () => {
 
 	test("foo.toml returns foo", () => {
 		expect(shortAlias("foo.toml")).toBe("foo");
+	});
+});
+
+describe("sortExports", () => {
+	test("sorts export keys deterministically", () => {
+		const sorted = sortExports({
+			"./z": "./z.js",
+			".": "./index.js",
+			"./a": "./a.js",
+		});
+
+		expect(Object.keys(sorted)).toEqual([".", "./a", "./z"]);
+	});
+});
+
+describe("buildSyncedExports", () => {
+	test("removes stale config exports and regenerates from files", () => {
+		const synced = buildSyncedExports({
+			files: [
+				"dist",
+				"biome.json",
+				"tsconfig.preset.json",
+				"tsconfig.preset.bun.json",
+				"lefthook.yml",
+				".markdownlint-cli2.jsonc",
+			],
+			exports: {
+				"./cli/check": {
+					import: {
+						types: "./dist/cli/check.d.ts",
+						default: "./dist/cli/check.js",
+					},
+				},
+				"./biome": "./stale.json",
+				"./biome.json": "./stale.json",
+				"./tsconfig": "./stale.json",
+				"./tsconfig.preset.json": "./stale.json",
+				"./package.json": "./package.json",
+				".": {
+					import: {
+						types: "./dist/index.d.ts",
+						default: "./dist/index.js",
+					},
+				},
+			},
+		});
+
+		expect(synced["./biome"]).toBe("./biome.json");
+		expect(synced["./biome.json"]).toBe("./biome.json");
+		expect(synced["./tsconfig"]).toBe("./tsconfig.preset.json");
+		expect(synced["./tsconfig.preset.json"]).toBe("./tsconfig.preset.json");
+		expect(synced["./tsconfig-bun"]).toBe("./tsconfig.preset.bun.json");
+		expect(synced["./lefthook"]).toBe("./lefthook.yml");
+		expect(synced["./.markdownlint-cli2"]).toBe("./.markdownlint-cli2.jsonc");
+		expect(Object.keys(synced)).toEqual([
+			".",
+			"./.markdownlint-cli2",
+			"./.markdownlint-cli2.jsonc",
+			"./biome",
+			"./biome.json",
+			"./cli/check",
+			"./lefthook",
+			"./lefthook.yml",
+			"./package.json",
+			"./tsconfig",
+			"./tsconfig-bun",
+			"./tsconfig.preset.bun.json",
+			"./tsconfig.preset.json",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary
- Add non-mutating `--check` mode to `packages/tooling/scripts/sync-exports.ts`.
- Make `sync-exports` writes deterministic by sorting top-level `exports` keys.
- Update `@outfitter/tooling` `prebuild` to run `sync:exports:check` so routine checks fail fast instead of rewriting `package.json`.

## Why
- Prevent unrelated `package.json` export churn while moving through stacked branches.
- Keep explicit `sync:exports` as the single deterministic write path.

## Test plan
- [x] `cd packages/tooling && bun test scripts/__tests__/sync-exports.test.ts`
- [x] `bun run test --filter=@outfitter/tooling`
- [x] `bun run typecheck`
- [x] Pre-push `verify:ci` passed during `gt submit --stack`
