### PR TITLE
docs(plans): clarify gt modify commit flags and examples

### DIFF
--- a/.agents/plans/outfitter-docs-plan.md
+++ b/.agents/plans/outfitter-docs-plan.md
@@ -465,6 +465,13 @@ Graphite commit workflow guidance:
 4. If accidental mixed staging happens, unstage and restage by hunk before committing.
 5. After finishing the linear sequence, run `gt split --by-commit` to materialize the stacked branches.
 
+Command usage note:
+
+1. In this workflow, create commits with `gt modify -c -m "<message>"`.
+2. Combine with staging mode as needed:
+   - `gt modify --patch -c -m "<message>"` for selective hunk commits
+   - `gt modify -a -c -m "<message>"` when all tracked changes belong together
+
 ## Definition of Done (for OS-107)
 
 1. Package docs are centralized under `docs/packages/*` through the new docs pipeline.


### PR DESCRIPTION
## Summary
This PR adds concrete `gt modify` command guidance to the docs implementation plan.

## What Changed
- Updated `.agents/plans/outfitter-docs-plan.md` with explicit flag usage for:
  - `gt modify -c -m "..."`
  - `gt modify --patch -c -m "..."`
  - `gt modify -a -c -m "..."`
- Clarified when to use `--patch` vs `-a` to keep issue slices clean.

## Why
- Prevents accidental cross-slice commits in the stack.
- Makes staged commit creation consistent and repeatable for the implementation sequence.

## Testing
- Docs-only planning changes.
- No runtime code path changed in this PR.

## Risks / Notes
- This is process/documentation guidance only.

## Stack Context
- Linear: `OS-107`
- Base: `docs/plans/gt-modify-workflow-os-107`
- Head: `docs/plans/gt-modify-flags-os-107`
