### PR TITLE
feat(docs): add docs CLI and host command adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,21 @@
         "typescript": "^5.8.0",
       },
     },
+    "packages/docs": {
+      "name": "@outfitter/docs",
+      "version": "0.1.0",
+      "bin": {
+        "outfitter-docs": "./dist/cli.js",
+      },
+      "dependencies": {
+        "@outfitter/docs-core": "workspace:*",
+        "commander": "^14.0.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.8.0",
+      },
+    },
     "packages/docs-core": {
       "name": "@outfitter/docs-core",
       "version": "0.1.0",
@@ -392,6 +407,8 @@
     "@outfitter/contracts": ["@outfitter/contracts@workspace:packages/contracts"],
 
     "@outfitter/daemon": ["@outfitter/daemon@workspace:packages/daemon"],
+
+    "@outfitter/docs": ["@outfitter/docs@workspace:packages/docs"],
 
     "@outfitter/docs-core": ["@outfitter/docs-core@workspace:packages/docs-core"],
 
@@ -969,6 +986,8 @@
 
     "@outfitter/contracts/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@outfitter/docs/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@outfitter/docs-core/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@outfitter/kit/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
@@ -996,6 +1015,8 @@
     "@outfitter/contracts/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@outfitter/docs-core/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@outfitter/docs/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@outfitter/kit/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -102,6 +102,10 @@ export default defineWorkspace(
       root: "packages/docs-core",
     },
     {
+      name: "@outfitter/docs",
+      root: "packages/docs",
+    },
+    {
       name: "@outfitter/cli",
       root: "packages/cli",
       // Exclude internal exports - consumers should use barrel exports (./render, ./demo)

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,0 +1,27 @@
+# @outfitter/docs
+
+CLI and host command adapter for Outfitter docs workflows.
+
+## Commands
+
+- `docs sync` — assemble package docs output
+- `docs check` — verify package docs output freshness
+
+## Host CLI Adapter
+
+```ts
+import { createDocsCommand } from "@outfitter/docs";
+
+program.addCommand(createDocsCommand());
+```
+
+## Standalone CLI
+
+```bash
+bunx @outfitter/docs docs sync
+bunx @outfitter/docs docs check
+```
+
+## License
+
+MIT

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@outfitter/docs",
+  "description": "CLI and host command adapter for Outfitter docs workflows",
+  "version": "0.1.0",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "outfitter-docs": "./dist/cli.js"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "bunup --filter @outfitter/docs",
+    "lint": "biome lint ./src",
+    "lint:fix": "biome lint --write ./src",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@outfitter/docs-core": "workspace:*",
+    "commander": "^14.0.2"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.8.0"
+  },
+  "keywords": [
+    "outfitter",
+    "docs",
+    "cli",
+    "typescript"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/outfitter-dev/outfitter.git",
+    "directory": "packages/docs"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/docs/src/__tests__/docs-command.test.ts
+++ b/packages/docs/src/__tests__/docs-command.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Command } from "commander";
+import { createDocsCommand } from "../command/create-docs-command.js";
+import { executeCheckCommand } from "../commands/check.js";
+import { executeSyncCommand } from "../commands/sync.js";
+
+async function createWorkspaceFixture(): Promise<string> {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "outfitter-docs-test-"));
+  const pkgRoot = join(workspaceRoot, "packages", "alpha");
+
+  await mkdir(join(pkgRoot, "docs"), { recursive: true });
+  await mkdir(join(workspaceRoot, "docs"), { recursive: true });
+
+  await writeFile(join(workspaceRoot, "docs", "PATTERNS.md"), "# Patterns\n");
+  await writeFile(
+    join(pkgRoot, "package.json"),
+    JSON.stringify({ name: "@acme/alpha", version: "0.0.1" })
+  );
+  await writeFile(
+    join(pkgRoot, "README.md"),
+    "# Alpha\n\nSee [patterns](../../docs/PATTERNS.md).\n"
+  );
+
+  return workspaceRoot;
+}
+
+describe("docs command execution", () => {
+  const workspaceRoots = new Set<string>();
+
+  afterEach(async () => {
+    for (const workspaceRoot of workspaceRoots) {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+    workspaceRoots.clear();
+  });
+
+  it("executeSyncCommand returns success and writes outputs", async () => {
+    const workspaceRoot = await createWorkspaceFixture();
+    workspaceRoots.add(workspaceRoot);
+
+    const out: string[] = [];
+    const err: string[] = [];
+
+    const code = await executeSyncCommand(
+      { cwd: workspaceRoot },
+      {
+        out: (line) => out.push(line),
+        err: (line) => err.push(line),
+      }
+    );
+
+    expect(code).toBe(0);
+    expect(err).toEqual([]);
+    expect(out[0]).toContain("Synced package docs for 1 package(s)");
+
+    const generatedReadme = await readFile(
+      join(workspaceRoot, "docs", "packages", "alpha", "README.md"),
+      "utf8"
+    );
+    expect(generatedReadme).toContain("[patterns](../../PATTERNS.md)");
+  });
+
+  it("executeCheckCommand reports drift when generated docs are stale", async () => {
+    const workspaceRoot = await createWorkspaceFixture();
+    workspaceRoots.add(workspaceRoot);
+
+    const syncCode = await executeSyncCommand(
+      { cwd: workspaceRoot },
+      { out: () => undefined, err: () => undefined }
+    );
+    expect(syncCode).toBe(0);
+
+    await writeFile(
+      join(workspaceRoot, "docs", "packages", "alpha", "README.md"),
+      "# stale\n"
+    );
+
+    const out: string[] = [];
+    const err: string[] = [];
+
+    const checkCode = await executeCheckCommand(
+      { cwd: workspaceRoot },
+      {
+        out: (line) => out.push(line),
+        err: (line) => err.push(line),
+      }
+    );
+
+    expect(checkCode).toBe(1);
+    expect(out).toEqual([]);
+    expect(err[0]).toBe("Package docs are stale:");
+    expect(err.some((line) => line.includes("[changed]"))).toBe(true);
+  });
+});
+
+describe("createDocsCommand", () => {
+  it("creates a host-mountable docs command with sync and check subcommands", () => {
+    const command = createDocsCommand();
+
+    expect(command.name()).toBe("docs");
+
+    const subcommandNames = command.commands.map((subcommand: Command) =>
+      subcommand.name()
+    );
+
+    expect(subcommandNames).toEqual(["sync", "check"]);
+  });
+});

--- a/packages/docs/src/cli.ts
+++ b/packages/docs/src/cli.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander";
+import { createDocsCommand } from "./command/create-docs-command.js";
+import { VERSION } from "./version.js";
+
+async function main(): Promise<void> {
+  const program = new Command();
+  program
+    .name("outfitter-docs")
+    .description("Outfitter docs command line interface")
+    .version(VERSION);
+
+  const docsCommand = createDocsCommand();
+  docsCommand.name("docs");
+
+  program.addCommand(docsCommand);
+
+  await program.parseAsync(process.argv);
+}
+
+main();

--- a/packages/docs/src/command/create-docs-command.ts
+++ b/packages/docs/src/command/create-docs-command.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { executeCheckCommand } from "../commands/check.js";
+import { executeSyncCommand } from "../commands/sync.js";
+
+export interface CreateDocsCommandOptions {
+  readonly commandName?: string;
+  readonly io?: {
+    readonly out?: (line: string) => void;
+    readonly err?: (line: string) => void;
+  };
+}
+
+function getIo(options: CreateDocsCommandOptions | undefined): {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+} {
+  return {
+    out:
+      options?.io?.out ?? ((line: string) => process.stdout.write(`${line}\n`)),
+    err:
+      options?.io?.err ?? ((line: string) => process.stderr.write(`${line}\n`)),
+  };
+}
+
+export function createDocsCommand(options?: CreateDocsCommandOptions): Command {
+  const io = getIo(options);
+
+  const command = new Command(options?.commandName ?? "docs");
+  command.description("Synchronize and verify package docs outputs");
+
+  command
+    .command("sync")
+    .description("Assemble package docs into docs/packages")
+    .option("--cwd <path>", "Workspace root to operate in")
+    .option("--packages-dir <path>", "Packages directory relative to workspace")
+    .option("--output-dir <path>", "Output directory relative to workspace")
+    .action(
+      async (cmdOptions: {
+        cwd?: string;
+        packagesDir?: string;
+        outputDir?: string;
+      }) => {
+        const code = await executeSyncCommand(cmdOptions, io);
+        if (code !== 0) {
+          process.exitCode = code;
+        }
+      }
+    );
+
+  command
+    .command("check")
+    .description("Check whether assembled package docs are in sync")
+    .option("--cwd <path>", "Workspace root to operate in")
+    .option("--packages-dir <path>", "Packages directory relative to workspace")
+    .option("--output-dir <path>", "Output directory relative to workspace")
+    .action(
+      async (cmdOptions: {
+        cwd?: string;
+        packagesDir?: string;
+        outputDir?: string;
+      }) => {
+        const code = await executeCheckCommand(cmdOptions, io);
+        if (code !== 0) {
+          process.exitCode = code;
+        }
+      }
+    );
+
+  return command;
+}

--- a/packages/docs/src/commands/check.ts
+++ b/packages/docs/src/commands/check.ts
@@ -1,0 +1,48 @@
+import {
+  checkPackageDocs,
+  type PackageDocsOptions,
+} from "@outfitter/docs-core";
+import type { CommandIo } from "./sync.js";
+
+export interface ExecuteCheckCommandOptions extends PackageDocsOptions {
+  readonly cwd?: string;
+}
+
+function toCoreOptions(
+  options: ExecuteCheckCommandOptions
+): PackageDocsOptions {
+  const workspaceRoot = options.cwd ?? options.workspaceRoot;
+
+  return {
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+    ...(options.packagesDir ? { packagesDir: options.packagesDir } : {}),
+    ...(options.outputDir ? { outputDir: options.outputDir } : {}),
+    ...(options.excludedFilenames
+      ? { excludedFilenames: options.excludedFilenames }
+      : {}),
+  };
+}
+
+export async function executeCheckCommand(
+  options: ExecuteCheckCommandOptions,
+  io: CommandIo
+): Promise<number> {
+  const result = await checkPackageDocs(toCoreOptions(options));
+
+  if (result.isErr()) {
+    io.err(`docs check failed: ${result.error.message}`);
+    return 1;
+  }
+
+  if (result.value.isUpToDate) {
+    io.out("Package docs are up to date.");
+    return 0;
+  }
+
+  io.err("Package docs are stale:");
+  for (const drift of result.value.drift) {
+    io.err(`- [${drift.kind}] ${drift.path}`);
+  }
+
+  return 1;
+}

--- a/packages/docs/src/commands/sync.ts
+++ b/packages/docs/src/commands/sync.ts
@@ -1,0 +1,43 @@
+import { type PackageDocsOptions, syncPackageDocs } from "@outfitter/docs-core";
+
+export interface ExecuteSyncCommandOptions extends PackageDocsOptions {
+  readonly cwd?: string;
+}
+
+export interface CommandIo {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+}
+
+function toCoreOptions(options: ExecuteSyncCommandOptions): PackageDocsOptions {
+  const workspaceRoot = options.cwd ?? options.workspaceRoot;
+
+  return {
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+    ...(options.packagesDir ? { packagesDir: options.packagesDir } : {}),
+    ...(options.outputDir ? { outputDir: options.outputDir } : {}),
+    ...(options.excludedFilenames
+      ? { excludedFilenames: options.excludedFilenames }
+      : {}),
+  };
+}
+
+export async function executeSyncCommand(
+  options: ExecuteSyncCommandOptions,
+  io: CommandIo
+): Promise<number> {
+  const result = await syncPackageDocs(toCoreOptions(options));
+
+  if (result.isErr()) {
+    io.err(`docs sync failed: ${result.error.message}`);
+    return 1;
+  }
+
+  io.out(
+    `Synced package docs for ${result.value.packageNames.length} package(s).`
+  );
+  io.out(
+    `Wrote ${result.value.writtenFiles.length} file(s), removed ${result.value.removedFiles.length} stale file(s).`
+  );
+  return 0;
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @outfitter/docs
+ *
+ * CLI and host command adapter for Outfitter docs workflows.
+ *
+ * @packageDocumentation
+ */
+
+export type { CreateDocsCommandOptions } from "./command/create-docs-command.js";
+export { createDocsCommand } from "./command/create-docs-command.js";
+export {
+  type ExecuteCheckCommandOptions,
+  executeCheckCommand,
+} from "./commands/check.js";
+export {
+  type ExecuteSyncCommandOptions,
+  executeSyncCommand,
+} from "./commands/sync.js";

--- a/packages/docs/src/version.ts
+++ b/packages/docs/src/version.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGE_ROOT = join(import.meta.dir, "..");
+
+export const VERSION = (() => {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8")
+    ) as { version?: string };
+
+    if (
+      typeof packageJson.version === "string" &&
+      packageJson.version.length > 0
+    ) {
+      return packageJson.version;
+    }
+  } catch {
+    // Fall through.
+  }
+
+  return "0.0.0";
+})();

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary
This PR adds `@outfitter/docs` CLI + host adapter (`OS-149`).

## What Changed
- Added standalone docs CLI entrypoint in `packages/docs/src/cli.ts`.
- Added host integration adapter in `packages/docs/src/command/create-docs-command.ts`.
- Added `sync` and `check` command implementations.
- Added tests in `packages/docs/src/__tests__/docs-command.test.ts`.
- Added package exports/version plumbing and package docs.

## Why
- Enables shared docs behavior across products while preserving host CLI branding (`outfitter docs`, `waymark docs`, etc.).
- Keeps command orchestration in a focused package rather than embedding logic in app-specific code.

## Testing
- Verified in stack with `bun run verify:ci` on the stack tip after restack.
- This includes typecheck, lint/check, build, and test coverage across workspace packages.

## Risks / Notes
- Downstream integration PR mounts this command into `apps/outfitter`.

## Stack Context
- Linear: `OS-149`
- Base: `feat/docs-core/sync-check-os-148`
- Head: `feat/docs/cli-adapter-os-149`
