### PR TITLE
feat(tooling): add check-exports command

### DIFF
--- a/packages/tooling/src/__tests__/check-exports.test.ts
+++ b/packages/tooling/src/__tests__/check-exports.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type CheckResult,
+	compareExports,
+	type ExportMap,
+	entryToSubpath,
+} from "../cli/check-exports.js";
+
+describe("entryToSubpath", () => {
+	test("maps root index.ts to '.'", () => {
+		expect(entryToSubpath("src/index.ts")).toBe(".");
+	});
+
+	test("maps top-level file to bare name", () => {
+		expect(entryToSubpath("src/branded.ts")).toBe("./branded");
+	});
+
+	test("maps nested index.ts to directory path", () => {
+		expect(entryToSubpath("src/cli/index.ts")).toBe("./cli");
+	});
+
+	test("maps nested file to full subpath", () => {
+		expect(entryToSubpath("src/cli/check.ts")).toBe("./cli/check");
+	});
+});
+
+describe("compareExports", () => {
+	const simpleEntry = (name: string) => ({
+		import: {
+			types: `./dist/${name}.d.ts`,
+			default: `./dist/${name}.js`,
+		},
+	});
+
+	test("reports ok when exports match exactly", () => {
+		const exports: ExportMap = {
+			".": simpleEntry("index"),
+			"./branded": simpleEntry("branded"),
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual: exports,
+			expected: exports,
+		});
+
+		expect(result.status).toBe("ok");
+		expect(result.drift).toBeUndefined();
+	});
+
+	test("detects added exports (in expected but not actual)", () => {
+		const actual: ExportMap = {
+			".": simpleEntry("index"),
+		};
+		const expected: ExportMap = {
+			".": simpleEntry("index"),
+			"./branded": simpleEntry("branded"),
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual,
+			expected,
+		});
+
+		expect(result.status).toBe("drift");
+		expect(result.drift).toBeDefined();
+		expect(result.drift?.added).toEqual(["./branded"]);
+		expect(result.drift?.removed).toEqual([]);
+		expect(result.drift?.changed).toEqual([]);
+	});
+
+	test("detects removed exports (in actual but not expected)", () => {
+		const actual: ExportMap = {
+			".": simpleEntry("index"),
+			"./old-module": simpleEntry("old-module"),
+		};
+		const expected: ExportMap = {
+			".": simpleEntry("index"),
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual,
+			expected,
+		});
+
+		expect(result.status).toBe("drift");
+		expect(result.drift).toBeDefined();
+		expect(result.drift?.removed).toEqual(["./old-module"]);
+		expect(result.drift?.added).toEqual([]);
+		expect(result.drift?.changed).toEqual([]);
+	});
+
+	test("detects changed export values", () => {
+		const actual: ExportMap = {
+			".": simpleEntry("index"),
+			"./branded": simpleEntry("branded"),
+		};
+		const expected: ExportMap = {
+			".": simpleEntry("index"),
+			"./branded": {
+				import: {
+					types: "./dist/branded/index.d.ts",
+					default: "./dist/branded/index.js",
+				},
+			},
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual,
+			expected,
+		});
+
+		expect(result.status).toBe("drift");
+		expect(result.drift).toBeDefined();
+		expect(result.drift?.changed).toEqual([
+			{
+				key: "./branded",
+				expected: expected["./branded"],
+				actual: actual["./branded"],
+			},
+		]);
+		expect(result.drift?.added).toEqual([]);
+		expect(result.drift?.removed).toEqual([]);
+	});
+
+	test("detects multiple drift types simultaneously", () => {
+		const actual: ExportMap = {
+			".": simpleEntry("index"),
+			"./old": simpleEntry("old"),
+			"./changed": simpleEntry("changed"),
+		};
+		const expected: ExportMap = {
+			".": simpleEntry("index"),
+			"./new": simpleEntry("new"),
+			"./changed": {
+				import: {
+					types: "./dist/changed/index.d.ts",
+					default: "./dist/changed/index.js",
+				},
+			},
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual,
+			expected,
+		});
+
+		expect(result.status).toBe("drift");
+		expect(result.drift?.added).toEqual(["./new"]);
+		expect(result.drift?.removed).toEqual(["./old"]);
+		expect(result.drift?.changed).toHaveLength(1);
+		expect(result.drift?.changed[0]?.key).toBe("./changed");
+	});
+
+	test("returns sorted keys in drift output", () => {
+		const actual: ExportMap = {
+			".": simpleEntry("index"),
+		};
+		const expected: ExportMap = {
+			".": simpleEntry("index"),
+			"./zebra": simpleEntry("zebra"),
+			"./alpha": simpleEntry("alpha"),
+			"./middle": simpleEntry("middle"),
+		};
+
+		const result = compareExports({
+			name: "@outfitter/types",
+			actual,
+			expected,
+		});
+
+		expect(result.drift?.added).toEqual(["./alpha", "./middle", "./zebra"]);
+	});
+
+	test("treats string export values correctly", () => {
+		const actual: ExportMap = {
+			"./package.json": "./package.json",
+			"./biome": "./biome.json",
+		};
+		const expected: ExportMap = {
+			"./package.json": "./package.json",
+			"./biome": "./biome.json",
+		};
+
+		const result = compareExports({
+			name: "@outfitter/tooling",
+			actual,
+			expected,
+		});
+
+		expect(result.status).toBe("ok");
+	});
+});
+
+describe("CheckResult aggregation", () => {
+	test("ok is true when all packages match", () => {
+		const results: CheckResult = {
+			ok: true,
+			packages: [
+				{ name: "@outfitter/types", status: "ok" },
+				{ name: "@outfitter/contracts", status: "ok" },
+			],
+		};
+
+		expect(results.ok).toBe(true);
+	});
+
+	test("ok is false when any package has drift", () => {
+		const results: CheckResult = {
+			ok: false,
+			packages: [
+				{ name: "@outfitter/types", status: "ok" },
+				{
+					name: "@outfitter/contracts",
+					status: "drift",
+					drift: {
+						package: "@outfitter/contracts",
+						path: "packages/contracts",
+						added: ["./new-export"],
+						removed: [],
+						changed: [],
+					},
+				},
+			],
+		};
+
+		expect(results.ok).toBe(false);
+	});
+});

--- a/packages/tooling/src/cli/check-exports.ts
+++ b/packages/tooling/src/cli/check-exports.ts
@@ -1,0 +1,439 @@
+/**
+ * Check-exports command — validates package.json exports are in sync with source.
+ *
+ * Pure core functions for comparing export maps. The CLI runner in
+ * {@link runCheckExports} handles filesystem discovery and output.
+ *
+ * @packageDocumentation
+ */
+
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A package.json export map: keys are subpaths, values are export conditions or strings */
+export type ExportMap = Record<string, unknown>;
+
+/** Describes drift between expected and actual exports for a single package */
+export interface ExportDrift {
+	readonly package: string;
+	readonly path: string;
+	readonly added: string[];
+	readonly removed: string[];
+	readonly changed: Array<{
+		readonly key: string;
+		readonly expected: unknown;
+		readonly actual: unknown;
+	}>;
+}
+
+/** Per-package comparison result */
+export interface PackageResult {
+	readonly name: string;
+	readonly status: "ok" | "drift";
+	readonly drift?: ExportDrift;
+}
+
+/** Aggregated result across all checked packages */
+export interface CheckResult {
+	readonly ok: boolean;
+	readonly packages: PackageResult[];
+}
+
+/** Input for comparing a single package's exports */
+export interface CompareInput {
+	readonly name: string;
+	readonly actual: ExportMap;
+	readonly expected: ExportMap;
+	readonly path?: string;
+}
+
+/** Bunup workspace entry from bunup.config.ts */
+interface WorkspaceEntry {
+	readonly name: string;
+	readonly root: string;
+	readonly config?: {
+		readonly exports?:
+			| boolean
+			| {
+					readonly exclude?: readonly string[];
+					readonly customExports?: Readonly<Record<string, string>>;
+			  };
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a source entry file path to its export subpath.
+ *
+ * @example
+ * entryToSubpath("src/index.ts")       // "."
+ * entryToSubpath("src/branded.ts")     // "./branded"
+ * entryToSubpath("src/cli/index.ts")   // "./cli"
+ * entryToSubpath("src/cli/check.ts")   // "./cli/check"
+ */
+export function entryToSubpath(entry: string): string {
+	// Strip src/ prefix and .ts extension
+	const stripped = entry.replace(/^src\//, "").replace(/\.[cm]?[jt]sx?$/, "");
+
+	// index at root -> "."
+	if (stripped === "index") {
+		return ".";
+	}
+
+	// dir/index -> ./dir
+	if (stripped.endsWith("/index")) {
+		return `./${stripped.slice(0, -"/index".length)}`;
+	}
+
+	return `./${stripped}`;
+}
+
+/**
+ * Compare actual vs expected exports for a single package.
+ *
+ * Returns a PackageResult with status "ok" or "drift" and detailed diff.
+ */
+export function compareExports(input: CompareInput): PackageResult {
+	const { name, actual, expected, path } = input;
+
+	const actualKeys = new Set(Object.keys(actual));
+	const expectedKeys = new Set(Object.keys(expected));
+
+	const added: string[] = [];
+	const removed: string[] = [];
+	const changed: Array<{
+		readonly key: string;
+		readonly expected: unknown;
+		readonly actual: unknown;
+	}> = [];
+
+	// Keys in expected but not in actual
+	for (const key of expectedKeys) {
+		if (!actualKeys.has(key)) {
+			added.push(key);
+		}
+	}
+
+	// Keys in actual but not in expected
+	for (const key of actualKeys) {
+		if (!expectedKeys.has(key)) {
+			removed.push(key);
+		}
+	}
+
+	// Keys in both but with different values
+	for (const key of actualKeys) {
+		if (expectedKeys.has(key)) {
+			const actualValue = actual[key];
+			const expectedValue = expected[key];
+			if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
+				changed.push({ key, expected: expectedValue, actual: actualValue });
+			}
+		}
+	}
+
+	// Sort for deterministic output
+	added.sort();
+	removed.sort();
+	changed.sort((a, b) => a.key.localeCompare(b.key));
+
+	if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+		return { name, status: "ok" };
+	}
+
+	return {
+		name,
+		status: "drift",
+		drift: {
+			package: name,
+			path: path ?? "",
+			added,
+			removed,
+			changed,
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers (used by runner)
+// ---------------------------------------------------------------------------
+
+/** Check if a subpath matches any exclude pattern using Bun.Glob */
+function matchesExclude(subpath: string, excludes: readonly string[]): boolean {
+	return excludes.some((pattern) => new Bun.Glob(pattern).match(subpath));
+}
+
+/**
+ * Bunup CLI exclusion patterns — entry files matching these are excluded
+ * from the generated exports map (they are bin entrypoints, not library exports).
+ */
+const CLI_EXCLUSION_PATTERNS = [
+	"**/cli.ts",
+	"**/cli/index.ts",
+	"**/bin.ts",
+	"**/bin/index.ts",
+] as const;
+
+/** Check if a source entry is a CLI entrypoint per bunup convention */
+function isCliEntrypoint(entry: string): boolean {
+	return CLI_EXCLUSION_PATTERNS.some((pattern) =>
+		new Bun.Glob(pattern).match(entry),
+	);
+}
+
+/** Build a standard bunup export entry from a source entry path */
+function buildExportValue(entry: string): {
+	import: { types: string; default: string };
+} {
+	// Strip src/ prefix and .ts extension, keep directory structure
+	const distPath = entry.replace(/^src\//, "").replace(/\.[cm]?[jt]sx?$/, "");
+	return {
+		import: {
+			types: `./dist/${distPath}.d.ts`,
+			default: `./dist/${distPath}.js`,
+		},
+	};
+}
+
+/** Discover source entry files for a workspace package */
+function discoverEntries(packageRoot: string): string[] {
+	const glob = new Bun.Glob("src/**/*.ts");
+	const entries: string[] = [];
+
+	for (const match of glob.scanSync({ cwd: packageRoot, dot: false })) {
+		if (match.includes("__tests__") || match.endsWith(".test.ts")) {
+			continue;
+		}
+		entries.push(match);
+	}
+
+	return entries.sort();
+}
+
+/**
+ * Add config file exports derived from the `files` array in package.json.
+ *
+ * Replicates the logic from `scripts/sync-exports.ts`: config files
+ * (json, jsonc, yml, yaml, toml) get two exports each — a full-filename
+ * export and a short alias without the extension/preset suffix.
+ */
+function addConfigFileExports(
+	expected: ExportMap,
+	pkg: { files?: string[] },
+): void {
+	const CONFIG_RE = /\.(json|jsonc|yml|yaml|toml)$/;
+
+	const configFiles = (pkg.files ?? []).filter(
+		(file) => CONFIG_RE.test(file) && file !== "package.json",
+	);
+
+	for (const file of configFiles) {
+		// Full filename export
+		expected[`./${file}`] = `./${file}`;
+
+		// Short alias: strip extension, normalize .preset.variant -> name-variant
+		let base = file.replace(CONFIG_RE, "");
+		const match = base.match(/^(.+)\.preset(?:\.(.+))?$/);
+		if (match?.[1]) {
+			base = match[2] ? `${match[1]}-${match[2]}` : match[1];
+		}
+		if (base !== file) {
+			expected[`./${base}`] = `./${file}`;
+		}
+	}
+}
+
+/** Compute expected exports for a workspace package */
+function computeExpectedExports(
+	packageRoot: string,
+	workspace: WorkspaceEntry,
+	pkg: { files?: string[] },
+): ExportMap {
+	const entries = discoverEntries(packageRoot);
+	const exportsConfig =
+		typeof workspace.config?.exports === "object"
+			? workspace.config.exports
+			: undefined;
+
+	const excludes: readonly string[] = exportsConfig?.exclude ?? [];
+	const customExports: Readonly<Record<string, string>> =
+		exportsConfig?.customExports ?? {};
+
+	const expected: ExportMap = {};
+
+	// Source-derived exports
+	// Track subpath -> entry mapping to resolve conflicts:
+	// When both foo.ts and foo/index.ts exist, bunup prefers foo.ts
+	const subpathEntries = new Map<string, string>();
+	for (const entry of entries) {
+		// Skip CLI entrypoints (bunup excludes these by default)
+		if (isCliEntrypoint(entry)) continue;
+
+		const subpath = entryToSubpath(entry);
+		// Skip user-configured exclusions
+		if (matchesExclude(subpath, excludes)) continue;
+
+		const existing = subpathEntries.get(subpath);
+		if (existing) {
+			// Prefer direct file (foo.ts) over directory index (foo/index.ts)
+			if (!existing.endsWith("/index.ts") && entry.endsWith("/index.ts")) {
+				continue;
+			}
+		}
+		subpathEntries.set(subpath, entry);
+	}
+
+	for (const [subpath, entry] of subpathEntries) {
+		expected[subpath] = buildExportValue(entry);
+	}
+
+	// Custom static exports from bunup config
+	for (const [key, value] of Object.entries(customExports)) {
+		expected[`./${key.replace(/^\.\//, "")}`] = value;
+	}
+
+	// Config file exports from the files array (sync-exports convention)
+	addConfigFileExports(expected, pkg);
+
+	// Bunup always includes ./package.json
+	expected["./package.json"] = "./package.json";
+
+	return expected;
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const COLORS = {
+	reset: "\x1b[0m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	blue: "\x1b[34m",
+	dim: "\x1b[2m",
+};
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface CheckExportsOptions {
+	readonly json?: boolean;
+}
+
+/**
+ * Run check-exports across all workspace packages.
+ *
+ * Reads the bunup workspace config to discover packages and their export
+ * settings, then compares expected vs actual exports in each package.json.
+ */
+export async function runCheckExports(
+	options: CheckExportsOptions = {},
+): Promise<void> {
+	const cwd = process.cwd();
+	const configPath = resolve(cwd, "bunup.config.ts");
+
+	let workspaces: WorkspaceEntry[];
+	try {
+		const configModule = await import(configPath);
+		const rawConfig: unknown = configModule.default;
+		if (!Array.isArray(rawConfig)) {
+			process.stderr.write("bunup.config.ts must export a workspace array\n");
+			process.exit(1);
+		}
+		workspaces = rawConfig as WorkspaceEntry[];
+	} catch {
+		process.stderr.write(`Could not load bunup.config.ts from ${cwd}\n`);
+		process.exit(1);
+	}
+
+	const results: PackageResult[] = [];
+
+	for (const workspace of workspaces) {
+		const packageRoot = resolve(cwd, workspace.root);
+		const pkgPath = resolve(packageRoot, "package.json");
+
+		let pkg: { name?: string; exports?: ExportMap; files?: string[] };
+		try {
+			pkg = await Bun.file(pkgPath).json();
+		} catch {
+			results.push({ name: workspace.name, status: "ok" });
+			continue;
+		}
+
+		const actual: ExportMap =
+			typeof pkg.exports === "object" && pkg.exports !== null
+				? (pkg.exports as ExportMap)
+				: {};
+		const expected = computeExpectedExports(packageRoot, workspace, pkg);
+
+		results.push(
+			compareExports({
+				name: workspace.name,
+				actual,
+				expected,
+				path: workspace.root,
+			}),
+		);
+	}
+
+	const checkResult: CheckResult = {
+		ok: results.every((r) => r.status === "ok"),
+		packages: results,
+	};
+
+	if (options.json) {
+		process.stdout.write(`${JSON.stringify(checkResult, null, 2)}\n`);
+	} else {
+		const drifted = results.filter((r) => r.status === "drift");
+
+		if (drifted.length === 0) {
+			process.stdout.write(
+				`${COLORS.green}All ${results.length} packages have exports in sync.${COLORS.reset}\n`,
+			);
+		} else {
+			process.stderr.write(
+				`${COLORS.red}Export drift detected in ${drifted.length} package(s):${COLORS.reset}\n\n`,
+			);
+
+			for (const result of drifted) {
+				const drift = result.drift;
+				if (!drift) continue;
+
+				process.stderr.write(
+					`  ${COLORS.yellow}${result.name}${COLORS.reset} ${COLORS.dim}(${drift.path})${COLORS.reset}\n`,
+				);
+
+				for (const key of drift.added) {
+					process.stderr.write(
+						`    ${COLORS.green}+ ${key}${COLORS.reset}  ${COLORS.dim}(missing from package.json)${COLORS.reset}\n`,
+					);
+				}
+				for (const key of drift.removed) {
+					process.stderr.write(
+						`    ${COLORS.red}- ${key}${COLORS.reset}  ${COLORS.dim}(not in source)${COLORS.reset}\n`,
+					);
+				}
+				for (const entry of drift.changed) {
+					process.stderr.write(
+						`    ${COLORS.yellow}~ ${entry.key}${COLORS.reset}  ${COLORS.dim}(value mismatch)${COLORS.reset}\n`,
+					);
+				}
+				process.stderr.write("\n");
+			}
+
+			process.stderr.write(
+				`Run ${COLORS.blue}bun run build${COLORS.reset} to regenerate exports.\n`,
+			);
+		}
+	}
+
+	process.exit(checkResult.ok ? 0 : 1);
+}

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -10,6 +10,7 @@
 import { Command } from "commander";
 import { VERSION } from "../version.js";
 import { runCheck } from "./check.js";
+import { runCheckExports } from "./check-exports.js";
 import { runFix } from "./fix.js";
 import { runInit } from "./init.js";
 import { runPrePush } from "./pre-push.js";
@@ -62,6 +63,14 @@ program
 	.option("-f, --force", "Skip strict verification entirely")
 	.action(async (options: { force?: boolean }) => {
 		await runPrePush(options);
+	});
+
+program
+	.command("check-exports")
+	.description("Validate package.json exports match source entry points")
+	.option("--json", "Output results as JSON")
+	.action(async (options: { json?: boolean }) => {
+		await runCheckExports(options);
 	});
 
 program.parse();


### PR DESCRIPTION
## Summary

Adds a `check-exports` command to `@outfitter/tooling` that validates each workspace package's `package.json#exports` are in sync with what bunup would generate from source files.

- Deterministic output with sorted keys and stable ordering
- Machine-readable `--json` flag for agent consumption
- Exits non-zero on drift, zero when in sync
- No file mutation — read-only check mode

### Core design

Pure functions (`entryToSubpath`, `compareExports`) are extracted for testability. The CLI runner handles filesystem discovery, bunup config loading, and output formatting.

Drift categories:
- **`+` added** — source file exists but `package.json` is missing the export
- **`-` removed** — `package.json` has an export with no corresponding source
- **`~` changed** — both exist but the export value differs

## Test plan

- [x] 13 unit tests covering `entryToSubpath` and `compareExports` pure functions
- [x] Validates against real monorepo (11 packages checked)
- [x] `verify:ci` green

Closes OS-157

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)