### PR TITLE
feat(tooling): apply intentional export-surface policy

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -84,6 +84,13 @@ export default defineWorkspace(
     {
       name: "@outfitter/types",
       root: "packages/types",
+      // Prevent future internal utilities from leaking into the public API.
+      // All current source files are intentional exports.
+      config: {
+        exports: {
+          exclude: ["./internal", "./internal/*"],
+        },
+      },
     },
     {
       name: "@outfitter/agents",
@@ -92,6 +99,13 @@ export default defineWorkspace(
     {
       name: "@outfitter/contracts",
       root: "packages/contracts",
+      // Prevent future internal utilities from leaking into the public API.
+      // All current source files (including assert/ and result/) are intentional exports.
+      config: {
+        exports: {
+          exclude: ["./internal", "./internal/*"],
+        },
+      },
     },
     {
       name: "@outfitter/config",
@@ -146,9 +160,20 @@ export default defineWorkspace(
     {
       name: "@outfitter/tooling",
       root: "packages/tooling",
-      // Preserve static config file exports (not in src/)
+      // CLI scripts and internal registry modules are not public API.
+      // Public surface: ".", "./cli/check", "./cli/fix", "./cli/init", "./registry"
       config: {
         exports: {
+          exclude: [
+            "./cli/check-clean-tree",
+            "./cli/check-exports",
+            "./cli/check-readme-imports",
+            "./cli/pre-push",
+            "./cli/upgrade-bun",
+            "./registry/build",
+            "./registry/schema",
+            "./version",
+          ],
           customExports: {
             "./biome.json": "./biome.json",
             "./tsconfig.preset.json": "./tsconfig.preset.json",
@@ -161,6 +186,13 @@ export default defineWorkspace(
     {
       name: "outfitter",
       root: "apps/outfitter",
+      // Prevent internal utilities from leaking into the public API.
+      // Current exports cover all command, engine, and create subpaths.
+      config: {
+        exports: {
+          exclude: ["./internal/*", "./output-mode"],
+        },
+      },
     },
   ],
   {

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -48,8 +48,8 @@
 		"./package.json": "./package.json",
 		"./registry": {
 			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
+				"types": "./dist/registry/index.d.ts",
+				"default": "./dist/registry/index.js"
 			}
 		},
 		"./tsconfig": "./tsconfig.preset.json",


### PR DESCRIPTION
## Summary

Adds `exports.exclude` patterns to `bunup.config.ts` so new internal source files don't silently widen the public API.

### Changes by package

| Package | Change | Risk level |
|---------|--------|-----------|
| `@outfitter/tooling` | Exclude 8 CLI scripts and internal modules | High (48 exports) |
| `@outfitter/contracts` | Guard `./internal/*` | Medium (15 exports) |
| `@outfitter/types` | Guard `./internal/*` | Medium (8 exports) |
| `outfitter` (app) | Guard `./internal/*`, `./output-mode` | Medium |

Seven packages left unchanged — already protected or low risk (2-5 exports).

Also fixes a pre-existing bug: `@outfitter/tooling`'s `./registry` export incorrectly pointed to `./dist/index.d.ts` (root) instead of `./dist/registry/index.d.ts`.

## Test plan

- [x] `check-exports` reports all 11 packages in sync
- [x] Full tooling test suite passes (123 tests)
- [x] `verify:ci` green

Closes OS-159

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)