### PR TITLE
feat(tooling): add clean-tree invariant to verify:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   ],
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
-    "verify:ci": "bun run typecheck && bun run check && bun run docs:check:ci && bun run build && bun run test",
+    "verify:ci": "bun run typecheck && bun run check && bun run docs:check:ci && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run test",
+    "check-exports": "bun run packages/tooling/src/cli/index.ts check-exports",
+    "check-readme-imports": "bun run packages/tooling/src/cli/index.ts check-readme-imports",
+    "check-clean-tree": "bun run packages/tooling/src/cli/index.ts check-clean-tree",
     "build": "bunup && bun scripts/normalize-exports.ts",
     "build:local": "bunup && bun scripts/normalize-exports.ts && cd apps/outfitter && bun link",
     "build:turbo": "turbo run build",

--- a/packages/tooling/src/__tests__/check-clean-tree.test.ts
+++ b/packages/tooling/src/__tests__/check-clean-tree.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isCleanTree,
+	parseGitDiff,
+	parseUntrackedFiles,
+	type TreeStatus,
+} from "../cli/check-clean-tree.js";
+
+describe("parseGitDiff", () => {
+	test("returns empty array for empty output", () => {
+		expect(parseGitDiff("")).toEqual([]);
+	});
+
+	test("returns empty array for whitespace-only output", () => {
+		expect(parseGitDiff("  \n  \n")).toEqual([]);
+	});
+
+	test("parses single modified file", () => {
+		expect(parseGitDiff("packages/cli/dist/index.js\n")).toEqual([
+			"packages/cli/dist/index.js",
+		]);
+	});
+
+	test("parses multiple modified files", () => {
+		const output = [
+			"packages/cli/dist/index.js",
+			"packages/types/dist/branded.d.ts",
+			"docs/llms.txt",
+		].join("\n");
+
+		expect(parseGitDiff(output)).toEqual([
+			"packages/cli/dist/index.js",
+			"packages/types/dist/branded.d.ts",
+			"docs/llms.txt",
+		]);
+	});
+
+	test("trims whitespace from file paths", () => {
+		expect(parseGitDiff("  foo.ts  \n  bar.ts  \n")).toEqual([
+			"foo.ts",
+			"bar.ts",
+		]);
+	});
+});
+
+describe("parseUntrackedFiles", () => {
+	test("returns empty array for empty output", () => {
+		expect(parseUntrackedFiles("")).toEqual([]);
+	});
+
+	test("returns empty array for whitespace-only output", () => {
+		expect(parseUntrackedFiles("  \n  \n")).toEqual([]);
+	});
+
+	test("parses single untracked file", () => {
+		expect(parseUntrackedFiles("dist/new-file.js\n")).toEqual([
+			"dist/new-file.js",
+		]);
+	});
+
+	test("parses multiple untracked files", () => {
+		const output = ["dist/new-file.js", "packages/cli/dist/foo.js"].join("\n");
+
+		expect(parseUntrackedFiles(output)).toEqual([
+			"dist/new-file.js",
+			"packages/cli/dist/foo.js",
+		]);
+	});
+});
+
+describe("isCleanTree", () => {
+	test("returns true when no modified or untracked files", () => {
+		const status: TreeStatus = {
+			clean: true,
+			modified: [],
+			untracked: [],
+		};
+		expect(isCleanTree(status)).toBe(true);
+	});
+
+	test("returns false when modified files exist", () => {
+		const status: TreeStatus = {
+			clean: false,
+			modified: ["packages/cli/dist/index.js"],
+			untracked: [],
+		};
+		expect(isCleanTree(status)).toBe(false);
+	});
+
+	test("returns false when untracked files exist", () => {
+		const status: TreeStatus = {
+			clean: false,
+			modified: [],
+			untracked: ["dist/new-file.js"],
+		};
+		expect(isCleanTree(status)).toBe(false);
+	});
+
+	test("returns false when both modified and untracked files exist", () => {
+		const status: TreeStatus = {
+			clean: false,
+			modified: ["packages/cli/dist/index.js"],
+			untracked: ["dist/new-file.js"],
+		};
+		expect(isCleanTree(status)).toBe(false);
+	});
+});

--- a/packages/tooling/src/cli/check-clean-tree.ts
+++ b/packages/tooling/src/cli/check-clean-tree.ts
@@ -1,0 +1,137 @@
+/**
+ * Check-clean-tree command — asserts the working tree has no modified or untracked files.
+ *
+ * Pure core functions for parsing git output and determining tree cleanliness.
+ * The CLI runner in {@link runCheckCleanTree} handles git invocation and output.
+ *
+ * @packageDocumentation
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Status of the working tree after verification steps */
+export interface TreeStatus {
+	readonly clean: boolean;
+	readonly modified: string[];
+	readonly untracked: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `git diff --name-only` output into a list of modified file paths.
+ */
+export function parseGitDiff(diffOutput: string): string[] {
+	return diffOutput
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Parse `git ls-files --others --exclude-standard` output into a list of untracked file paths.
+ */
+export function parseUntrackedFiles(lsOutput: string): string[] {
+	return lsOutput
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Determine if the tree status represents a clean working tree.
+ */
+export function isCleanTree(status: TreeStatus): boolean {
+	return status.modified.length === 0 && status.untracked.length === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const COLORS = {
+	reset: "\x1b[0m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	dim: "\x1b[2m",
+};
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface CheckCleanTreeOptions {
+	readonly paths?: string[];
+}
+
+/**
+ * Run clean-tree check against the current working directory.
+ *
+ * Exits 0 if clean, 1 if dirty files are found.
+ */
+export async function runCheckCleanTree(
+	options: CheckCleanTreeOptions = {},
+): Promise<void> {
+	const pathArgs = options.paths ?? [];
+
+	// Find modified tracked files (HEAD catches both staged and unstaged)
+	const diffResult = Bun.spawnSync(
+		["git", "diff", "HEAD", "--name-only", "--", ...pathArgs],
+		{ stderr: "pipe" },
+	);
+	if (diffResult.exitCode !== 0) {
+		process.stderr.write("Failed to run git diff\n");
+		process.exit(1);
+	}
+	const modified = parseGitDiff(diffResult.stdout.toString());
+
+	// Find new untracked files
+	const lsResult = Bun.spawnSync(
+		["git", "ls-files", "--others", "--exclude-standard", "--", ...pathArgs],
+		{ stderr: "pipe" },
+	);
+	if (lsResult.exitCode !== 0) {
+		process.stderr.write("Failed to run git ls-files\n");
+		process.exit(1);
+	}
+	const untracked = parseUntrackedFiles(lsResult.stdout.toString());
+
+	const clean = modified.length === 0 && untracked.length === 0;
+	const status: TreeStatus = { clean, modified, untracked };
+
+	if (status.clean) {
+		process.stdout.write(
+			`${COLORS.green}Working tree is clean.${COLORS.reset}\n`,
+		);
+		process.exit(0);
+	}
+
+	process.stderr.write(
+		`${COLORS.red}Working tree is dirty after verification:${COLORS.reset}\n\n`,
+	);
+
+	if (modified.length > 0) {
+		process.stderr.write("Modified files:\n");
+		for (const file of modified) {
+			process.stderr.write(`  ${COLORS.dim}M${COLORS.reset} ${file}\n`);
+		}
+	}
+
+	if (untracked.length > 0) {
+		process.stderr.write("Untracked files:\n");
+		for (const file of untracked) {
+			process.stderr.write(`  ${COLORS.dim}?${COLORS.reset} ${file}\n`);
+		}
+	}
+
+	process.stderr.write(
+		"\nThis likely means a build step produced uncommitted changes.\n",
+	);
+	process.stderr.write("Commit these changes or add them to .gitignore.\n");
+
+	process.exit(1);
+}

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -10,6 +10,7 @@
 import { Command } from "commander";
 import { VERSION } from "../version.js";
 import { runCheck } from "./check.js";
+import { runCheckCleanTree } from "./check-clean-tree.js";
 import { runCheckExports } from "./check-exports.js";
 import { runFix } from "./fix.js";
 import { runInit } from "./init.js";
@@ -71,6 +72,14 @@ program
 	.option("--json", "Output results as JSON")
 	.action(async (options: { json?: boolean }) => {
 		await runCheckExports(options);
+	});
+
+program
+	.command("check-clean-tree")
+	.description("Assert working tree is clean (no modified or untracked files)")
+	.option("--paths <paths...>", "Limit check to specific paths")
+	.action(async (options: { paths?: string[] }) => {
+		await runCheckCleanTree(options);
 	});
 
 program.parse();


### PR DESCRIPTION
## Summary

Adds a `check-clean-tree` command that asserts no tracked files were modified by verification/build steps. Wired into `verify:ci` after `build` and before `test`.

```
typecheck → lint → docs-check → build → check-clean-tree → test
```

This closes the gap where verification could pass while leaving local drift (e.g., stale `package.json#exports` after build).

### Design

- Pure functions (`parseGitDiff`, `parseUntrackedFiles`, `isCleanTree`) for testability
- `--paths` option to limit check to specific directories
- Clear failure messages listing which files changed
- Same behavior locally (pre-push) and in CI

## Test plan

- [x] 13 unit tests covering all parsing and assertion functions
- [x] Command registered and working via CLI
- [x] `verify:ci` green (includes the new check)

Closes OS-158

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)