### PR TITLE
feat(tooling): add README subpath contract linting

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5147,12 +5147,12 @@ Import specific modules directly for smaller bundles:
 ```typescript
 // Just fixtures
 import { createFixture, withTempDir, withEnv } from "@outfitter/testing/fixtures";
+```
 
-// Just CLI harness
-import { createCliHarness } from "@outfitter/testing/cli-harness";
+All harness utilities are available from the main package export:
 
-// Just MCP harness
-import { createMcpHarness } from "@outfitter/testing/mcp-harness";
+```typescript
+import { createCliHarness, createMcpHarness } from "@outfitter/testing";
 ```
 
 ## API Reference

--- a/docs/packages/testing/README.md
+++ b/docs/packages/testing/README.md
@@ -261,12 +261,12 @@ Import specific modules directly for smaller bundles:
 ```typescript
 // Just fixtures
 import { createFixture, withTempDir, withEnv } from "@outfitter/testing/fixtures";
+```
 
-// Just CLI harness
-import { createCliHarness } from "@outfitter/testing/cli-harness";
+All harness utilities are available from the main package export:
 
-// Just MCP harness
-import { createMcpHarness } from "@outfitter/testing/mcp-harness";
+```typescript
+import { createCliHarness, createMcpHarness } from "@outfitter/testing";
 ```
 
 ## API Reference

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -261,12 +261,12 @@ Import specific modules directly for smaller bundles:
 ```typescript
 // Just fixtures
 import { createFixture, withTempDir, withEnv } from "@outfitter/testing/fixtures";
+```
 
-// Just CLI harness
-import { createCliHarness } from "@outfitter/testing/cli-harness";
+All harness utilities are available from the main package export:
 
-// Just MCP harness
-import { createMcpHarness } from "@outfitter/testing/mcp-harness";
+```typescript
+import { createCliHarness, createMcpHarness } from "@outfitter/testing";
 ```
 
 ## API Reference

--- a/packages/tooling/src/__tests__/check-readme-imports.test.ts
+++ b/packages/tooling/src/__tests__/check-readme-imports.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type ExportMap,
+	extractImports,
+	isExportedSubpath,
+	parseSpecifier,
+} from "../cli/check-readme-imports.js";
+
+// ---------------------------------------------------------------------------
+// parseSpecifier
+// ---------------------------------------------------------------------------
+
+describe("parseSpecifier", () => {
+	test("parses root import with no subpath", () => {
+		expect(parseSpecifier("@outfitter/contracts")).toEqual({
+			packageName: "@outfitter/contracts",
+			subpath: ".",
+		});
+	});
+
+	test("parses single-level subpath", () => {
+		expect(parseSpecifier("@outfitter/cli/output")).toEqual({
+			packageName: "@outfitter/cli",
+			subpath: "./output",
+		});
+	});
+
+	test("parses deep subpath", () => {
+		expect(parseSpecifier("@outfitter/cli/preset/standard")).toEqual({
+			packageName: "@outfitter/cli",
+			subpath: "./preset/standard",
+		});
+	});
+
+	test("returns null for non-scoped packages", () => {
+		expect(parseSpecifier("commander")).toBeNull();
+	});
+
+	test("returns null for non-@outfitter scoped packages", () => {
+		expect(parseSpecifier("@types/node")).toBeNull();
+	});
+
+	test("parses @outfitter/mcp/types", () => {
+		expect(parseSpecifier("@outfitter/mcp/types")).toEqual({
+			packageName: "@outfitter/mcp",
+			subpath: "./types",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractImports
+// ---------------------------------------------------------------------------
+
+describe("extractImports", () => {
+	test("extracts imports from typescript code blocks", () => {
+		const markdown = [
+			"# Example",
+			"",
+			"```typescript",
+			'import { output } from "@outfitter/cli/output";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			packageName: "@outfitter/cli",
+			subpath: "./output",
+			fullSpecifier: "@outfitter/cli/output",
+			file: "README.md",
+		});
+	});
+
+	test("extracts type imports", () => {
+		const markdown = [
+			"```ts",
+			'import type { OutputMode } from "@outfitter/cli/output";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(1);
+		expect(results[0]?.fullSpecifier).toBe("@outfitter/cli/output");
+	});
+
+	test("extracts multiple imports from a single code block", () => {
+		const markdown = [
+			"```typescript",
+			'import { output } from "@outfitter/cli/output";',
+			'import { collectIds } from "@outfitter/cli/input";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(2);
+	});
+
+	test("ignores imports outside code blocks", () => {
+		const markdown = [
+			'import { output } from "@outfitter/cli/output";',
+			"",
+			"This is just prose mentioning @outfitter/cli.",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(0);
+	});
+
+	test("ignores non-@outfitter imports in code blocks", () => {
+		const markdown = [
+			"```typescript",
+			'import { z } from "zod";',
+			'import { Command } from "commander";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(0);
+	});
+
+	test("tracks line numbers accurately", () => {
+		const markdown = [
+			"# Title", // line 1
+			"", // line 2
+			"Some text.", // line 3
+			"", // line 4
+			"```typescript", // line 5
+			'import { output } from "@outfitter/cli/output";', // line 6
+			"```", // line 7
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(1);
+		expect(results[0]?.line).toBe(6);
+	});
+
+	test("handles js and javascript code blocks", () => {
+		const markdown = [
+			"```js",
+			'import { output } from "@outfitter/cli/output";',
+			"```",
+			"",
+			"```javascript",
+			'import { collectIds } from "@outfitter/cli/input";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(2);
+	});
+
+	test("deduplicates identical specifiers from the same file", () => {
+		const markdown = [
+			"```typescript",
+			'import { output } from "@outfitter/cli/output";',
+			"```",
+			"",
+			"```typescript",
+			'import { output, exitWithError } from "@outfitter/cli/output";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(1);
+	});
+
+	test("skips code blocks marked with non-contractual comment", () => {
+		const markdown = [
+			"<!-- non-contractual -->",
+			"```typescript",
+			'import { internal } from "@outfitter/cli/internal";',
+			"```",
+		].join("\n");
+
+		const results = extractImports(markdown, "README.md");
+		expect(results).toHaveLength(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isExportedSubpath
+// ---------------------------------------------------------------------------
+
+describe("isExportedSubpath", () => {
+	const sampleExports: ExportMap = {
+		".": {
+			import: {
+				types: "./dist/index.d.ts",
+				default: "./dist/index.js",
+			},
+		},
+		"./output": {
+			import: {
+				types: "./dist/output.d.ts",
+				default: "./dist/output.js",
+			},
+		},
+		"./package.json": "./package.json",
+	};
+
+	test("returns true for root subpath when . exists", () => {
+		expect(isExportedSubpath(".", sampleExports)).toBe(true);
+	});
+
+	test("returns true for existing subpath", () => {
+		expect(isExportedSubpath("./output", sampleExports)).toBe(true);
+	});
+
+	test("returns false for non-existent subpath", () => {
+		expect(isExportedSubpath("./missing", sampleExports)).toBe(false);
+	});
+
+	test("returns true for ./package.json", () => {
+		expect(isExportedSubpath("./package.json", sampleExports)).toBe(true);
+	});
+
+	test("returns false for empty exports", () => {
+		expect(isExportedSubpath(".", {})).toBe(false);
+	});
+});

--- a/packages/tooling/src/cli/check-readme-imports.ts
+++ b/packages/tooling/src/cli/check-readme-imports.ts
@@ -1,0 +1,326 @@
+/**
+ * Check-readme-imports command — validates README import examples against package.json exports.
+ *
+ * Pure core functions for extracting and validating import specifiers from
+ * markdown code blocks. The CLI runner in {@link runCheckReadmeImports}
+ * handles filesystem discovery and output.
+ *
+ * @packageDocumentation
+ */
+
+import { resolve } from "node:path";
+import type { ExportMap } from "./check-exports.js";
+
+export type { ExportMap };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** An import example extracted from a markdown code block */
+export interface ImportExample {
+	/** Package name, e.g. "@outfitter/cli" */
+	readonly packageName: string;
+	/** Export subpath, e.g. "./output" or "." */
+	readonly subpath: string;
+	/** Full import specifier, e.g. "@outfitter/cli/output" */
+	readonly fullSpecifier: string;
+	/** File where the import was found */
+	readonly file: string;
+	/** 1-based line number */
+	readonly line: number;
+}
+
+/** Result of checking imports in a single file */
+export interface ImportCheckResult {
+	readonly file: string;
+	readonly valid: ImportExample[];
+	readonly invalid: ImportExample[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a full import specifier into package name and subpath.
+ *
+ * Only recognizes `@outfitter/*` scoped packages.
+ *
+ * @example
+ * parseSpecifier("@outfitter/cli/output")
+ * // { packageName: "@outfitter/cli", subpath: "./output" }
+ *
+ * parseSpecifier("@outfitter/contracts")
+ * // { packageName: "@outfitter/contracts", subpath: "." }
+ */
+export function parseSpecifier(
+	specifier: string,
+): { packageName: string; subpath: string } | null {
+	if (!specifier.startsWith("@outfitter/")) {
+		return null;
+	}
+
+	// @outfitter/cli/output -> ["@outfitter", "cli", "output"]
+	const parts = specifier.split("/");
+	if (parts.length < 2) {
+		return null;
+	}
+
+	const packageName = `${parts[0]}/${parts[1]}`;
+	const rest = parts.slice(2);
+
+	if (rest.length === 0) {
+		return { packageName, subpath: "." };
+	}
+
+	return { packageName, subpath: `./${rest.join("/")}` };
+}
+
+/**
+ * Extract import specifiers from markdown content.
+ *
+ * Only extracts imports from fenced code blocks (typescript, ts,
+ * javascript, js). Skips blocks preceded by a non-contractual HTML comment.
+ * Deduplicates by full specifier within a single file.
+ */
+export function extractImports(content: string, file: string): ImportExample[] {
+	const lines = content.split("\n");
+	const results: ImportExample[] = [];
+	const seen = new Set<string>();
+
+	const CODE_FENCE_OPEN = /^```(?:typescript|ts|javascript|js)\s*$/;
+	const CODE_FENCE_CLOSE = /^```\s*$/;
+	const IMPORT_RE = /from\s+["'](@outfitter\/[^"']+)["']/;
+	const NON_CONTRACTUAL = /<!--\s*non-contractual\s*-->/;
+
+	let inCodeBlock = false;
+	let skipBlock = false;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] as string;
+
+		if (!inCodeBlock) {
+			if (CODE_FENCE_OPEN.test(line)) {
+				inCodeBlock = true;
+				// Check if previous non-empty line is the non-contractual marker
+				skipBlock = false;
+				for (let j = i - 1; j >= 0; j--) {
+					const prev = (lines[j] as string).trim();
+					if (prev === "") continue;
+					if (NON_CONTRACTUAL.test(prev)) {
+						skipBlock = true;
+					}
+					break;
+				}
+			}
+			continue;
+		}
+
+		// Inside a code block
+		if (CODE_FENCE_CLOSE.test(line) && !CODE_FENCE_OPEN.test(line)) {
+			inCodeBlock = false;
+			skipBlock = false;
+			continue;
+		}
+
+		if (skipBlock) continue;
+
+		const match = IMPORT_RE.exec(line);
+		if (!match?.[1]) continue;
+
+		const fullSpecifier = match[1];
+		if (seen.has(fullSpecifier)) continue;
+		seen.add(fullSpecifier);
+
+		const parsed = parseSpecifier(fullSpecifier);
+		if (!parsed) continue;
+
+		results.push({
+			packageName: parsed.packageName,
+			subpath: parsed.subpath,
+			fullSpecifier,
+			file,
+			line: i + 1, // 1-based
+		});
+	}
+
+	return results;
+}
+
+/**
+ * Check whether a subpath exists in a package.json export map.
+ */
+export function isExportedSubpath(
+	subpath: string,
+	exports: ExportMap,
+): boolean {
+	return subpath in exports;
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const COLORS = {
+	reset: "\x1b[0m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	blue: "\x1b[34m",
+	dim: "\x1b[2m",
+};
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface CheckReadmeImportsOptions {
+	readonly json?: boolean;
+}
+
+/**
+ * Run check-readme-imports across all workspace packages.
+ *
+ * Finds README.md files in `packages/` and `docs/packages/`, extracts
+ * import examples, and validates each subpath against the corresponding
+ * package.json exports.
+ */
+export async function runCheckReadmeImports(
+	options: CheckReadmeImportsOptions = {},
+): Promise<void> {
+	const cwd = process.cwd();
+
+	// Discover README files
+	const readmeGlob = new Bun.Glob("**/README.md");
+	const readmeDirs = ["packages", "docs/packages"];
+	const readmePaths: string[] = [];
+
+	for (const dir of readmeDirs) {
+		const fullDir = resolve(cwd, dir);
+		try {
+			for (const match of readmeGlob.scanSync({ cwd: fullDir, dot: false })) {
+				// Only top-level READMEs in each package dir (depth 1)
+				const segments = match.split("/");
+				if (segments.length === 2 && segments[1] === "README.md") {
+					readmePaths.push(resolve(fullDir, match));
+				}
+			}
+		} catch {
+			// Directory may not exist
+		}
+	}
+
+	if (readmePaths.length === 0) {
+		process.stdout.write("No README.md files found.\n");
+		return;
+	}
+
+	// Cache loaded package.json exports
+	const exportsCache = new Map<string, ExportMap>();
+
+	async function getExportsForPackage(
+		packageName: string,
+	): Promise<ExportMap | null> {
+		if (exportsCache.has(packageName)) {
+			return exportsCache.get(packageName) ?? null;
+		}
+
+		// Derive package dir from name: @outfitter/cli -> packages/cli
+		const shortName = packageName.replace("@outfitter/", "");
+		const pkgPath = resolve(cwd, "packages", shortName, "package.json");
+
+		try {
+			const pkg: { exports?: ExportMap } = await Bun.file(pkgPath).json();
+			const exports =
+				typeof pkg.exports === "object" && pkg.exports !== null
+					? pkg.exports
+					: {};
+			exportsCache.set(packageName, exports);
+			return exports;
+		} catch {
+			return null;
+		}
+	}
+
+	const results: ImportCheckResult[] = [];
+	let hasInvalid = false;
+
+	for (const readmePath of readmePaths.sort()) {
+		const content = await Bun.file(readmePath).text();
+		const relativePath = readmePath.replace(`${cwd}/`, "");
+		const imports = extractImports(content, relativePath);
+
+		if (imports.length === 0) continue;
+
+		const valid: ImportExample[] = [];
+		const invalid: ImportExample[] = [];
+
+		for (const imp of imports) {
+			const exports = await getExportsForPackage(imp.packageName);
+			if (exports === null) {
+				// Package not found in workspace — treat as invalid
+				invalid.push(imp);
+				continue;
+			}
+
+			if (isExportedSubpath(imp.subpath, exports)) {
+				valid.push(imp);
+			} else {
+				invalid.push(imp);
+			}
+		}
+
+		if (valid.length > 0 || invalid.length > 0) {
+			results.push({ file: relativePath, valid, invalid });
+		}
+
+		if (invalid.length > 0) {
+			hasInvalid = true;
+		}
+	}
+
+	// Output
+	if (options.json) {
+		const output = {
+			ok: !hasInvalid,
+			files: results,
+		};
+		process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+	} else {
+		const totalValid = results.reduce((n, r) => n + r.valid.length, 0);
+		const totalInvalid = results.reduce((n, r) => n + r.invalid.length, 0);
+
+		if (!hasInvalid) {
+			process.stdout.write(
+				`${COLORS.green}All ${totalValid} README import examples match package exports.${COLORS.reset}\n`,
+			);
+		} else {
+			process.stderr.write(
+				`${COLORS.red}Invalid README import examples found:${COLORS.reset}\n\n`,
+			);
+
+			for (const result of results) {
+				if (result.invalid.length === 0) continue;
+
+				process.stderr.write(
+					`  ${COLORS.yellow}${result.file}${COLORS.reset}\n`,
+				);
+
+				for (const imp of result.invalid) {
+					process.stderr.write(
+						`    ${COLORS.red}line ${imp.line}:${COLORS.reset} ${imp.fullSpecifier}  ${COLORS.dim}(subpath ${imp.subpath} not in ${imp.packageName} exports)${COLORS.reset}\n`,
+					);
+				}
+
+				process.stderr.write("\n");
+			}
+
+			process.stderr.write(
+				`${totalInvalid} invalid, ${totalValid} valid across ${results.length} file(s).\n`,
+			);
+		}
+	}
+
+	process.exit(hasInvalid ? 1 : 0);
+}

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -82,4 +82,13 @@ program
 		await runCheckCleanTree(options);
 	});
 
+program
+	.command("check-readme-imports")
+	.description("Validate README import examples match package exports")
+	.option("--json", "Output results as JSON")
+	.action(async (options: { json?: boolean }) => {
+		const { runCheckReadmeImports } = await import("./check-readme-imports.js");
+		await runCheckReadmeImports(options);
+	});
+
 program.parse();


### PR DESCRIPTION
## Summary

Adds a `check-readme-imports` command that validates import examples in README files reference actually-exported subpaths. README examples are treated as contractual unless explicitly marked otherwise.

### How it works

1. Scans `packages/*/README.md` and `docs/packages/*/README.md`
2. Extracts `from "@outfitter/..."` imports from fenced code blocks
3. Validates each subpath exists in the corresponding `package.json#exports`
4. Reports mismatches with file and line numbers

### Escape hatch

Place `<!-- non-contractual -->` before a code block to exempt it from validation.

### Fix included

Corrects `@outfitter/testing` README — `cli-harness` and `mcp-harness` were documented as subpath imports but aren't actually exported (and have zero imports in the codebase). Updated to show the main package import instead.

## Test plan

- [x] 20 unit tests covering `parseSpecifier`, `extractImports`, `isExportedSubpath`
- [x] Validates against real monorepo (54 valid imports across 28 files)
- [x] `verify:ci` green

Closes OS-160

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)