### PR TITLE
fix(tooling): add 6 missing packages to bunup workspace config

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -150,12 +150,36 @@ export default defineWorkspace(
       },
     },
     {
+      name: "@outfitter/daemon",
+      root: "packages/daemon",
+    },
+    {
+      name: "@outfitter/file-ops",
+      root: "packages/file-ops",
+    },
+    {
       name: "@outfitter/index",
       root: "packages/index",
     },
     {
       name: "@outfitter/kit",
       root: "packages/kit",
+    },
+    {
+      name: "@outfitter/logging",
+      root: "packages/logging",
+    },
+    {
+      name: "@outfitter/mcp",
+      root: "packages/mcp",
+    },
+    {
+      name: "@outfitter/state",
+      root: "packages/state",
+    },
+    {
+      name: "@outfitter/testing",
+      root: "packages/testing",
     },
     {
       name: "@outfitter/tooling",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -15,7 +15,49 @@
         "default": "./dist/index.js"
       }
     },
-    "./package.json": "./package.json"
+    "./errors": {
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      }
+    },
+    "./health": {
+      "import": {
+        "types": "./dist/health.d.ts",
+        "default": "./dist/health.js"
+      }
+    },
+    "./ipc": {
+      "import": {
+        "types": "./dist/ipc.d.ts",
+        "default": "./dist/ipc.js"
+      }
+    },
+    "./lifecycle": {
+      "import": {
+        "types": "./dist/lifecycle.d.ts",
+        "default": "./dist/lifecycle.js"
+      }
+    },
+    "./locking": {
+      "import": {
+        "types": "./dist/locking.d.ts",
+        "default": "./dist/locking.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./platform": {
+      "import": {
+        "types": "./dist/platform.d.ts",
+        "default": "./dist/platform.js"
+      }
+    },
+    "./types": {
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/types.js"
+      }
+    }
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,11 +15,41 @@
         "default": "./dist/index.js"
       }
     },
+    "./actions": {
+      "import": {
+        "types": "./dist/actions.d.ts",
+        "default": "./dist/actions.js"
+      }
+    },
+    "./core-tools": {
+      "import": {
+        "types": "./dist/core-tools.d.ts",
+        "default": "./dist/core-tools.js"
+      }
+    },
+    "./logging": {
+      "import": {
+        "types": "./dist/logging.d.ts",
+        "default": "./dist/logging.js"
+      }
+    },
     "./package.json": "./package.json",
+    "./schema": {
+      "import": {
+        "types": "./dist/schema.d.ts",
+        "default": "./dist/schema.js"
+      }
+    },
     "./server": {
       "import": {
         "types": "./dist/server.d.ts",
         "default": "./dist/server.js"
+      }
+    },
+    "./transport": {
+      "import": {
+        "types": "./dist/transport.d.ts",
+        "default": "./dist/transport.js"
       }
     },
     "./types": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,10 +15,34 @@
         "default": "./dist/index.js"
       }
     },
+    "./cli-harness": {
+      "import": {
+        "types": "./dist/cli-harness.d.ts",
+        "default": "./dist/cli-harness.js"
+      }
+    },
+    "./cli-helpers": {
+      "import": {
+        "types": "./dist/cli-helpers.d.ts",
+        "default": "./dist/cli-helpers.js"
+      }
+    },
     "./fixtures": {
       "import": {
         "types": "./dist/fixtures.d.ts",
         "default": "./dist/fixtures.js"
+      }
+    },
+    "./mcp-harness": {
+      "import": {
+        "types": "./dist/mcp-harness.d.ts",
+        "default": "./dist/mcp-harness.js"
+      }
+    },
+    "./mock-factories": {
+      "import": {
+        "types": "./dist/mock-factories.d.ts",
+        "default": "./dist/mock-factories.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
## Summary

- Add 6 missing packages (`daemon`, `file-ops`, `logging`, `mcp`, `state`, `testing`) to `bunup.config.ts` workspace array
- Sync `package.json` exports for `daemon`, `mcp`, and `testing` (now validated by `check-exports`)

These packages had `bunup --filter` build scripts but were not registered in the workspace config. This caused `bunup --filter <name>` to silently exit 0 with no output when run from root, leading to intermittent CI failures when downstream typechecks couldn't find `.d.ts` files.

## Test plan

- [x] `bunup --filter @outfitter/logging` from root now produces output (was silent before)
- [x] `bun run check-exports` passes (no export drift)
- [x] `bun run verify:ci` passes
- [x] All 143 tooling tests pass

Resolves OS-162

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)