### PR TITLE
feat(tooling): add check-bunup-registry command

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -189,6 +189,7 @@ export default defineWorkspace(
       config: {
         exports: {
           exclude: [
+            "./cli/check-bunup-registry",
             "./cli/check-clean-tree",
             "./cli/check-exports",
             "./cli/check-readme-imports",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
-    "verify:ci": "bun run typecheck && bun run check && bun run docs:check:ci && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run test",
+    "verify:ci": "bun run typecheck && bun run check && bun run check-bunup-registry && bun run docs:check:ci && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run test",
+    "check-bunup-registry": "bun run packages/tooling/src/cli/index.ts check-bunup-registry",
     "check-exports": "bun run packages/tooling/src/cli/index.ts check-exports",
     "check-readme-imports": "bun run packages/tooling/src/cli/index.ts check-readme-imports",
     "check-clean-tree": "bun run packages/tooling/src/cli/index.ts check-clean-tree",

--- a/packages/tooling/src/__tests__/check-bunup-registry.test.ts
+++ b/packages/tooling/src/__tests__/check-bunup-registry.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+	extractBunupFilterName,
+	findUnregisteredPackages,
+	type RegistryCheckResult,
+} from "../cli/check-bunup-registry.js";
+
+describe("extractBunupFilterName", () => {
+	test("returns package name from simple bunup --filter script", () => {
+		expect(extractBunupFilterName("bunup --filter @outfitter/logging")).toBe(
+			"@outfitter/logging",
+		);
+	});
+
+	test("returns package name when cd precedes bunup", () => {
+		expect(
+			extractBunupFilterName("cd ../.. && bunup --filter @outfitter/types"),
+		).toBe("@outfitter/types");
+	});
+
+	test("returns package name with additional commands after", () => {
+		expect(
+			extractBunupFilterName(
+				"bun run sync:migrations && cd ../.. && bunup --filter @outfitter/kit",
+			),
+		).toBe("@outfitter/kit");
+	});
+
+	test("returns null for scripts without bunup --filter", () => {
+		expect(extractBunupFilterName("tsc --noEmit")).toBeNull();
+	});
+
+	test("returns null for empty string", () => {
+		expect(extractBunupFilterName("")).toBeNull();
+	});
+
+	test("returns null for bunup without --filter flag", () => {
+		expect(extractBunupFilterName("bunup")).toBeNull();
+	});
+
+	test("returns unscoped package name", () => {
+		expect(extractBunupFilterName("bunup --filter outfitter")).toBe(
+			"outfitter",
+		);
+	});
+});
+
+describe("findUnregisteredPackages", () => {
+	test("returns empty when all packages are registered", () => {
+		const result = findUnregisteredPackages(
+			["@outfitter/cli", "@outfitter/types"],
+			["@outfitter/cli", "@outfitter/types", "@outfitter/contracts"],
+		);
+		expect(result).toEqual<RegistryCheckResult>({
+			ok: true,
+			missing: [],
+		});
+	});
+
+	test("returns missing packages", () => {
+		const result = findUnregisteredPackages(
+			["@outfitter/cli", "@outfitter/logging", "@outfitter/daemon"],
+			["@outfitter/cli"],
+		);
+		expect(result).toEqual<RegistryCheckResult>({
+			ok: false,
+			missing: ["@outfitter/daemon", "@outfitter/logging"],
+		});
+	});
+
+	test("returns sorted missing packages", () => {
+		const result = findUnregisteredPackages(
+			["@outfitter/state", "@outfitter/mcp", "@outfitter/daemon"],
+			[],
+		);
+		expect(result.missing).toEqual([
+			"@outfitter/daemon",
+			"@outfitter/mcp",
+			"@outfitter/state",
+		]);
+	});
+
+	test("handles empty inputs", () => {
+		expect(findUnregisteredPackages([], [])).toEqual<RegistryCheckResult>({
+			ok: true,
+			missing: [],
+		});
+	});
+
+	test("handles all packages missing", () => {
+		const result = findUnregisteredPackages(["@outfitter/logging"], []);
+		expect(result).toEqual<RegistryCheckResult>({
+			ok: false,
+			missing: ["@outfitter/logging"],
+		});
+	});
+});

--- a/packages/tooling/src/cli/check-bunup-registry.ts
+++ b/packages/tooling/src/cli/check-bunup-registry.ts
@@ -1,0 +1,167 @@
+/**
+ * Check-bunup-registry command — validates all packages with `bunup --filter`
+ * build scripts are registered in bunup.config.ts.
+ *
+ * Prevents silent build failures where `bunup --filter <name>` silently exits 0
+ * with no output when the package isn't in the workspace config.
+ *
+ * @packageDocumentation
+ */
+
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Result of checking bunup workspace registration */
+export interface RegistryCheckResult {
+	readonly ok: boolean;
+	readonly missing: string[];
+}
+
+/** Bunup workspace entry (minimal shape for name extraction) */
+interface WorkspaceEntry {
+	readonly name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the package name from a build script containing `bunup --filter`.
+ *
+ * @example
+ * extractBunupFilterName("bunup --filter @outfitter/logging")
+ * // => "@outfitter/logging"
+ *
+ * extractBunupFilterName("cd ../.. && bunup --filter @outfitter/types")
+ * // => "@outfitter/types"
+ *
+ * extractBunupFilterName("tsc --noEmit")
+ * // => null
+ */
+export function extractBunupFilterName(script: string): string | null {
+	const match = script.match(/bunup\s+--filter\s+(\S+)/);
+	return match?.[1] ?? null;
+}
+
+/**
+ * Find packages that have `bunup --filter` build scripts but are not
+ * registered in the bunup workspace config.
+ *
+ * @param packagesWithFilter - Package names that have `bunup --filter` in their build script
+ * @param registeredNames - Package names registered in bunup.config.ts
+ * @returns Result with sorted list of missing packages
+ */
+export function findUnregisteredPackages(
+	packagesWithFilter: string[],
+	registeredNames: string[],
+): RegistryCheckResult {
+	const registered = new Set(registeredNames);
+	const missing = packagesWithFilter
+		.filter((name) => !registered.has(name))
+		.sort();
+
+	return {
+		ok: missing.length === 0,
+		missing,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const COLORS = {
+	reset: "\x1b[0m",
+	red: "\x1b[31m",
+	green: "\x1b[32m",
+	yellow: "\x1b[33m",
+	blue: "\x1b[34m",
+	dim: "\x1b[2m",
+};
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run bunup registry check across all workspace packages.
+ *
+ * Scans packages/&#42;/package.json for build scripts containing `bunup --filter`,
+ * then verifies each is registered in bunup.config.ts.
+ */
+export async function runCheckBunupRegistry(): Promise<void> {
+	const cwd = process.cwd();
+	const configPath = resolve(cwd, "bunup.config.ts");
+
+	// Load bunup workspace config to get registered names
+	let registeredNames: string[];
+	try {
+		const configModule = await import(configPath);
+		const rawConfig: unknown = configModule.default;
+		if (!Array.isArray(rawConfig)) {
+			process.stderr.write("bunup.config.ts must export a workspace array\n");
+			process.exit(1);
+		}
+		registeredNames = (rawConfig as WorkspaceEntry[]).map(
+			(entry) => entry.name,
+		);
+	} catch {
+		process.stderr.write(`Could not load bunup.config.ts from ${cwd}\n`);
+		process.exit(1);
+	}
+
+	// Scan packages/*/package.json and apps/*/package.json for bunup --filter build scripts
+	const packagesWithFilter: string[] = [];
+	const glob = new Bun.Glob("{packages,apps}/*/package.json");
+
+	for (const match of glob.scanSync({ cwd })) {
+		const pkgPath = resolve(cwd, match);
+		try {
+			const pkg = (await Bun.file(pkgPath).json()) as {
+				name?: string;
+				scripts?: Record<string, string>;
+			};
+			const buildScript = pkg.scripts?.["build"];
+			if (!buildScript) continue;
+
+			const filterName = extractBunupFilterName(buildScript);
+			if (filterName) {
+				packagesWithFilter.push(filterName);
+			}
+		} catch {
+			// Skip unreadable package.json files
+		}
+	}
+
+	const result = findUnregisteredPackages(packagesWithFilter, registeredNames);
+
+	if (result.ok) {
+		process.stdout.write(
+			`${COLORS.green}All ${packagesWithFilter.length} packages with bunup --filter are registered in bunup.config.ts.${COLORS.reset}\n`,
+		);
+		process.exit(0);
+	}
+
+	process.stderr.write(
+		`${COLORS.red}${result.missing.length} package(s) have bunup --filter build scripts but are not registered in bunup.config.ts:${COLORS.reset}\n\n`,
+	);
+
+	for (const name of result.missing) {
+		process.stderr.write(
+			`  ${COLORS.yellow}${name}${COLORS.reset}  ${COLORS.dim}(missing from workspace array)${COLORS.reset}\n`,
+		);
+	}
+
+	process.stderr.write(
+		`\nAdd the missing entries to ${COLORS.blue}bunup.config.ts${COLORS.reset} defineWorkspace array.\n`,
+	);
+	process.stderr.write(
+		`Without registration, ${COLORS.dim}bunup --filter <name>${COLORS.reset} silently exits with no output.\n`,
+	);
+
+	process.exit(1);
+}

--- a/packages/tooling/src/cli/index.ts
+++ b/packages/tooling/src/cli/index.ts
@@ -10,6 +10,7 @@
 import { Command } from "commander";
 import { VERSION } from "../version.js";
 import { runCheck } from "./check.js";
+import { runCheckBunupRegistry } from "./check-bunup-registry.js";
 import { runCheckCleanTree } from "./check-clean-tree.js";
 import { runCheckExports } from "./check-exports.js";
 import { runFix } from "./fix.js";
@@ -64,6 +65,15 @@ program
 	.option("-f, --force", "Skip strict verification entirely")
 	.action(async (options: { force?: boolean }) => {
 		await runPrePush(options);
+	});
+
+program
+	.command("check-bunup-registry")
+	.description(
+		"Validate packages with bunup --filter are registered in bunup.config.ts",
+	)
+	.action(async () => {
+		await runCheckBunupRegistry();
 	});
 
 program


### PR DESCRIPTION
## Summary

- New `check-bunup-registry` command in `@outfitter/tooling` that validates all packages with `bunup --filter` build scripts are registered in `bunup.config.ts`
- Wired into `verify:ci` pipeline (runs after `check`, before `docs:check:ci`)
- Covers both CI and pre-push since pre-push delegates to `verify:ci`

Prevents the silent build failure discovered in OS-162 from recurring. Without registration, `bunup --filter <name>` silently exits 0 with no output — this check catches missing registrations before they reach CI.

## Test plan

- [x] 12 unit tests for pure functions (`extractBunupFilterName`, `findUnregisteredPackages`)
- [x] End-to-end: `bun run check-bunup-registry` reports all packages registered
- [x] `bun run verify:ci` passes with new check in pipeline
- [x] All 143 tooling tests pass

Resolves OS-163

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)