### PR TITLE
fix(outfitter): consolidate output mode resolution

### DIFF
--- a/apps/outfitter/src/__tests__/json-parity.test.ts
+++ b/apps/outfitter/src/__tests__/json-parity.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolveOutputModeFromContext } from "../output-mode.js";
+
+// Capture original env state to restore after each test
+const originalJson = process.env["OUTFITTER_JSON"];
+const originalJsonl = process.env["OUTFITTER_JSONL"];
+
+beforeEach(() => {
+  // Clear env vars before each test for isolation
+  delete process.env["OUTFITTER_JSON"];
+  delete process.env["OUTFITTER_JSONL"];
+});
+
+afterEach(() => {
+  // Restore original env state
+  if (originalJson === undefined) {
+    delete process.env["OUTFITTER_JSON"];
+  } else {
+    process.env["OUTFITTER_JSON"] = originalJson;
+  }
+
+  if (originalJsonl === undefined) {
+    delete process.env["OUTFITTER_JSONL"];
+  } else {
+    process.env["OUTFITTER_JSONL"] = originalJsonl;
+  }
+});
+
+describe("resolveOutputModeFromContext", () => {
+  test("returns json when --json flag is set", () => {
+    expect(resolveOutputModeFromContext({ json: true })).toBe("json");
+  });
+
+  test("returns jsonl when --jsonl flag is set", () => {
+    expect(resolveOutputModeFromContext({ jsonl: true })).toBe("jsonl");
+  });
+
+  test("returns json when OUTFITTER_JSON=1 env var is set", () => {
+    process.env["OUTFITTER_JSON"] = "1";
+    expect(resolveOutputModeFromContext({})).toBe("json");
+  });
+
+  test("returns jsonl when OUTFITTER_JSONL=1 env var is set", () => {
+    process.env["OUTFITTER_JSONL"] = "1";
+    expect(resolveOutputModeFromContext({})).toBe("jsonl");
+  });
+
+  test("returns human when no flag or env var is set", () => {
+    expect(resolveOutputModeFromContext({})).toBe("human");
+  });
+
+  test("flag takes priority over env var", () => {
+    process.env["OUTFITTER_JSON"] = "1";
+    // Even with JSON env set, explicit jsonl flag wins
+    expect(resolveOutputModeFromContext({ jsonl: true })).toBe("jsonl");
+  });
+
+  test("json flag takes priority over OUTFITTER_JSONL env var", () => {
+    process.env["OUTFITTER_JSONL"] = "1";
+    expect(resolveOutputModeFromContext({ json: true })).toBe("json");
+  });
+
+  test("OUTFITTER_JSONL env takes priority over OUTFITTER_JSON env", () => {
+    process.env["OUTFITTER_JSON"] = "1";
+    process.env["OUTFITTER_JSONL"] = "1";
+    expect(resolveOutputModeFromContext({})).toBe("jsonl");
+  });
+
+  test("does NOT set any env vars as side effect", () => {
+    resolveOutputModeFromContext({ json: true });
+    expect(process.env["OUTFITTER_JSON"]).toBeUndefined();
+
+    resolveOutputModeFromContext({ jsonl: true });
+    expect(process.env["OUTFITTER_JSONL"]).toBeUndefined();
+  });
+});

--- a/apps/outfitter/src/commands/add.ts
+++ b/apps/outfitter/src/commands/add.ts
@@ -466,7 +466,7 @@ export async function printAddResults(
     }
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }
 
 /**

--- a/apps/outfitter/src/commands/check.ts
+++ b/apps/outfitter/src/commands/check.ts
@@ -609,5 +609,5 @@ export async function printCheckResults(
     );
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }

--- a/apps/outfitter/src/commands/demo.ts
+++ b/apps/outfitter/src/commands/demo.ts
@@ -10,6 +10,7 @@
 import { isCancel, select } from "@clack/prompts";
 import { output } from "@outfitter/cli/output";
 import { isInteractive } from "@outfitter/cli/terminal";
+import type { OutputMode } from "@outfitter/cli/types";
 import { createTheme, renderTable, SPINNERS } from "@outfitter/tui/render";
 import { ANSI } from "@outfitter/tui/streaming";
 import {
@@ -295,8 +296,11 @@ async function runAnimatedSpinnerDemo(): Promise<void> {
 /**
  * Outputs demo results.
  */
-export async function printDemoResults(result: DemoResult): Promise<void> {
+export async function printDemoResults(
+  result: DemoResult,
+  options?: { mode?: OutputMode }
+): Promise<void> {
   if (result.output) {
-    await output(result.output, { mode: "human" });
+    await output(result.output, { mode: options?.mode ?? "human" });
   }
 }

--- a/apps/outfitter/src/commands/doctor.ts
+++ b/apps/outfitter/src/commands/doctor.ts
@@ -423,7 +423,7 @@ export async function printDoctorResults(
     );
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }
 
 /**

--- a/apps/outfitter/src/commands/init.ts
+++ b/apps/outfitter/src/commands/init.ts
@@ -693,7 +693,7 @@ export async function printInitResults(
     lines.push(`  ${step}`);
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }
 
 // =============================================================================

--- a/apps/outfitter/src/commands/migrate-kit.ts
+++ b/apps/outfitter/src/commands/migrate-kit.ts
@@ -1019,7 +1019,7 @@ export async function printMigrateKitResults(
 
   if (result.changedFiles.length === 0) {
     lines.push("No kit migration changes needed.");
-    await output(lines);
+    await output(lines, { mode: "human" });
     return;
   }
 
@@ -1044,7 +1044,7 @@ export async function printMigrateKitResults(
     }
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }
 
 /**

--- a/apps/outfitter/src/commands/scaffold.ts
+++ b/apps/outfitter/src/commands/scaffold.ts
@@ -740,7 +740,7 @@ export async function printScaffoldResults(
     lines.push(`  ${step}`);
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }
 
 export function scaffoldCommand(program: Command): void {

--- a/apps/outfitter/src/commands/update.ts
+++ b/apps/outfitter/src/commands/update.ts
@@ -607,7 +607,7 @@ export async function printUpdateResults(
 
   if (result.packages.length === 0) {
     lines.push("No @outfitter/* packages found in package.json.");
-    await output(lines);
+    await output(lines, { mode: "human" });
     return;
   }
 
@@ -781,5 +781,5 @@ export async function printUpdateResults(
     }
   }
 
-  await output(lines);
+  await output(lines, { mode: "human" });
 }

--- a/apps/outfitter/src/engine/render-plan.ts
+++ b/apps/outfitter/src/engine/render-plan.ts
@@ -131,5 +131,5 @@ export async function renderOperationPlan(
   lines.push(
     `Total operations: ${Object.values(summary).reduce((a, b) => a + b, 0)}`
   );
-  await output(lines);
+  await output(lines, { mode: "human" });
 }

--- a/apps/outfitter/src/output-mode.ts
+++ b/apps/outfitter/src/output-mode.ts
@@ -2,6 +2,30 @@ import type { OutputMode } from "@outfitter/cli/types";
 
 export type StructuredOutputMode = Extract<OutputMode, "json" | "jsonl">;
 
+/** Output modes resolvable from CLI flags and env vars. */
+export type CliOutputMode = "human" | "json" | "jsonl";
+
+/**
+ * Resolve output mode from CLI context (flags + env vars).
+ *
+ * Precedence: explicit flag > OUTFITTER_JSONL env > OUTFITTER_JSON env > "human"
+ *
+ * This function is pure -- no env var side effects.
+ */
+export function resolveOutputModeFromContext(
+  flags: Record<string, unknown>
+): CliOutputMode {
+  // Flag takes priority
+  if (flags["json"]) return "json";
+  if (flags["jsonl"]) return "jsonl";
+
+  // Env var fallback (JSONL takes priority over JSON)
+  if (process.env["OUTFITTER_JSONL"] === "1") return "jsonl";
+  if (process.env["OUTFITTER_JSON"] === "1") return "json";
+
+  return "human";
+}
+
 /**
  * Resolve machine-readable output mode from explicit options first, then env.
  */


### PR DESCRIPTION
## Summary

- Replaces fragile `resolveOutputMode` (mutated `process.env` as side effect) with pure `resolveOutputModeFromContext` (flags > env vars > "human")
- Adds `CliOutputMode` type to narrow action input types from broad `OutputMode` union
- Updates all 9 command action sites to thread concrete output mode (never `undefined`)
- Fixes demo command anti-pattern (was discarding resolved mode)
- Adds explicit `{ mode: "human" }` to 10 human-path `output()` calls for defense-in-depth
- 9 new parity tests verify resolver precedence and no-side-effect guarantee

## Context

Analyst research confirmed no active bug in current code, but the pattern was fragile — one missed mode thread and `detectMode()` would pick up stale `OUTFITTER_JSON=1` env var, producing JSON-wrapped human strings. This refactor makes the system robust by construction.

## Test plan

- [x] 9 parity tests for `resolveOutputModeFromContext` pass
- [x] 299 total app tests pass (0 regressions)
- [x] Full `verify:ci` passes
- [x] TypeScript strict mode with `exactOptionalPropertyTypes` clean

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)