### PR TITLE
fix(cli): avoid output subpath race in workspace typecheck

### DIFF
--- a/apps/cli-demo/package.json
+++ b/apps/cli-demo/package.json
@@ -54,7 +54,7 @@
     "test:watch": "bun test --watch",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
-    "pretypecheck": "bun run --filter @outfitter/tui build && bun run --filter @outfitter/cli build",
+    "pretypecheck": "(test -f ../../packages/tui/dist/index.d.ts || bun run --filter @outfitter/tui build) && (test -f ../../packages/cli/dist/output.d.ts || bun run --filter @outfitter/cli build)",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/apps/cli-demo/src/cli.ts
+++ b/apps/cli-demo/src/cli.ts
@@ -7,8 +7,8 @@
  */
 
 import { readFileSync } from "node:fs";
+import { exitWithError } from "@outfitter/cli";
 import { createCLI } from "@outfitter/cli/command";
-import { exitWithError } from "@outfitter/cli/output";
 import type { Command } from "commander";
 import { printDemoResults, runDemo } from "./commands/demo.js";
 import { resolveOutputModeFromContext } from "./output-mode.js";

--- a/apps/cli-demo/src/commands/demo.ts
+++ b/apps/cli-demo/src/commands/demo.ts
@@ -8,7 +8,7 @@
  */
 
 import { isCancel, select } from "@clack/prompts";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import { isInteractive } from "@outfitter/cli/terminal";
 import type { OutputMode } from "@outfitter/cli/types";
 import { createTheme, renderTable, SPINNERS } from "@outfitter/tui/render";

--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -229,7 +229,7 @@
     "test:watch": "bun test --watch",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
-    "pretypecheck": "bun run --filter @outfitter/logging build && bun run --filter @outfitter/cli build",
+    "pretypecheck": "(test -f ../../packages/logging/dist/index.d.ts || bun run --filter @outfitter/logging build) && (test -f ../../packages/cli/dist/output.d.ts || bun run --filter @outfitter/cli build)",
     "typecheck": "tsc --noEmit",
     "sync:templates": "bun run ../../scripts/sync-templates.ts",
     "prepack": "bun run sync:templates",

--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -5,7 +5,7 @@
  */
 
 import { resolve } from "node:path";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import {
   type ActionCliInputContext,
   type ActionCliOption,

--- a/apps/outfitter/src/cli.ts
+++ b/apps/outfitter/src/cli.ts
@@ -11,9 +11,9 @@
  */
 
 import { readFileSync } from "node:fs";
+import { exitWithError } from "@outfitter/cli";
 import { buildCliCommands } from "@outfitter/cli/actions";
 import { createCLI } from "@outfitter/cli/command";
-import { exitWithError } from "@outfitter/cli/output";
 import { createContext, generateRequestId } from "@outfitter/contracts";
 import { createOutfitterLoggerFactory } from "@outfitter/logging";
 import { outfitterActions } from "./actions.js";

--- a/apps/outfitter/src/commands/add.ts
+++ b/apps/outfitter/src/commands/add.ts
@@ -16,7 +16,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { AddBlockResult, Block, Registry } from "@outfitter/tooling";

--- a/apps/outfitter/src/commands/check.ts
+++ b/apps/outfitter/src/commands/check.ts
@@ -11,7 +11,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { FileEntry, Registry } from "@outfitter/tooling";

--- a/apps/outfitter/src/commands/demo.ts
+++ b/apps/outfitter/src/commands/demo.ts
@@ -8,7 +8,7 @@
  */
 
 import { fileURLToPath } from "node:url";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import {
   getPrimitiveIds,
   isPrimitiveId,

--- a/apps/outfitter/src/commands/doctor.ts
+++ b/apps/outfitter/src/commands/doctor.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { createTheme } from "@outfitter/tui/render";
 import type { Command } from "commander";

--- a/apps/outfitter/src/commands/init.ts
+++ b/apps/outfitter/src/commands/init.ts
@@ -18,7 +18,7 @@ import {
   select,
   text,
 } from "@clack/prompts";
-import { exitWithError, output } from "@outfitter/cli/output";
+import { exitWithError, output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { AddBlockResult } from "@outfitter/tooling";

--- a/apps/outfitter/src/commands/migrate-kit.ts
+++ b/apps/outfitter/src/commands/migrate-kit.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { Command } from "commander";

--- a/apps/outfitter/src/commands/scaffold.ts
+++ b/apps/outfitter/src/commands/scaffold.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { exitWithError, output } from "@outfitter/cli/output";
+import { exitWithError, output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { AddBlockResult } from "@outfitter/tooling";

--- a/apps/outfitter/src/commands/update.ts
+++ b/apps/outfitter/src/commands/update.ts
@@ -9,7 +9,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import type { OutfitterError } from "@outfitter/contracts";
 import { InternalError, Result } from "@outfitter/contracts";

--- a/apps/outfitter/src/engine/render-plan.ts
+++ b/apps/outfitter/src/engine/render-plan.ts
@@ -1,5 +1,5 @@
 import { relative } from "node:path";
-import { output } from "@outfitter/cli/output";
+import { output } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { resolveStructuredOutputMode } from "../output-mode.js";
 import type { Operation, OperationCollector } from "./collector.js";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,5 +26,5 @@ export {
 } from "./colors/index.js";
 
 // Output (stdout/stderr abstraction)
-export { output } from "./output.js";
+export { exitWithError, output } from "./output.js";
 export type { OutputMode } from "./types.js";

--- a/plugins/fieldguides/agents/analyst.md
+++ b/plugins/fieldguides/agents/analyst.md
@@ -7,7 +7,7 @@ color: blue
 skills:
   - research
   - codebase-analysis
-memory: project
+memory: user
 ---
 
 # Analyst

--- a/plugins/fieldguides/agents/debugger.md
+++ b/plugins/fieldguides/agents/debugger.md
@@ -8,7 +8,7 @@ skills:
   - debugging
   - codebase-analysis
   - find-root-causes
-memory: project
+memory: user
 ---
 
 # Debugger

--- a/plugins/fieldguides/agents/engineer.md
+++ b/plugins/fieldguides/agents/engineer.md
@@ -7,7 +7,7 @@ color: blue
 skills:
   - tdd-fieldguide
   - typescript-fieldguide
-memory: project
+memory: user
 ---
 
 # Engineer

--- a/plugins/fieldguides/agents/reviewer.md
+++ b/plugins/fieldguides/agents/reviewer.md
@@ -6,7 +6,7 @@ model: inherit
 color: orange
 skills:
   - code-review
-memory: project
+memory: user
 ---
 
 # Reviewer

--- a/plugins/fieldguides/agents/scout.md
+++ b/plugins/fieldguides/agents/scout.md
@@ -6,7 +6,7 @@ model: inherit
 color: blue
 skills:
   - check-status
-memory: project
+memory: user
 ---
 
 # Scout

--- a/plugins/fieldguides/agents/specialist.md
+++ b/plugins/fieldguides/agents/specialist.md
@@ -4,7 +4,7 @@ description: Use this agent when the task requires domain-specific expertise, in
 tools: Bash, BashOutput, Glob, Grep, KillShell, Read, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, WebFetch, WebSearch
 model: inherit
 color: green
-memory: project
+memory: user
 ---
 
 # Specialist

--- a/plugins/fieldguides/agents/tester.md
+++ b/plugins/fieldguides/agents/tester.md
@@ -6,7 +6,7 @@ model: inherit
 color: yellow
 skills:
   - prove-it-works
-memory: project
+memory: user
 ---
 
 # Tester

--- a/plugins/team/agents/comms.md
+++ b/plugins/team/agents/comms.md
@@ -5,7 +5,7 @@ skills:
   - outfitter-voice
   - outfitter-styleguide
 tools: Read, Write, Edit, Glob, Grep, Skill, WebSearch, WebFetch
-memory: project
+memory: user
 ---
 
 # Comms

--- a/plugins/team/agents/editor.md
+++ b/plugins/team/agents/editor.md
@@ -4,7 +4,7 @@ description: Reviews and refines Outfitter content for voice, style, and structu
 skills:
   - outfitter-editorial
 tools: Read, Write, Edit, Glob, Grep, Skill
-memory: project
+memory: user
 ---
 
 # Editor

--- a/plugins/team/agents/technical-writer.md
+++ b/plugins/team/agents/technical-writer.md
@@ -5,7 +5,7 @@ skills:
   - outfitter-styleguide
   - outfitter-documentation
 tools: Read, Write, Edit, Glob, Grep, Bash, Skill
-memory: project
+memory: user
 ---
 
 # Technical Writer


### PR DESCRIPTION
## Context
Intermittent workspace typecheck runs were failing in app packages due to declaration files being rebuilt concurrently while TypeScript was resolving `@outfitter/cli/output` subpath types.

## What Changed
- Made app `pretypecheck` scripts in `apps/outfitter` and `apps/cli-demo` conditional so dependency builds only run when declaration files are missing.
- Switched app imports from `@outfitter/cli/output` to root `@outfitter/cli` exports.
- Re-exported `exitWithError` from `packages/cli/src/index.ts` to support root import usage.
- Added a changeset for `@outfitter/cli` patch impact.
- Updated tracked agent definitions from `memory: project` to `memory: user` so agent memory does not write into repo-scoped state.

## Validation
- Full stack pre-push verification from top branch (`verify:ci`) passed, including typecheck, checks, build, and tests.

## Risks / Notes
- This commit intentionally touches both CLI typecheck stability and agent memory scope to unblock stack verification and prevent repo-local agent-memory file churn.
