### PR TITLE
feat(cli): add projection preset

### DIFF
--- a/packages/cli/src/__tests__/flags-projection.test.ts
+++ b/packages/cli/src/__tests__/flags-projection.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import {
+  composePresets,
+  paginationPreset,
+  projectionPreset,
+  verbosePreset,
+} from "../flags.js";
+
+describe("projectionPreset", () => {
+  describe("defaults", () => {
+    it("has id 'projection'", () => {
+      const preset = projectionPreset();
+      expect(preset.id).toBe("projection");
+    });
+
+    it("defines three options", () => {
+      const preset = projectionPreset();
+      expect(preset.options).toHaveLength(3);
+      expect(preset.options.map((o) => o.flags)).toEqual([
+        "--fields <fields>",
+        "--exclude-fields <fields>",
+        "--count",
+      ]);
+    });
+
+    it("resolves with undefined fields and false count by default", () => {
+      const preset = projectionPreset();
+      const result = preset.resolve({});
+      expect(result).toEqual({
+        fields: undefined,
+        excludeFields: undefined,
+        count: false,
+      });
+    });
+
+    it("returns fresh instance per call", () => {
+      expect(projectionPreset()).not.toBe(projectionPreset());
+    });
+  });
+
+  describe("fields resolution", () => {
+    it("parses comma-separated fields", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ fields: "name,email,id" }).fields).toEqual([
+        "name",
+        "email",
+        "id",
+      ]);
+    });
+
+    it("trims whitespace from field names", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ fields: " name , email , id " }).fields).toEqual([
+        "name",
+        "email",
+        "id",
+      ]);
+    });
+
+    it("returns undefined when not provided", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({}).fields).toBeUndefined();
+    });
+
+    it("handles single field", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ fields: "name" }).fields).toEqual(["name"]);
+    });
+
+    it("filters out empty entries from trailing commas", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ fields: "name,,email," }).fields).toEqual([
+        "name",
+        "email",
+      ]);
+    });
+  });
+
+  describe("excludeFields resolution", () => {
+    it("parses comma-separated exclude fields", () => {
+      const preset = projectionPreset();
+      expect(
+        preset.resolve({ excludeFields: "password,secret" }).excludeFields
+      ).toEqual(["password", "secret"]);
+    });
+
+    it("handles kebab-case key", () => {
+      const preset = projectionPreset();
+      expect(
+        preset.resolve({ "exclude-fields": "password" }).excludeFields
+      ).toEqual(["password"]);
+    });
+
+    it("trims whitespace", () => {
+      const preset = projectionPreset();
+      expect(
+        preset.resolve({ excludeFields: " password , secret " }).excludeFields
+      ).toEqual(["password", "secret"]);
+    });
+
+    it("returns undefined when not provided", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({}).excludeFields).toBeUndefined();
+    });
+  });
+
+  describe("count resolution", () => {
+    it("resolves count as true when passed", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ count: true }).count).toBe(true);
+    });
+
+    it("resolves count as false by default", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({}).count).toBe(false);
+    });
+
+    it("coerces truthy values to boolean", () => {
+      const preset = projectionPreset();
+      expect(preset.resolve({ count: 1 }).count).toBe(true);
+    });
+  });
+
+  describe("composition", () => {
+    it("composes with pagination and verbose presets", () => {
+      const composed = composePresets(
+        projectionPreset(),
+        paginationPreset(),
+        verbosePreset()
+      );
+      expect(composed.options).toHaveLength(7);
+      const result = composed.resolve({
+        fields: "name,email",
+        limit: "10",
+        verbose: true,
+      });
+      expect(result).toEqual({
+        fields: ["name", "email"],
+        excludeFields: undefined,
+        count: false,
+        limit: 10,
+        next: false,
+        reset: false,
+        verbose: true,
+      });
+    });
+
+    it("deduplicates by id when composed twice", () => {
+      const composed = composePresets(projectionPreset(), projectionPreset());
+      expect(composed.options).toHaveLength(3);
+    });
+  });
+});

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -14,6 +14,7 @@ import type {
   InteractionFlags,
   PaginationFlags,
   PaginationPresetConfig,
+  ProjectionFlags,
   StrictFlags,
 } from "./types.js";
 
@@ -346,6 +347,60 @@ export function colorPreset(): FlagPreset<ColorFlags> {
 }
 
 /**
+ * Parse a comma-separated string into a trimmed, non-empty string array.
+ * Returns `undefined` if the input is not a string or produces no entries.
+ */
+function parseCommaSeparated(value: unknown): string[] | undefined {
+  if (typeof value !== "string") return undefined;
+  const items = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Projection flag preset.
+ *
+ * Adds: `--fields <fields>`, `--exclude-fields <fields>`, `--count`
+ * Resolves: `{ fields: string[] | undefined, excludeFields: string[] | undefined, count: boolean }`
+ *
+ * Fields are parsed as comma-separated strings with whitespace trimming.
+ * `undefined` when not provided (not empty array) to distinguish
+ * "not specified" from "empty".
+ *
+ * Conflict between `--fields` and `--exclude-fields` is a handler
+ * concern (documented, not enforced).
+ */
+export function projectionPreset(): FlagPreset<ProjectionFlags> {
+  return createPreset({
+    id: "projection",
+    options: [
+      {
+        flags: "--fields <fields>",
+        description: "Comma-separated list of fields to include",
+      },
+      {
+        flags: "--exclude-fields <fields>",
+        description: "Comma-separated list of fields to exclude",
+      },
+      {
+        flags: "--count",
+        description: "Output only the count of results",
+        defaultValue: false,
+      },
+    ],
+    resolve: (flags) => ({
+      fields: parseCommaSeparated(flags["fields"]),
+      excludeFields: parseCommaSeparated(
+        flags["excludeFields"] ?? flags["exclude-fields"]
+      ),
+      count: Boolean(flags["count"]),
+    }),
+  });
+}
+
+/**
  * Pagination flag preset.
  *
  * Adds: `-l, --limit <n>`, `--next`, `--reset`
@@ -413,5 +468,6 @@ export type {
   InteractionFlags,
   PaginationFlags,
   PaginationPresetConfig,
+  ProjectionFlags,
   StrictFlags,
 } from "./types.js";

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -201,6 +201,21 @@ export type StrictFlags = {
 };
 
 /**
+ * Resolved projection flags from CLI input.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+export type ProjectionFlags = {
+  /** Fields to include (undefined = all) */
+  readonly fields: string[] | undefined;
+
+  /** Fields to exclude (undefined = none) */
+  readonly excludeFields: string[] | undefined;
+
+  /** Whether to output only the count of results */
+  readonly count: boolean;
+};
+
+/**
  * Color mode for CLI output.
  */
 export type ColorMode = "auto" | "always" | "never";


### PR DESCRIPTION
## Context
Add projection conventions for selecting/omitting fields and count-only output across list-like commands.

## What Changed
- Added projection preset support for include/exclude field controls and count mode.
- Extended CLI types for projection preset resolution.
- Added tests for defaults, field parsing, and composition.

## Validation
- Added/updated tests in `packages/cli/src/__tests__/flags-projection.test.ts`.
- Full stack pre-push verification from top branch (`verify:ci`) passed.

## Risks / Notes
- Low risk; additive preset and typing updates.
