### PR TITLE
feat(cli): add time-window and execution presets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/cli-demo": {
       "name": "outfitter-cli-demo",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "outfitter-demo": "./dist/cli.js",
         "cli-demo": "./dist/cli.js",
@@ -42,7 +42,7 @@
     },
     "apps/outfitter": {
       "name": "outfitter",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "bin": {
         "outfitter": "./dist/cli.js",
         "out": "./dist/cli.js",
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "@outfitter/cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "better-result": "^2.5.1",
@@ -101,7 +101,7 @@
     },
     "packages/config": {
       "name": "@outfitter/config",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/contracts": {
       "name": "@outfitter/contracts",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "better-result": "^2.5.0",
         "zod": "^4.3.5",
@@ -126,7 +126,7 @@
     },
     "packages/daemon": {
       "name": "@outfitter/daemon",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -139,7 +139,7 @@
     },
     "packages/docs": {
       "name": "@outfitter/docs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "outfitter-docs": "./dist/cli.js",
       },
@@ -154,7 +154,7 @@
     },
     "packages/docs-core": {
       "name": "@outfitter/docs-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "better-result": "^2.5.0",
       },
@@ -165,7 +165,7 @@
     },
     "packages/file-ops": {
       "name": "@outfitter/file-ops",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -177,7 +177,7 @@
     },
     "packages/index": {
       "name": "@outfitter/index",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/file-ops": "workspace:*",
@@ -189,7 +189,7 @@
     },
     "packages/kit": {
       "name": "@outfitter/kit",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "packages/logging": {
       "name": "@outfitter/logging",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@logtape/logtape": "^2.0.0",
       },
@@ -218,7 +218,7 @@
     },
     "packages/mcp": {
       "name": "@outfitter/mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^4.3.5",
@@ -238,7 +238,7 @@
     },
     "packages/state": {
       "name": "@outfitter/state",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/types": "workspace:*",
@@ -250,7 +250,7 @@
     },
     "packages/testing": {
       "name": "@outfitter/testing",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "@outfitter/mcp": "workspace:*",
@@ -263,7 +263,7 @@
     },
     "packages/tooling": {
       "name": "@outfitter/tooling",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "bin": {
         "tooling": "./dist/cli/index.js",
       },
@@ -289,7 +289,7 @@
     },
     "packages/tui": {
       "name": "@outfitter/tui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "better-result": "^2.5.1",
@@ -310,7 +310,7 @@
     },
     "packages/types": {
       "name": "@outfitter/types",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@outfitter/contracts": "workspace:*",
         "better-result": "^2.5.0",

--- a/packages/cli/src/__tests__/flags-time-execution.test.ts
+++ b/packages/cli/src/__tests__/flags-time-execution.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from "bun:test";
+import {
+  composePresets,
+  executionPreset,
+  timeWindowPreset,
+  verbosePreset,
+} from "../flags.js";
+
+describe("timeWindowPreset", () => {
+  describe("defaults", () => {
+    it("has id 'timeWindow'", () => {
+      const preset = timeWindowPreset();
+      expect(preset.id).toBe("timeWindow");
+    });
+
+    it("defines two options", () => {
+      const preset = timeWindowPreset();
+      expect(preset.options).toHaveLength(2);
+      expect(preset.options.map((o) => o.flags)).toEqual([
+        "--since <date>",
+        "--until <date>",
+      ]);
+    });
+
+    it("resolves both as undefined by default", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({});
+      expect(result).toEqual({ since: undefined, until: undefined });
+    });
+
+    it("returns fresh instance per call", () => {
+      expect(timeWindowPreset()).not.toBe(timeWindowPreset());
+    });
+  });
+
+  describe("ISO date parsing", () => {
+    it("parses ISO 8601 date string for --since", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ since: "2024-01-15" });
+      expect(result.since).toBeInstanceOf(Date);
+      expect(result.since?.toISOString()).toContain("2024-01-15");
+    });
+
+    it("parses ISO 8601 date string for --until", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ until: "2024-06-30" });
+      expect(result.until).toBeInstanceOf(Date);
+      expect(result.until?.toISOString()).toContain("2024-06-30");
+    });
+
+    it("parses full ISO 8601 datetime", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ since: "2024-01-15T10:30:00Z" });
+      expect(result.since).toBeInstanceOf(Date);
+      expect(result.since?.getUTCHours()).toBe(10);
+    });
+  });
+
+  describe("duration parsing", () => {
+    it("parses days duration (7d)", () => {
+      const preset = timeWindowPreset();
+      const before = Date.now();
+      const result = preset.resolve({ since: "7d" });
+      const after = Date.now();
+
+      expect(result.since).toBeInstanceOf(Date);
+      const expected = 7 * 24 * 60 * 60 * 1000;
+      expect(before - result.since?.getTime()).toBeGreaterThanOrEqual(
+        expected - 100
+      );
+      expect(after - result.since?.getTime()).toBeLessThanOrEqual(
+        expected + 100
+      );
+    });
+
+    it("parses hours duration (24h)", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ since: "24h" });
+      expect(result.since).toBeInstanceOf(Date);
+      const diff = Date.now() - result.since?.getTime();
+      expect(diff).toBeGreaterThan(23 * 60 * 60 * 1000);
+      expect(diff).toBeLessThan(25 * 60 * 60 * 1000);
+    });
+
+    it("parses minutes duration (30m)", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ since: "30m" });
+      expect(result.since).toBeInstanceOf(Date);
+      const diff = Date.now() - result.since?.getTime();
+      expect(diff).toBeGreaterThan(29 * 60 * 1000);
+      expect(diff).toBeLessThan(31 * 60 * 1000);
+    });
+
+    it("parses weeks duration (2w)", () => {
+      const preset = timeWindowPreset();
+      const result = preset.resolve({ since: "2w" });
+      expect(result.since).toBeInstanceOf(Date);
+      const diff = Date.now() - result.since?.getTime();
+      const expected = 14 * 24 * 60 * 60 * 1000;
+      expect(diff).toBeGreaterThan(expected - 1000);
+      expect(diff).toBeLessThan(expected + 1000);
+    });
+
+    it("uses a single timestamp when resolving relative since/until", () => {
+      const preset = timeWindowPreset();
+      const originalNow = Date.now;
+      Date.now = () => 1_000_000;
+      try {
+        const result = preset.resolve({ since: "1h", until: "30m" });
+        expect(result.since).toBeInstanceOf(Date);
+        expect(result.until).toBeInstanceOf(Date);
+        if (!(result.since instanceof Date && result.until instanceof Date)) {
+          throw new Error("Expected both since and until to be dates");
+        }
+        expect(result.until.getTime() - result.since.getTime()).toBe(
+          30 * 60 * 1000
+        );
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns undefined for invalid strings", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: "not-a-date" }).since).toBeUndefined();
+    });
+
+    it("returns undefined for empty string", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: "" }).since).toBeUndefined();
+    });
+
+    it("returns undefined for non-string values", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: 42 }).since).toBeUndefined();
+      expect(preset.resolve({ since: true }).since).toBeUndefined();
+    });
+
+    it("returns undefined for invalid duration suffix", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: "7x" }).since).toBeUndefined();
+    });
+
+    it("returns undefined for zero duration", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: "0d" }).since).toBeUndefined();
+    });
+
+    it("returns undefined for negative duration", () => {
+      const preset = timeWindowPreset();
+      expect(preset.resolve({ since: "-7d" }).since).toBeUndefined();
+    });
+  });
+
+  describe("composition", () => {
+    it("composes with other presets", () => {
+      const composed = composePresets(timeWindowPreset(), verbosePreset());
+      expect(composed.options).toHaveLength(3);
+      const result = composed.resolve({ since: "7d", verbose: true });
+      expect(result.verbose).toBe(true);
+      expect(result.since).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("maxRange config", () => {
+    it("keeps parsed dates when range is within maxRange", () => {
+      const preset = timeWindowPreset({
+        maxRange: 24 * 60 * 60 * 1000, // 1 day
+      });
+      const result = preset.resolve({
+        since: "2024-01-01T00:00:00Z",
+        until: "2024-01-01T12:00:00Z",
+      });
+
+      expect(result.since).toBeInstanceOf(Date);
+      expect(result.until).toBeInstanceOf(Date);
+    });
+
+    it("invalidates both bounds when range exceeds maxRange", () => {
+      const preset = timeWindowPreset({
+        maxRange: 6 * 60 * 60 * 1000, // 6 hours
+      });
+      const result = preset.resolve({
+        since: "2024-01-01T00:00:00Z",
+        until: "2024-01-02T00:00:00Z",
+      });
+
+      expect(result).toEqual({
+        since: undefined,
+        until: undefined,
+      });
+    });
+
+    it("does not enforce maxRange when only one bound is provided", () => {
+      const preset = timeWindowPreset({
+        maxRange: 60 * 1000,
+      });
+      const result = preset.resolve({
+        since: "2024-01-01T00:00:00Z",
+      });
+
+      expect(result.since).toBeInstanceOf(Date);
+      expect(result.until).toBeUndefined();
+    });
+  });
+});
+
+describe("executionPreset", () => {
+  describe("defaults", () => {
+    it("has id 'execution'", () => {
+      const preset = executionPreset();
+      expect(preset.id).toBe("execution");
+    });
+
+    it("defines three options", () => {
+      const preset = executionPreset();
+      expect(preset.options).toHaveLength(3);
+      expect(preset.options.map((o) => o.flags)).toEqual([
+        "--timeout <ms>",
+        "--retries <n>",
+        "--offline",
+      ]);
+    });
+
+    it("resolves with defaults", () => {
+      const preset = executionPreset();
+      const result = preset.resolve({});
+      expect(result).toEqual({
+        timeout: undefined,
+        retries: 0,
+        offline: false,
+      });
+    });
+
+    it("returns fresh instance per call", () => {
+      expect(executionPreset()).not.toBe(executionPreset());
+    });
+  });
+
+  describe("timeout resolution", () => {
+    it("parses string timeout", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ timeout: "5000" }).timeout).toBe(5000);
+    });
+
+    it("parses numeric timeout", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ timeout: 3000 }).timeout).toBe(3000);
+    });
+
+    it("returns undefined for zero", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ timeout: "0" }).timeout).toBeUndefined();
+    });
+
+    it("returns undefined for negative", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ timeout: "-100" }).timeout).toBeUndefined();
+    });
+
+    it("returns undefined for invalid string", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ timeout: "abc" }).timeout).toBeUndefined();
+    });
+
+    it("returns undefined when not provided", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({}).timeout).toBeUndefined();
+    });
+  });
+
+  describe("retries resolution", () => {
+    it("parses string retries", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: "3" }).retries).toBe(3);
+    });
+
+    it("parses numeric retries", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: 5 }).retries).toBe(5);
+    });
+
+    it("defaults to 0 when not provided", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({}).retries).toBe(0);
+    });
+
+    it("defaults to 0 for invalid input", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: "abc" }).retries).toBe(0);
+    });
+
+    it("clamps to maxRetries (default 10)", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: "20" }).retries).toBe(10);
+    });
+
+    it("clamps to custom maxRetries", () => {
+      const preset = executionPreset({ maxRetries: 5 });
+      expect(preset.resolve({ retries: "8" }).retries).toBe(5);
+    });
+
+    it("defaults to 0 for negative values", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: "-3" }).retries).toBe(0);
+    });
+
+    it("floors fractional values", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ retries: "2.7" }).retries).toBe(2);
+    });
+  });
+
+  describe("offline resolution", () => {
+    it("resolves offline as true when passed", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({ offline: true }).offline).toBe(true);
+    });
+
+    it("resolves offline as false by default", () => {
+      const preset = executionPreset();
+      expect(preset.resolve({}).offline).toBe(false);
+    });
+  });
+
+  describe("custom config", () => {
+    it("uses custom defaultTimeout", () => {
+      const preset = executionPreset({ defaultTimeout: 5000 });
+      expect(preset.resolve({}).timeout).toBe(5000);
+    });
+
+    it("uses custom defaultRetries", () => {
+      const preset = executionPreset({ defaultRetries: 3 });
+      expect(preset.resolve({}).retries).toBe(3);
+    });
+  });
+
+  describe("composition", () => {
+    it("composes with time-window and other presets", () => {
+      const composed = composePresets(
+        timeWindowPreset(),
+        executionPreset(),
+        verbosePreset()
+      );
+      expect(composed.options).toHaveLength(6);
+      const result = composed.resolve({
+        timeout: "5000",
+        retries: "2",
+        verbose: true,
+      });
+      expect(result).toEqual({
+        since: undefined,
+        until: undefined,
+        timeout: 5000,
+        retries: 2,
+        offline: false,
+        verbose: true,
+      });
+    });
+
+    it("deduplicates by id when composed twice", () => {
+      const composed = composePresets(executionPreset(), executionPreset());
+      expect(composed.options).toHaveLength(3);
+    });
+  });
+});

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -201,6 +201,55 @@ export type StrictFlags = {
 };
 
 /**
+ * Resolved time-window flags from CLI input.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+export type TimeWindowFlags = {
+  /** Start of time window */
+  readonly since: Date | undefined;
+
+  /** End of time window */
+  readonly until: Date | undefined;
+};
+
+/**
+ * Configuration for the time-window flag preset.
+ */
+export interface TimeWindowPresetConfig {
+  /** Maximum range in milliseconds between since and until (optional guard) */
+  readonly maxRange?: number;
+}
+
+/**
+ * Resolved execution flags from CLI input.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+export type ExecutionFlags = {
+  /** Timeout in milliseconds (undefined = no timeout) */
+  readonly timeout: number | undefined;
+
+  /** Number of retries */
+  readonly retries: number;
+
+  /** Whether to operate in offline mode */
+  readonly offline: boolean;
+};
+
+/**
+ * Configuration for the execution flag preset.
+ */
+export interface ExecutionPresetConfig {
+  /** Default timeout in milliseconds (default: undefined) */
+  readonly defaultTimeout?: number;
+
+  /** Default number of retries (default: 0) */
+  readonly defaultRetries?: number;
+
+  /** Maximum number of retries (default: 10) */
+  readonly maxRetries?: number;
+}
+
+/**
  * Resolved projection flags from CLI input.
  */
 // biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>


### PR DESCRIPTION
## Context
Add time-window and execution control presets to standardize common runtime controls across commands.

## What Changed
- Added `timeWindowPreset` for `since`/`until` style windows.
- Added `executionPreset` for execution controls (timeout/retries/offline conventions).
- Extended CLI types for both preset outputs.
- Added focused tests for parsing, defaults, bounds, and composition.
- Included lockfile update required by dependency graph changes.

## Validation
- Added/updated tests in `packages/cli/src/__tests__/flags-time-execution.test.ts`.
- Full stack pre-push verification from top branch (`verify:ci`) passed.

## Risks / Notes
- Low risk; additive convention APIs with comprehensive tests.
