### PR TITLE
feat(cli): add command verb conventions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,6 +81,12 @@
         "types": "./dist/types.d.ts",
         "default": "./dist/types.js"
       }
+    },
+    "./verbs": {
+      "import": {
+        "types": "./dist/verbs.d.ts",
+        "default": "./dist/verbs.js"
+      }
     }
   },
   "sideEffects": false,

--- a/packages/cli/src/__tests__/verbs.test.ts
+++ b/packages/cli/src/__tests__/verbs.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import { applyVerb, resolveVerb, VERB_FAMILIES } from "../verbs.js";
+
+describe("VERB_FAMILIES", () => {
+  it("defines create family", () => {
+    expect(VERB_FAMILIES.create).toEqual({
+      primary: "create",
+      aliases: ["new"],
+      description: "Create a new resource",
+    });
+  });
+
+  it("defines modify family", () => {
+    expect(VERB_FAMILIES.modify).toEqual({
+      primary: "modify",
+      aliases: ["edit", "update"],
+      description: "Modify a resource",
+    });
+  });
+
+  it("defines remove family", () => {
+    expect(VERB_FAMILIES.remove).toEqual({
+      primary: "remove",
+      aliases: ["delete", "rm"],
+      description: "Remove a resource",
+    });
+  });
+
+  it("defines list family", () => {
+    expect(VERB_FAMILIES.list).toEqual({
+      primary: "list",
+      aliases: ["ls"],
+      description: "List resources",
+    });
+  });
+
+  it("defines show family", () => {
+    expect(VERB_FAMILIES.show).toEqual({
+      primary: "show",
+      aliases: ["get", "view"],
+      description: "Show details",
+    });
+  });
+});
+
+describe("resolveVerb", () => {
+  it("returns default primary and aliases for a family", () => {
+    const result = resolveVerb("create");
+    expect(result).toEqual({ name: "create", aliases: ["new"] });
+  });
+
+  it("overrides primary verb", () => {
+    const result = resolveVerb("modify", { primary: "edit" });
+    expect(result).toEqual({ name: "edit", aliases: ["update"] });
+  });
+
+  it("overrides primary and removes it from aliases", () => {
+    const result = resolveVerb("modify", { primary: "update" });
+    expect(result).toEqual({ name: "update", aliases: ["edit"] });
+  });
+
+  it("disables aliases when aliases: false", () => {
+    const result = resolveVerb("remove", { aliases: false });
+    expect(result).toEqual({ name: "remove", aliases: [] });
+  });
+
+  it("adds extra aliases", () => {
+    const result = resolveVerb("create", {
+      extraAliases: ["add", "init"],
+    });
+    expect(result).toEqual({
+      name: "create",
+      aliases: ["new", "add", "init"],
+    });
+  });
+
+  it("excludes specific aliases", () => {
+    const result = resolveVerb("modify", {
+      excludeAliases: ["update"],
+    });
+    expect(result).toEqual({ name: "modify", aliases: ["edit"] });
+  });
+
+  it("combines extra and exclude aliases", () => {
+    const result = resolveVerb("modify", {
+      extraAliases: ["patch"],
+      excludeAliases: ["update"],
+    });
+    expect(result).toEqual({
+      name: "modify",
+      aliases: ["edit", "patch"],
+    });
+  });
+
+  it("throws on unknown family", () => {
+    expect(() => resolveVerb("unknown")).toThrow(
+      'Unknown verb family: "unknown"'
+    );
+  });
+
+  it("rejects prototype keys as unknown families", () => {
+    expect(() => resolveVerb("__proto__")).toThrow(
+      'Unknown verb family: "__proto__"'
+    );
+    expect(() => resolveVerb("constructor")).toThrow(
+      'Unknown verb family: "constructor"'
+    );
+  });
+
+  it("deduplicates aliases", () => {
+    const result = resolveVerb("create", {
+      extraAliases: ["new"],
+    });
+    expect(result).toEqual({ name: "create", aliases: ["new"] });
+  });
+});
+
+describe("applyVerb", () => {
+  it("applies verb name and aliases to a command builder", () => {
+    const applied: { aliases: string[] } = { aliases: [] };
+    const mockBuilder = {
+      alias(a: string) {
+        applied.aliases.push(a);
+        return this;
+      },
+    };
+
+    applyVerb(mockBuilder as never, "remove");
+    expect(applied.aliases).toEqual(["delete", "rm"]);
+  });
+
+  it("respects config overrides", () => {
+    const applied: { aliases: string[] } = { aliases: [] };
+    const mockBuilder = {
+      alias(a: string) {
+        applied.aliases.push(a);
+        return this;
+      },
+    };
+
+    applyVerb(mockBuilder as never, "modify", { aliases: false });
+    expect(applied.aliases).toEqual([]);
+  });
+});

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -127,6 +127,41 @@ export interface CommandBuilder {
 }
 
 // =============================================================================
+// Verb Convention Types
+// =============================================================================
+
+/**
+ * A family of related command verbs with a primary name and aliases.
+ */
+export interface VerbFamily {
+  /** Primary verb name */
+  readonly primary: string;
+
+  /** Alternative names for this verb */
+  readonly aliases: readonly string[];
+
+  /** Description of what this verb family does */
+  readonly description: string;
+}
+
+/**
+ * Configuration for resolving a verb family with project-level overrides.
+ */
+export interface VerbConfig {
+  /** Override the primary verb (e.g., "edit" instead of "modify") */
+  readonly primary?: string;
+
+  /** Whether to include aliases (default: true) */
+  readonly aliases?: boolean;
+
+  /** Additional aliases beyond defaults */
+  readonly extraAliases?: readonly string[];
+
+  /** Aliases to exclude */
+  readonly excludeAliases?: readonly string[];
+}
+
+// =============================================================================
 // Flag Preset Types
 // =============================================================================
 

--- a/packages/cli/src/verbs.ts
+++ b/packages/cli/src/verbs.ts
@@ -1,0 +1,124 @@
+/**
+ * Command verb conventions for consistent CLI command naming.
+ *
+ * @packageDocumentation
+ */
+
+import type { CommandBuilder, VerbConfig, VerbFamily } from "./types.js";
+
+/**
+ * Built-in verb families with standard primary verbs and aliases.
+ *
+ * These follow POSIX and modern CLI conventions:
+ * - `create` / `new` — Create a new resource
+ * - `modify` / `edit` / `update` — Modify an existing resource
+ * - `remove` / `delete` / `rm` — Remove a resource
+ * - `list` / `ls` — List resources
+ * - `show` / `get` / `view` — Show resource details
+ */
+export const VERB_FAMILIES: Readonly<Record<string, VerbFamily>> = {
+  create: {
+    primary: "create",
+    aliases: ["new"],
+    description: "Create a new resource",
+  },
+  modify: {
+    primary: "modify",
+    aliases: ["edit", "update"],
+    description: "Modify a resource",
+  },
+  remove: {
+    primary: "remove",
+    aliases: ["delete", "rm"],
+    description: "Remove a resource",
+  },
+  list: {
+    primary: "list",
+    aliases: ["ls"],
+    description: "List resources",
+  },
+  show: {
+    primary: "show",
+    aliases: ["get", "view"],
+    description: "Show details",
+  },
+};
+
+/**
+ * Resolve a verb family with optional project-level config overrides.
+ *
+ * @param family - Name of the verb family (e.g., "create", "modify")
+ * @param config - Optional overrides for primary verb, aliases, etc.
+ * @returns Resolved verb name and aliases
+ *
+ * @example
+ * ```typescript
+ * resolveVerb("modify"); // { name: "modify", aliases: ["edit", "update"] }
+ * resolveVerb("modify", { primary: "edit" }); // { name: "edit", aliases: ["update"] }
+ * resolveVerb("remove", { aliases: false }); // { name: "remove", aliases: [] }
+ * ```
+ */
+export function resolveVerb(
+  family: string,
+  config?: VerbConfig
+): { name: string; aliases: string[] } {
+  const def = VERB_FAMILIES[family as keyof typeof VERB_FAMILIES];
+  if (!Object.hasOwn(VERB_FAMILIES, family) || def === undefined) {
+    throw new Error(`Unknown verb family: "${family}"`);
+  }
+
+  const name = config?.primary ?? def.primary;
+
+  if (config?.aliases === false) {
+    return { name, aliases: [] };
+  }
+
+  // Start with default aliases, removing the primary if it was promoted
+  let aliases = [...def.aliases].filter((a) => a !== name);
+
+  // Add extra aliases
+  if (config?.extraAliases) {
+    aliases.push(...config.extraAliases);
+  }
+
+  // Remove excluded aliases
+  if (config?.excludeAliases) {
+    const exclude = new Set(config.excludeAliases);
+    aliases = aliases.filter((a) => !exclude.has(a));
+  }
+
+  // Deduplicate
+  aliases = [...new Set(aliases)];
+
+  return { name, aliases };
+}
+
+/**
+ * Apply verb conventions to a CommandBuilder.
+ *
+ * Adds aliases from the resolved verb family to the command builder.
+ *
+ * @param builder - CommandBuilder to apply aliases to
+ * @param family - Name of the verb family
+ * @param config - Optional overrides
+ * @returns The builder for chaining
+ *
+ * @example
+ * ```typescript
+ * const cmd = command("remove <id>")
+ *   .description("Remove a resource");
+ * applyVerb(cmd, "remove");
+ * // Adds aliases: "delete", "rm"
+ * ```
+ */
+export function applyVerb(
+  builder: CommandBuilder,
+  family: string,
+  config?: VerbConfig
+): CommandBuilder {
+  const { aliases } = resolveVerb(family, config);
+  for (const alias of aliases) {
+    builder.alias(alias);
+  }
+  return builder;
+}


### PR DESCRIPTION
## Context
Introduce verb-family conventions for CLI commands to keep command naming and discoverability consistent.

## What Changed
- Added `verbs` conventions and exports in `packages/cli/src/verbs.ts`.
- Extended CLI shared types as needed for verb metadata.
- Added tests for verb mapping and behavior.
- Updated package metadata/exports accordingly.

## Validation
- Added/updated tests in `packages/cli/src/__tests__/verbs.test.ts`.
- Full stack pre-push verification from top branch (`verify:ci`) passed.

## Risks / Notes
- Low risk; additive API with tests and export wiring.
