### PR TITLE
feat(cli): add queryability conventions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,6 +82,12 @@
         "default": "./dist/types.js"
       }
     },
+    "./query": {
+      "import": {
+        "types": "./dist/query.d.ts",
+        "default": "./dist/query.js"
+      }
+    },
     "./verbs": {
       "import": {
         "types": "./dist/verbs.d.ts",

--- a/packages/cli/src/__tests__/query.test.ts
+++ b/packages/cli/src/__tests__/query.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "bun:test";
+import { composePresets, verbosePreset } from "../flags.js";
+import { jqPreset, outputModePreset } from "../query.js";
+
+describe("outputModePreset", () => {
+  describe("defaults", () => {
+    it("has id 'outputMode'", () => {
+      const preset = outputModePreset();
+      expect(preset.id).toBe("outputMode");
+    });
+
+    it("defines one option", () => {
+      const preset = outputModePreset();
+      expect(preset.options).toHaveLength(1);
+      expect(preset.options[0]?.flags).toBe("-o, --output <mode>");
+    });
+
+    it("resolves to 'human' by default", () => {
+      const preset = outputModePreset();
+      expect(preset.resolve({}).outputMode).toBe("human");
+    });
+
+    it("returns fresh instance per call", () => {
+      expect(outputModePreset()).not.toBe(outputModePreset());
+    });
+  });
+
+  describe("output mode resolution", () => {
+    it("resolves 'json' mode", () => {
+      const preset = outputModePreset();
+      expect(preset.resolve({ output: "json" }).outputMode).toBe("json");
+    });
+
+    it("resolves 'human' mode", () => {
+      const preset = outputModePreset();
+      expect(preset.resolve({ output: "human" }).outputMode).toBe("human");
+    });
+
+    it("defaults to 'human' on invalid input", () => {
+      const preset = outputModePreset();
+      expect(preset.resolve({ output: "invalid" }).outputMode).toBe("human");
+    });
+
+    it("defaults to 'human' on non-string input", () => {
+      const preset = outputModePreset();
+      expect(preset.resolve({ output: 42 }).outputMode).toBe("human");
+    });
+  });
+
+  describe("custom config", () => {
+    it("supports custom default mode", () => {
+      const preset = outputModePreset({ defaultMode: "json" });
+      expect(preset.resolve({}).outputMode).toBe("json");
+    });
+
+    it("supports custom modes list", () => {
+      const preset = outputModePreset({
+        modes: ["human", "json", "table"],
+      });
+      expect(preset.resolve({ output: "table" }).outputMode).toBe("table");
+    });
+
+    it("rejects modes not in the allowed list", () => {
+      const preset = outputModePreset({
+        modes: ["human", "json"],
+      });
+      expect(preset.resolve({ output: "table" }).outputMode).toBe("human");
+    });
+
+    it("includes jsonl when configured", () => {
+      const preset = outputModePreset({ includeJsonl: true });
+      expect(preset.resolve({ output: "jsonl" }).outputMode).toBe("jsonl");
+    });
+
+    it("accepts defaultMode even when modes list omits it", () => {
+      const preset = outputModePreset({
+        modes: ["json"],
+        defaultMode: "jsonl",
+      });
+      expect(preset.resolve({}).outputMode).toBe("jsonl");
+      expect(preset.resolve({ output: "jsonl" }).outputMode).toBe("jsonl");
+    });
+  });
+
+  describe("composition", () => {
+    it("composes with other presets", () => {
+      const composed = composePresets(outputModePreset(), verbosePreset());
+      expect(composed.options).toHaveLength(2);
+      const result = composed.resolve({
+        output: "json",
+        verbose: true,
+      });
+      expect(result).toEqual({
+        outputMode: "json",
+        verbose: true,
+      });
+    });
+  });
+});
+
+describe("jqPreset", () => {
+  describe("defaults", () => {
+    it("has id 'jq'", () => {
+      const preset = jqPreset();
+      expect(preset.id).toBe("jq");
+    });
+
+    it("defines one option", () => {
+      const preset = jqPreset();
+      expect(preset.options).toHaveLength(1);
+      expect(preset.options[0]?.flags).toBe("--jq <expr>");
+    });
+
+    it("resolves to undefined by default", () => {
+      const preset = jqPreset();
+      expect(preset.resolve({}).jq).toBeUndefined();
+    });
+
+    it("returns fresh instance per call", () => {
+      expect(jqPreset()).not.toBe(jqPreset());
+    });
+  });
+
+  describe("jq expression resolution", () => {
+    it("resolves a jq expression", () => {
+      const preset = jqPreset();
+      expect(preset.resolve({ jq: ".data[]" }).jq).toBe(".data[]");
+    });
+
+    it("resolves complex jq expression", () => {
+      const preset = jqPreset();
+      expect(
+        preset.resolve({ jq: ".[] | select(.active == true) | .name" }).jq
+      ).toBe(".[] | select(.active == true) | .name");
+    });
+
+    it("returns undefined for non-string input", () => {
+      const preset = jqPreset();
+      expect(preset.resolve({ jq: 42 }).jq).toBeUndefined();
+    });
+
+    it("returns undefined for empty string", () => {
+      const preset = jqPreset();
+      expect(preset.resolve({ jq: "" }).jq).toBeUndefined();
+    });
+  });
+
+  describe("composition", () => {
+    it("composes with outputMode preset", () => {
+      const composed = composePresets(outputModePreset(), jqPreset());
+      expect(composed.options).toHaveLength(2);
+      const result = composed.resolve({
+        output: "json",
+        jq: ".data",
+      });
+      expect(result).toEqual({
+        outputMode: "json",
+        jq: ".data",
+      });
+    });
+  });
+});

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -1,0 +1,119 @@
+/**
+ * Queryability conventions for CLI commands.
+ *
+ * Provides presets for output mode selection and jq expression filtering.
+ *
+ * @packageDocumentation
+ */
+
+import { createPreset } from "./flags.js";
+import type { FlagPreset, OutputMode } from "./types.js";
+
+// =============================================================================
+// Output Mode Preset
+// =============================================================================
+
+/**
+ * Configuration for the output mode preset.
+ */
+export interface OutputModePresetConfig {
+  /** Allowed output modes (default: ["human", "json"]) */
+  readonly modes?: readonly OutputMode[];
+
+  /** Default mode when not specified (default: "human") */
+  readonly defaultMode?: OutputMode;
+
+  /** Whether to include "jsonl" in allowed modes (default: false) */
+  readonly includeJsonl?: boolean;
+}
+
+/**
+ * Resolved output mode from CLI input.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+export type OutputModeFlags = {
+  /** The resolved output mode */
+  readonly outputMode: OutputMode;
+};
+
+/**
+ * Output mode flag preset.
+ *
+ * Adds: `-o, --output <mode>`
+ * Resolves: `{ outputMode: string }`
+ *
+ * Replaces ad-hoc `--json`/`--jsonl` handling with a single
+ * `--output` flag that accepts a mode name. Invalid modes
+ * fall back to the configured default.
+ *
+ * @param config - Optional configuration for allowed modes and default
+ */
+export function outputModePreset(
+  config?: OutputModePresetConfig
+): FlagPreset<OutputModeFlags> {
+  const defaultMode = config?.defaultMode ?? "human";
+  const baseModes = config?.modes ?? (["human", "json"] as const);
+  const modes = new Set<OutputMode>(
+    config?.includeJsonl ? [...baseModes, "jsonl"] : baseModes
+  );
+  modes.add(defaultMode);
+
+  return createPreset({
+    id: "outputMode",
+    options: [
+      {
+        flags: "-o, --output <mode>",
+        description: `Output mode (${[...modes].join(", ")})`,
+        defaultValue: defaultMode,
+      },
+    ],
+    resolve: (flags) => {
+      const raw = flags["output"];
+      if (typeof raw === "string" && modes.has(raw as OutputMode)) {
+        return { outputMode: raw as OutputMode };
+      }
+      return { outputMode: defaultMode };
+    },
+  });
+}
+
+// =============================================================================
+// JQ Preset
+// =============================================================================
+
+/**
+ * Resolved jq expression from CLI input.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+export type JqFlags = {
+  /** The jq expression, or undefined if not provided */
+  readonly jq: string | undefined;
+};
+
+/**
+ * JQ expression flag preset.
+ *
+ * Adds: `--jq <expr>`
+ * Resolves: `{ jq: string | undefined }`
+ *
+ * The resolver returns the expression string or `undefined`.
+ * Actual jq execution is a consumer concern.
+ */
+export function jqPreset(): FlagPreset<JqFlags> {
+  return createPreset({
+    id: "jq",
+    options: [
+      {
+        flags: "--jq <expr>",
+        description: "Filter JSON output with a jq expression",
+      },
+    ],
+    resolve: (flags) => {
+      const raw = flags["jq"];
+      if (typeof raw === "string" && raw.length > 0) {
+        return { jq: raw };
+      }
+      return { jq: undefined };
+    },
+  });
+}


### PR DESCRIPTION
Add outputModePreset and jqPreset for structured output mode
selection and jq expression filtering. Replaces ad-hoc --json/--jsonl
handling with a composable --output <mode> flag and --jq <expr>.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)