### PR TITLE
feat(cli): add shell completion conventions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,12 @@
         "default": "./dist/command.js"
       }
     },
+    "./completion": {
+      "import": {
+        "types": "./dist/completion.d.ts",
+        "default": "./dist/completion.js"
+      }
+    },
     "./flags": {
       "import": {
         "types": "./dist/flags.d.ts",
@@ -58,6 +64,12 @@
         "default": "./dist/pagination.js"
       }
     },
+    "./query": {
+      "import": {
+        "types": "./dist/query.d.ts",
+        "default": "./dist/query.js"
+      }
+    },
     "./terminal": {
       "import": {
         "types": "./dist/terminal/index.d.ts",
@@ -80,12 +92,6 @@
       "import": {
         "types": "./dist/types.d.ts",
         "default": "./dist/types.js"
-      }
-    },
-    "./query": {
-      "import": {
-        "types": "./dist/query.d.ts",
-        "default": "./dist/query.js"
       }
     },
     "./verbs": {

--- a/packages/cli/src/__tests__/completion.test.ts
+++ b/packages/cli/src/__tests__/completion.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
+import { createCompletionCommand, generateCompletion } from "../completion.js";
+
+describe("createCompletionCommand", () => {
+  describe("defaults", () => {
+    it("creates a 'completion' command", () => {
+      const cmd = createCompletionCommand();
+      expect(cmd.name()).toBe("completion");
+    });
+
+    it("has a description", () => {
+      const cmd = createCompletionCommand();
+      expect(cmd.description()).toBeTruthy();
+    });
+
+    it("accepts a shell argument", () => {
+      const cmd = createCompletionCommand();
+      const args = cmd.registeredArguments;
+      expect(args).toHaveLength(1);
+      expect(args[0]?.name()).toBe("shell");
+    });
+
+    it("includes all three shells in description by default", () => {
+      const cmd = createCompletionCommand();
+      const desc = cmd.description();
+      expect(desc).toContain("bash");
+      expect(desc).toContain("zsh");
+      expect(desc).toContain("fish");
+    });
+  });
+
+  describe("custom config", () => {
+    it("accepts custom program name", () => {
+      const cmd = createCompletionCommand({ programName: "mycli" });
+      expect(cmd.name()).toBe("completion");
+    });
+
+    it("limits shells in description", () => {
+      const cmd = createCompletionCommand({
+        shells: ["bash", "zsh"],
+      });
+      const desc = cmd.description();
+      expect(desc).toContain("bash");
+      expect(desc).toContain("zsh");
+      expect(desc).not.toContain("fish");
+    });
+
+    it("infers program name from parent command when not configured", async () => {
+      const root = new Command("mycli");
+      root.addCommand(createCompletionCommand());
+
+      let captured = "";
+      const originalWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = ((
+        chunk: string | Uint8Array,
+        encodingOrCallback?: BufferEncoding | ((error?: Error) => void),
+        callback?: (error?: Error) => void
+      ) => {
+        captured +=
+          typeof chunk === "string"
+            ? chunk
+            : Buffer.from(chunk).toString("utf8");
+
+        const done =
+          typeof encodingOrCallback === "function"
+            ? encodingOrCallback
+            : callback;
+        done?.();
+        return true;
+      }) as typeof process.stdout.write;
+
+      try {
+        await root.parseAsync(["completion", "bash"], { from: "user" });
+      } finally {
+        process.stdout.write = originalWrite;
+      }
+
+      expect(captured).toContain("mycli");
+      expect(captured).not.toContain("program");
+    });
+  });
+});
+
+describe("generateCompletion", () => {
+  describe("bash", () => {
+    it("generates a bash completion script", () => {
+      const script = generateCompletion("bash", "mycli");
+      expect(script).toBeDefined();
+      expect(script).toContain("mycli");
+      expect(script).toContain("complete -F");
+      expect(script).toContain("_mycli_completions");
+    });
+
+    it("includes setup instructions", () => {
+      const script = generateCompletion("bash", "mycli");
+      expect(script).toContain("~/.bashrc");
+    });
+  });
+
+  describe("zsh", () => {
+    it("generates a zsh completion script", () => {
+      const script = generateCompletion("zsh", "mycli");
+      expect(script).toBeDefined();
+      expect(script).toContain("mycli");
+      expect(script).toContain("compdef");
+      expect(script).toContain("_mycli");
+    });
+
+    it("includes compdef directive", () => {
+      const script = generateCompletion("zsh", "mycli");
+      expect(script).toContain("#compdef mycli");
+    });
+  });
+
+  describe("fish", () => {
+    it("generates a fish completion script", () => {
+      const script = generateCompletion("fish", "mycli");
+      expect(script).toBeDefined();
+      expect(script).toContain("mycli");
+      expect(script).toContain("complete -c mycli");
+    });
+
+    it("includes file path hint", () => {
+      const script = generateCompletion("fish", "mycli");
+      expect(script).toContain("completions/mycli.fish");
+    });
+  });
+
+  describe("unsupported shell", () => {
+    it("returns undefined for unknown shell", () => {
+      expect(generateCompletion("powershell", "mycli")).toBeUndefined();
+    });
+
+    it("returns undefined for prototype property keys", () => {
+      expect(generateCompletion("__proto__", "mycli")).toBeUndefined();
+      expect(generateCompletion("constructor", "mycli")).toBeUndefined();
+      expect(generateCompletion("toString", "mycli")).toBeUndefined();
+    });
+  });
+
+  describe("program name substitution", () => {
+    it("uses custom program name throughout", () => {
+      const script = generateCompletion("bash", "my-special-tool");
+      expect(script).toContain("my-special-tool");
+      expect(script).not.toContain("mycli");
+    });
+
+    it("sanitizes bash function names for hyphenated program names", () => {
+      const script = generateCompletion("bash", "my-special-tool");
+      expect(script).toContain("_my_special_tool_completions()");
+      expect(script).toContain(
+        "complete -F _my_special_tool_completions my-special-tool"
+      );
+    });
+
+    it("sanitizes zsh function names for hyphenated program names", () => {
+      const script = generateCompletion("zsh", "my-special-tool");
+      expect(script).toContain("_my_special_tool()");
+      expect(script).toContain("compdef _my_special_tool my-special-tool");
+    });
+
+    it("rejects unsafe program names", () => {
+      expect(() => generateCompletion("bash", "mycli;rm -rf /")).toThrow(
+        "Invalid program name for shell completion"
+      );
+    });
+  });
+});

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -1,0 +1,165 @@
+/**
+ * Shell completion script generation for CLI commands.
+ *
+ * Creates a `completion <shell>` command that outputs install-ready
+ * completion scripts for bash, zsh, and fish.
+ *
+ * @packageDocumentation
+ */
+
+import { Command } from "commander";
+
+/**
+ * Configuration for the completion command.
+ */
+export interface CompletionConfig {
+  /** Supported shells (default: bash, zsh, fish) */
+  readonly shells?: readonly ("bash" | "zsh" | "fish")[];
+
+  /** Program name for completion scripts (inferred from CLI name if not provided) */
+  readonly programName?: string;
+}
+
+type Shell = "bash" | "zsh" | "fish";
+const SHELL_SAFE_PROGRAM_NAME = /^[A-Za-z0-9._-]+$/;
+
+function assertSafeProgramName(programName: string): void {
+  if (SHELL_SAFE_PROGRAM_NAME.test(programName)) return;
+
+  throw new Error(
+    `Invalid program name for shell completion: "${programName}".` +
+      " Must match /^[A-Za-z0-9._-]+$/."
+  );
+}
+
+function toShellIdentifier(programName: string): string {
+  assertSafeProgramName(programName);
+  return programName.replaceAll(/[^A-Za-z0-9_]/g, "_");
+}
+
+/**
+ * Generate a bash completion script.
+ */
+function generateBashCompletion(programName: string): string {
+  assertSafeProgramName(programName);
+  const shellIdentifier = toShellIdentifier(programName);
+
+  return `# bash completion for ${programName}
+# Add to ~/.bashrc or ~/.bash_profile:
+#   eval "$(${programName} completion bash)"
+
+_${shellIdentifier}_completions() {
+  local cur
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+
+  COMPREPLY=( $(compgen -W "$(${programName} --help 2>/dev/null | grep -oE '^  [a-z][-a-z]*' | tr -d ' ')" -- "\${cur}") )
+}
+
+complete -F _${shellIdentifier}_completions ${programName}
+`;
+}
+
+/**
+ * Generate a zsh completion script.
+ */
+function generateZshCompletion(programName: string): string {
+  assertSafeProgramName(programName);
+  const shellIdentifier = toShellIdentifier(programName);
+
+  return `#compdef ${programName}
+# zsh completion for ${programName}
+# Add to ~/.zshrc:
+#   eval "$(${programName} completion zsh)"
+
+_${shellIdentifier}() {
+  local -a commands
+  commands=($(${programName} --help 2>/dev/null | grep -oE '^  [a-z][-a-z]*' | tr -d ' '))
+
+  _arguments \\
+    '1:command:compadd -a commands' \\
+    '*::arg:->args'
+}
+
+compdef _${shellIdentifier} ${programName}
+`;
+}
+
+/**
+ * Generate a fish completion script.
+ */
+function generateFishCompletion(programName: string): string {
+  assertSafeProgramName(programName);
+  return `# fish completion for ${programName}
+# Add to ~/.config/fish/completions/${programName}.fish:
+#   ${programName} completion fish > ~/.config/fish/completions/${programName}.fish
+
+complete -c ${programName} -f
+complete -c ${programName} -n "__fish_use_subcommand" -a "(${programName} --help 2>/dev/null | string match -r '^  [a-z][-a-z]*' | string trim)"
+`;
+}
+
+const GENERATORS: Record<Shell, (name: string) => string> = {
+  bash: generateBashCompletion,
+  zsh: generateZshCompletion,
+  fish: generateFishCompletion,
+};
+
+/**
+ * Generate a completion script for the given shell.
+ *
+ * @param shell - Target shell
+ * @param programName - CLI program name
+ * @returns The completion script string, or undefined for unsupported shells
+ */
+export function generateCompletion(
+  shell: string,
+  programName: string
+): string | undefined {
+  const generator = Object.hasOwn(GENERATORS, shell)
+    ? GENERATORS[shell as Shell]
+    : undefined;
+  return generator?.(programName);
+}
+
+/**
+ * Create a `completion <shell>` command that outputs install-ready
+ * completion scripts.
+ *
+ * @param config - Optional configuration
+ * @returns A Commander command instance
+ *
+ * @example
+ * ```typescript
+ * import { createCLI } from "@outfitter/cli";
+ * import { createCompletionCommand } from "@outfitter/cli/completion";
+ *
+ * const cli = createCLI({ name: "mycli", version: "1.0.0" });
+ * cli.register(createCompletionCommand({ programName: "mycli" }));
+ * ```
+ */
+export function createCompletionCommand(config?: CompletionConfig): Command {
+  const shells = config?.shells ?? (["bash", "zsh", "fish"] as const);
+  const shellSet = new Set<string>(shells);
+
+  const cmd = new Command("completion")
+    .description(`Generate shell completion script (${shells.join(", ")})`)
+    .argument("<shell>", `Shell type (${shells.join(", ")})`)
+    .action((shell: string) => {
+      if (!shellSet.has(shell)) {
+        cmd.error(
+          `error: unsupported shell '${shell}'. Supported: ${shells.join(", ")}`
+        );
+        return;
+      }
+      const generator = GENERATORS[shell as Shell];
+      if (generator) {
+        const programName =
+          config?.programName ?? cmd.parent?.name() ?? "program";
+        assertSafeProgramName(programName);
+        const script = generator(programName);
+        process.stdout.write(script);
+      }
+    });
+
+  return cmd;
+}


### PR DESCRIPTION
Add createCompletionCommand and generateCompletion for bash, zsh,
and fish shell completion script generation. Supports custom program
names and configurable shell targets.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)