### PR TITLE
feat(cli): adopt flag presets in check action and templates

### DIFF
--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -157,7 +157,7 @@ describe("init command file creation", () => {
     );
     expect(packageJson.scripts["clean:artifacts"]).toBe("rm -rf dist .turbo");
     expect(packageJson.dependencies["@outfitter/kit"]).toBe("^0.1.0-rc.0");
-    expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.1.0-rc.0");
+    expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.4.0");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.1.0-rc.0");
     expect(packageJson.dependencies["@outfitter/contracts"]).toBeUndefined();
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();

--- a/apps/outfitter/templates/cli/package.json.template
+++ b/apps/outfitter/templates/cli/package.json.template
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"@outfitter/kit": "^0.1.0-rc.0",
-		"@outfitter/cli": "^0.1.0-rc.0",
+		"@outfitter/cli": "^0.4.0",
 		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},

--- a/apps/outfitter/templates/cli/src/program.ts.template
+++ b/apps/outfitter/templates/cli/src/program.ts.template
@@ -3,6 +3,7 @@
  */
 
 import { command, createCLI } from "@outfitter/cli/command";
+import { verbosePreset } from "@outfitter/cli/flags";
 import { createLogger } from "@outfitter/logging";
 
 const logger = createLogger({ name: "{{binName}}" });
@@ -13,11 +14,18 @@ export const program = createCLI({
 	description: "{{description}}",
 });
 
+const verbose = verbosePreset();
+
 program.register(
 	command("hello [name]")
 		.description("Say hello")
-		.action(async ({ args }) => {
+		.preset(verbose)
+		.action<{ verbose: boolean }>(async ({ args, flags }) => {
+			const { verbose: isVerbose } = verbose.resolve(flags);
 			const name = args[0] ?? "World";
 			logger.info(`Hello, ${name}!`);
+			if (isVerbose) {
+				logger.debug("Running in verbose mode");
+			}
 		}),
 );

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"@outfitter/kit": "^0.1.0-rc.0",
-		"@outfitter/cli": "^0.1.0-rc.0",
+		"@outfitter/cli": "^0.4.0",
 		"@outfitter/logging": "^0.1.0-rc.0",
 		"commander": "^12.0.0"
 	},

--- a/templates/cli/src/program.ts.template
+++ b/templates/cli/src/program.ts.template
@@ -2,7 +2,8 @@
  * {{projectName}} - CLI program definition
  */
 
-import { createCLI, command } from "@outfitter/cli";
+import { command, createCLI } from "@outfitter/cli/command";
+import { verbosePreset } from "@outfitter/cli/flags";
 import { createLogger } from "@outfitter/logging";
 
 const logger = createLogger({ name: "{{binName}}" });
@@ -13,11 +14,18 @@ export const program = createCLI({
 	description: "{{description}}",
 });
 
+const verbose = verbosePreset();
+
 program.register(
 	command("hello [name]")
 		.description("Say hello")
-		.action(async ({ args }) => {
+		.preset(verbose)
+		.action<{ verbose: boolean }>(async ({ args, flags }) => {
+			const { verbose: isVerbose } = verbose.resolve(flags);
 			const name = args[0] ?? "World";
-			logger.info`Hello, ${name}!`;
+			logger.info(`Hello, ${name}!`);
+			if (isVerbose) {
+				logger.debug("Running in verbose mode");
+			}
 		}),
 );


### PR DESCRIPTION
Demonstrate preset adoption pattern by refactoring the check action
to use verbosePreset() and cwdPreset(), and updating CLI templates
to show preset usage with the command builder.

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)