### PR TITLE
feat(cli): auto-register schema command in buildCliCommands

### DIFF
--- a/packages/cli/src/__tests__/actions-schema.test.ts
+++ b/packages/cli/src/__tests__/actions-schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createActionRegistry,
+  defineAction,
+  Result,
+} from "@outfitter/contracts";
+import { z } from "zod";
+import { buildCliCommands } from "../actions.js";
+
+function createTestRegistry() {
+  return createActionRegistry().add(
+    defineAction({
+      id: "ping",
+      description: "Ping action",
+      surfaces: ["cli"],
+      input: z.object({}),
+      cli: { command: "ping" },
+      handler: async () => Result.ok({ ok: true }),
+    })
+  );
+}
+
+describe("buildCliCommands schema auto-registration", () => {
+  it("includes schema command by default", () => {
+    const registry = createTestRegistry();
+    const commands = buildCliCommands(registry);
+    const names = commands.map((c) => c.name());
+
+    expect(names).toContain("schema");
+  });
+
+  it("places schema command after action commands", () => {
+    const registry = createTestRegistry();
+    const commands = buildCliCommands(registry);
+    const names = commands.map((c) => c.name());
+
+    expect(names.indexOf("ping")).toBeLessThan(names.indexOf("schema"));
+  });
+
+  it("can opt out with schema: false", () => {
+    const registry = createTestRegistry();
+    const commands = buildCliCommands(registry, { schema: false });
+    const names = commands.map((c) => c.name());
+
+    expect(names).not.toContain("schema");
+  });
+
+  it("works with array source", () => {
+    const registry = createTestRegistry();
+    const commands = buildCliCommands(registry.list());
+    const names = commands.map((c) => c.name());
+
+    expect(names).toContain("schema");
+  });
+
+  it("accepts schema command options", () => {
+    const registry = createTestRegistry();
+    const commands = buildCliCommands(registry, {
+      schema: { programName: "mycli" },
+    });
+    const schemaCmd = commands.find((c) => c.name() === "schema");
+
+    expect(schemaCmd).toBeDefined();
+  });
+});

--- a/packages/cli/src/actions.ts
+++ b/packages/cli/src/actions.ts
@@ -9,6 +9,7 @@ import {
   validateInput,
 } from "@outfitter/contracts";
 import { Command } from "commander";
+import { createSchemaCommand, type SchemaCommandOptions } from "./schema.js";
 
 export interface BuildCliCommandsOptions {
   readonly createContext?: (input: {
@@ -17,6 +18,7 @@ export interface BuildCliCommandsOptions {
     flags: Record<string, unknown>;
   }) => HandlerContext;
   readonly includeSurfaces?: readonly ActionSurface[];
+  readonly schema?: boolean | SchemaCommandOptions;
 }
 
 type ActionSource = ActionRegistry | readonly AnyActionSpec[];
@@ -253,6 +255,15 @@ export function buildCliCommands(
     }
 
     commands.push(groupCommand);
+  }
+
+  if (options.schema !== false) {
+    const hasSchemaCommand = commands.some((cmd) => cmd.name() === "schema");
+    if (!hasSchemaCommand) {
+      const schemaOptions =
+        typeof options.schema === "object" ? options.schema : undefined;
+      commands.push(createSchemaCommand(source, schemaOptions));
+    }
   }
 
   return commands;


### PR DESCRIPTION
## Summary

- `buildCliCommands()` now appends a `schema` command automatically — any CLI using the action registry gets introspection for free
- Opt out with `schema: false`, or pass `SchemaCommandOptions` for custom config (e.g., `schema: { programName: "mycli" }`)
- No changes needed for existing consumers — the schema command appears alongside action-derived commands

## Test plan

- [x] Auto-registration test confirms schema command present in output
- [x] Opt-out test confirms `schema: false` excludes it
- [x] All existing CLI tests pass (no regressions)
- [x] `bun run typecheck` passes

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

Part of OS-182.