### PR TITLE
feat(schema): create @outfitter/schema with manifest types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/cli-demo": {
       "name": "outfitter-cli-demo",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "outfitter-demo": "./dist/cli.js",
         "cli-demo": "./dist/cli.js",
@@ -42,7 +42,7 @@
     },
     "apps/outfitter": {
       "name": "outfitter",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "bin": {
         "outfitter": "./dist/cli.js",
         "out": "./dist/cli.js",
@@ -79,7 +79,7 @@
     },
     "packages/cli": {
       "name": "@outfitter/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "better-result": "^2.5.1",
@@ -234,6 +234,21 @@
         "@outfitter/config": ">=0.3.0",
         "@outfitter/contracts": ">=0.2.0",
         "@outfitter/logging": ">=0.3.0",
+      },
+    },
+    "packages/schema": {
+      "name": "@outfitter/schema",
+      "version": "0.1.0",
+      "dependencies": {
+        "@outfitter/contracts": "workspace:*",
+        "@outfitter/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.7",
+        "typescript": "^5.9.3",
+      },
+      "peerDependencies": {
+        "zod": "^4.3.5",
       },
     },
     "packages/state": {
@@ -466,6 +481,8 @@
     "@outfitter/logging": ["@outfitter/logging@workspace:packages/logging"],
 
     "@outfitter/mcp": ["@outfitter/mcp@workspace:packages/mcp"],
+
+    "@outfitter/schema": ["@outfitter/schema@workspace:packages/schema"],
 
     "@outfitter/state": ["@outfitter/state@workspace:packages/state"],
 
@@ -1045,6 +1062,8 @@
 
     "@outfitter/mcp/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@outfitter/schema/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+
     "@outfitter/tooling/@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@outfitter/tooling/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1078,6 +1097,8 @@
     "@outfitter/logging/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@outfitter/mcp/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@outfitter/schema/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@outfitter/tooling/@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 

--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -178,6 +178,10 @@ export default defineWorkspace(
       root: "packages/mcp",
     },
     {
+      name: "@outfitter/schema",
+      root: "packages/schema",
+    },
+    {
       name: "@outfitter/state",
       root: "packages/state",
     },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@outfitter/schema",
+  "description": "Schema introspection, surface map generation, and drift detection for Outfitter",
+  "version": "0.1.0",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./manifest": {
+      "import": {
+        "types": "./dist/manifest.d.ts",
+        "default": "./dist/manifest.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "cd ../.. && bunup --filter @outfitter/schema",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "lint": "biome lint ./src",
+    "lint:fix": "biome lint --write ./src",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@outfitter/contracts": "workspace:*",
+    "@outfitter/types": "workspace:*"
+  },
+  "peerDependencies": {
+    "zod": "^4.3.5"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.7",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "bun": ">=1.3.7"
+  },
+  "keywords": [
+    "outfitter",
+    "schema",
+    "manifest",
+    "surface-map",
+    "introspection",
+    "typescript"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/outfitter-dev/outfitter.git",
+    "directory": "packages/schema"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/schema/src/__tests__/manifest.test.ts
+++ b/packages/schema/src/__tests__/manifest.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createActionRegistry,
+  defineAction,
+  Result,
+} from "@outfitter/contracts";
+import { z } from "zod";
+import {
+  type ActionManifest,
+  type ActionManifestEntry,
+  generateManifest,
+} from "../manifest.js";
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createTestRegistry() {
+  return createActionRegistry()
+    .add(
+      defineAction({
+        id: "init",
+        description: "Create a new project",
+        surfaces: ["cli"],
+        input: z.object({
+          directory: z.string().optional(),
+          name: z.string().optional(),
+          force: z.boolean().optional(),
+        }),
+        cli: {
+          group: "init",
+          command: "[directory]",
+          description: "Create a new Outfitter project",
+          options: [
+            {
+              flags: "-n, --name <name>",
+              description: "Package name",
+            },
+            {
+              flags: "-f, --force",
+              description: "Overwrite existing files",
+              defaultValue: false,
+            },
+          ],
+          mapInput: () => ({}),
+        },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    )
+    .add(
+      defineAction({
+        id: "init.cli",
+        description: "Create a new CLI project",
+        surfaces: ["cli"],
+        input: z.object({
+          directory: z.string().optional(),
+        }),
+        cli: {
+          group: "init",
+          command: "cli [directory]",
+          description: "Create a new CLI project",
+          mapInput: () => ({}),
+        },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    )
+    .add(
+      defineAction({
+        id: "check",
+        description: "Compare local config against registry",
+        surfaces: ["cli"],
+        input: z.object({}),
+        cli: {
+          command: "check",
+          description: "Compare local config blocks against registry",
+        },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    )
+    .add(
+      defineAction({
+        id: "doctor",
+        description: "Validate environment and dependencies",
+        surfaces: ["cli", "mcp"],
+        input: z.object({
+          verbose: z.boolean().optional(),
+        }),
+        cli: {
+          command: "doctor",
+          description: "Validate environment and dependencies",
+          options: [
+            {
+              flags: "-v, --verbose",
+              description: "Show detailed output",
+              defaultValue: false,
+            },
+          ],
+        },
+        mcp: {
+          tool: "doctor",
+          description: "Validate environment",
+        },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    );
+}
+
+// =============================================================================
+// generateManifest
+// =============================================================================
+
+describe("generateManifest", () => {
+  it("generates manifest from registry", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    expect(manifest.version).toBe("1.0.0");
+    expect(manifest.generatedAt).toBeTruthy();
+    expect(manifest.actions.length).toBe(4);
+  });
+
+  it("includes error taxonomy", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    expect(manifest.errors["validation"]).toEqual({ exit: 1, http: 400 });
+    expect(manifest.errors["not_found"]).toEqual({ exit: 2, http: 404 });
+    expect(manifest.errors["cancelled"]).toEqual({ exit: 130, http: 499 });
+  });
+
+  it("includes output modes", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    expect(manifest.outputModes).toContain("human");
+    expect(manifest.outputModes).toContain("json");
+    expect(manifest.outputModes).toContain("jsonl");
+  });
+
+  it("detects surfaces from actions", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    expect(manifest.surfaces).toContain("cli");
+    expect(manifest.surfaces).toContain("mcp");
+  });
+
+  it("converts input schema to JSON Schema", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    const checkAction = manifest.actions.find((a) => a.id === "check");
+    expect(checkAction?.input).toEqual({ type: "object", properties: {} });
+  });
+
+  it("includes CLI metadata", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    const initAction = manifest.actions.find((a) => a.id === "init");
+    expect(initAction?.cli?.group).toBe("init");
+    expect(initAction?.cli?.command).toBe("[directory]");
+    expect(initAction?.cli?.options).toHaveLength(2);
+  });
+
+  it("includes MCP metadata when present", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+
+    const doctorAction = manifest.actions.find((a) => a.id === "doctor");
+    expect(doctorAction?.mcp?.tool).toBe("doctor");
+  });
+
+  it("filters by surface", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry, { surface: "mcp" });
+
+    expect(manifest.actions.length).toBe(1);
+    expect(manifest.actions[0]?.id).toBe("doctor");
+  });
+
+  it("includes custom version", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry, { version: "2.0.0" });
+
+    expect(manifest.version).toBe("2.0.0");
+  });
+
+  it("accepts array source", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry.list());
+
+    expect(manifest.actions.length).toBe(4);
+  });
+});
+
+// =============================================================================
+// Type exports
+// =============================================================================
+
+describe("type exports", () => {
+  it("ActionManifest has expected shape", () => {
+    const registry = createTestRegistry();
+    const manifest: ActionManifest = generateManifest(registry);
+
+    expect(manifest).toHaveProperty("version");
+    expect(manifest).toHaveProperty("generatedAt");
+    expect(manifest).toHaveProperty("surfaces");
+    expect(manifest).toHaveProperty("actions");
+    expect(manifest).toHaveProperty("errors");
+    expect(manifest).toHaveProperty("outputModes");
+  });
+
+  it("ActionManifestEntry has expected shape", () => {
+    const registry = createTestRegistry();
+    const manifest = generateManifest(registry);
+    const entry = manifest.actions[0];
+    expect(entry).toBeDefined();
+    const typedEntry: ActionManifestEntry = entry as ActionManifestEntry;
+
+    expect(typedEntry).toHaveProperty("id");
+    expect(typedEntry).toHaveProperty("surfaces");
+    expect(typedEntry).toHaveProperty("input");
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @outfitter/schema — Schema introspection and surface map generation.
+ *
+ * Generates machine-readable manifests from ActionRegistries,
+ * enabling agents and CI to discover capabilities and detect drift.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  type ActionManifest,
+  type ActionManifestEntry,
+  type ActionSource,
+  type GenerateManifestOptions,
+  generateManifest,
+  type ManifestApiSpec,
+  type ManifestCliOption,
+  type ManifestCliSpec,
+  type ManifestMcpSpec,
+} from "./manifest.js";

--- a/packages/schema/src/manifest.ts
+++ b/packages/schema/src/manifest.ts
@@ -1,0 +1,194 @@
+/**
+ * Manifest generation from action registries.
+ *
+ * Generates machine-readable manifests describing all registered actions,
+ * their schemas, surfaces, and metadata. Used by both CLI `schema` command
+ * and build-time surface map generation.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  ACTION_SURFACES,
+  type ActionRegistry,
+  type ActionSurface,
+  type AnyActionSpec,
+  DEFAULT_REGISTRY_SURFACES,
+  type ErrorCategory,
+  exitCodeMap,
+  type JsonSchema,
+  statusCodeMap,
+  zodToJsonSchema,
+} from "@outfitter/contracts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ActionManifest {
+  readonly version: string;
+  readonly generatedAt: string;
+  readonly surfaces: ActionSurface[];
+  readonly actions: ActionManifestEntry[];
+  readonly errors: Record<ErrorCategory, { exit: number; http: number }>;
+  readonly outputModes: string[];
+}
+
+export interface ActionManifestEntry {
+  readonly id: string;
+  readonly description?: string | undefined;
+  readonly surfaces: ActionSurface[];
+  readonly input: JsonSchema;
+  readonly output?: JsonSchema | undefined;
+  readonly cli?: ManifestCliSpec | undefined;
+  readonly mcp?: ManifestMcpSpec | undefined;
+  readonly api?: ManifestApiSpec | undefined;
+}
+
+export interface ManifestCliSpec {
+  readonly group?: string | undefined;
+  readonly command?: string | undefined;
+  readonly description?: string | undefined;
+  readonly aliases?: readonly string[] | undefined;
+  readonly options?: readonly ManifestCliOption[] | undefined;
+}
+
+export interface ManifestCliOption {
+  readonly flags: string;
+  readonly description: string;
+  readonly defaultValue?: string | boolean | string[] | undefined;
+  readonly required?: boolean | undefined;
+}
+
+export interface ManifestMcpSpec {
+  readonly tool?: string | undefined;
+  readonly description?: string | undefined;
+  readonly deferLoading?: boolean | undefined;
+}
+
+export interface ManifestApiSpec {
+  readonly method?: string | undefined;
+  readonly path?: string | undefined;
+  readonly tags?: readonly string[] | undefined;
+}
+
+export interface GenerateManifestOptions {
+  readonly surface?: ActionSurface;
+  readonly version?: string;
+}
+
+// =============================================================================
+// Manifest Generation
+// =============================================================================
+
+export type ActionSource = ActionRegistry | readonly AnyActionSpec[];
+
+function isActionRegistry(source: ActionSource): source is ActionRegistry {
+  return (
+    "list" in source && typeof (source as ActionRegistry).list === "function"
+  );
+}
+
+const OUTPUT_MODES = ["human", "json", "jsonl", "tree", "table"] as const;
+
+function buildErrorTaxonomy(): Record<
+  ErrorCategory,
+  { exit: number; http: number }
+> {
+  const taxonomy = {} as Record<ErrorCategory, { exit: number; http: number }>;
+  for (const category of Object.keys(exitCodeMap) as ErrorCategory[]) {
+    taxonomy[category] = {
+      exit: exitCodeMap[category],
+      http: statusCodeMap[category],
+    };
+  }
+  return taxonomy;
+}
+
+function actionToManifestEntry(action: AnyActionSpec): ActionManifestEntry {
+  const surfaces = [
+    ...(action.surfaces ?? DEFAULT_REGISTRY_SURFACES),
+  ] as ActionSurface[];
+
+  return {
+    id: action.id,
+    description: action.description,
+    surfaces,
+    input: zodToJsonSchema(action.input),
+    output: action.output ? zodToJsonSchema(action.output) : undefined,
+    cli: action.cli
+      ? {
+          group: action.cli.group,
+          command: action.cli.command,
+          description: action.cli.description,
+          aliases:
+            action.cli.aliases && action.cli.aliases.length > 0
+              ? action.cli.aliases
+              : undefined,
+          options:
+            action.cli.options && action.cli.options.length > 0
+              ? action.cli.options.map((o) => ({
+                  flags: o.flags,
+                  description: o.description,
+                  defaultValue: o.defaultValue,
+                  required: o.required,
+                }))
+              : undefined,
+        }
+      : undefined,
+    mcp: action.mcp
+      ? {
+          tool: action.mcp.tool,
+          description: action.mcp.description,
+          deferLoading: action.mcp.deferLoading,
+        }
+      : undefined,
+    api: action.api
+      ? {
+          method: action.api.method,
+          path: action.api.path,
+          tags: action.api.tags,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Generate a manifest from an action registry or action array.
+ *
+ * @param source - ActionRegistry or array of ActionSpec
+ * @param options - Filtering and version options
+ * @returns The manifest object
+ */
+export function generateManifest(
+  source: ActionSource,
+  options?: GenerateManifestOptions
+): ActionManifest {
+  let actions = isActionRegistry(source) ? source.list() : [...source];
+
+  if (options?.surface) {
+    const surface = options.surface;
+    actions = actions.filter((action) => {
+      const surfaces = action.surfaces ?? DEFAULT_REGISTRY_SURFACES;
+      return surfaces.includes(surface);
+    });
+  }
+
+  const surfaceSet = new Set<ActionSurface>();
+  for (const action of actions) {
+    for (const s of action.surfaces ?? DEFAULT_REGISTRY_SURFACES) {
+      if (ACTION_SURFACES.includes(s)) {
+        surfaceSet.add(s);
+      }
+    }
+  }
+
+  return {
+    version: options?.version ?? "1.0.0",
+    generatedAt: new Date().toISOString(),
+    surfaces: [...surfaceSet].sort(),
+    actions: actions.map(actionToManifestEntry),
+    errors: buildErrorTaxonomy(),
+    outputModes: [...OUTPUT_MODES],
+  };
+}

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary

- Create new `@outfitter/schema` package extracting manifest types and generation from `@outfitter/cli`
- `generateManifest()` converts an `ActionRegistry` to a typed `ActionManifest` with JSON Schema inputs, error taxonomy, and surface metadata
- Dependency flow: `contracts → schema → cli` — keeps schema utilities reusable outside CLIs
- Types: `ActionManifest`, `ActionManifestEntry`, `ManifestCliSpec`, `ManifestMcpSpec`, `ManifestApiSpec`, `GenerateManifestOptions`

Part of OS-182 Phase 2 — surface map generation.

## Test plan

- [x] 12 manifest generation tests covering structure, filtering, metadata, error taxonomy, JSON Schema conversion
- [x] Type shape verification tests
- [x] Package builds via bunup
- [x] Full monorepo suite green (40/40 Turbo tasks)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

Part of OS-182.