### PR TITLE
refactor(cli): use @outfitter/schema, add surface subcommands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
       "devDependencies": {
         "@outfitter/config": "workspace:*",
         "@outfitter/contracts": "workspace:*",
+        "@outfitter/schema": "workspace:*",
         "@types/bun": "^1.3.7",
         "@types/node": "^25.0.10",
         "typescript": "^5.9.3",
@@ -95,6 +96,7 @@
       "peerDependencies": {
         "@outfitter/config": ">=0.3.0",
         "@outfitter/contracts": ">=0.2.0",
+        "@outfitter/schema": ">=0.1.0",
         "@outfitter/types": ">=0.2.0",
         "zod": "^4.3.5",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -125,12 +125,14 @@
   "peerDependencies": {
     "@outfitter/config": ">=0.3.0",
     "@outfitter/contracts": ">=0.2.0",
+    "@outfitter/schema": ">=0.1.0",
     "@outfitter/types": ">=0.2.0",
     "zod": "^4.3.5"
   },
   "devDependencies": {
     "@outfitter/config": "workspace:*",
     "@outfitter/contracts": "workspace:*",
+    "@outfitter/schema": "workspace:*",
     "@types/bun": "^1.3.7",
     "@types/node": "^25.0.10",
     "typescript": "^5.9.3"

--- a/packages/cli/src/__tests__/schema.test.ts
+++ b/packages/cli/src/__tests__/schema.test.ts
@@ -297,4 +297,50 @@ describe("createSchemaCommand", () => {
 
     expect(options).toContain("--pretty");
   });
+
+  it("has show subcommand", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry);
+    const subcommands = cmd.commands.map((c) => c.name());
+
+    expect(subcommands).toContain("show");
+  });
+
+  it("does not have generate/diff without surface option", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry);
+    const subcommands = cmd.commands.map((c) => c.name());
+
+    expect(subcommands).not.toContain("generate");
+    expect(subcommands).not.toContain("diff");
+  });
+
+  it("has generate and diff subcommands with surface option", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry, { surface: {} });
+    const subcommands = cmd.commands.map((c) => c.name());
+
+    expect(subcommands).toContain("show");
+    expect(subcommands).toContain("generate");
+    expect(subcommands).toContain("diff");
+  });
+
+  it("generate subcommand has --dry-run and --snapshot options", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry, { surface: {} });
+    const generateCmd = cmd.commands.find((c) => c.name() === "generate");
+    const options = generateCmd?.options.map((o) => o.long) ?? [];
+
+    expect(options).toContain("--dry-run");
+    expect(options).toContain("--snapshot");
+  });
+
+  it("diff subcommand has --output option", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry, { surface: {} });
+    const diffCmd = cmd.commands.find((c) => c.name() === "diff");
+    const options = diffCmd?.options.map((o) => o.long) ?? [];
+
+    expect(options).toContain("--output");
+  });
 });

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -15,13 +15,25 @@
         "default": "./dist/index.js"
       }
     },
+    "./diff": {
+      "import": {
+        "types": "./dist/diff.d.ts",
+        "default": "./dist/diff.js"
+      }
+    },
     "./manifest": {
       "import": {
         "types": "./dist/manifest.d.ts",
         "default": "./dist/manifest.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./surface": {
+      "import": {
+        "types": "./dist/surface.d.ts",
+        "default": "./dist/surface.js"
+      }
+    }
   },
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
## Summary

- Refactor `@outfitter/cli/schema` to import types and generation from `@outfitter/schema`
- Re-export `ActionManifest`, `ActionManifestEntry`, `generateManifest` for backward compatibility
- Add `show` subcommand as explicit alias for parent action behavior
- Add opt-in `generate` and `diff` subcommands (enabled via `SchemaCommandOptions.surface`)
  - `generate` writes `.outfitter/surface.json` with `--dry-run` and `--snapshot <version>` support
  - `diff` compares runtime vs committed surface map, exits 1 on drift
- `formatManifestHuman()` and Commander integration remain in CLI (terminal-specific)

Subcommands are opt-in: \`buildCliCommands(registry, { schema: { surface: {} } })\` enables generate/diff.

## Test plan

- [x] 5 new subcommand structure tests (show, generate/diff presence, option flags)
- [x] All 450 existing CLI tests pass (backward compat)
- [x] Full monorepo suite green

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

Part of OS-182.