### PR TITLE
feat(schema): add cross-version snapshot diff

### DIFF
--- a/packages/cli/src/__tests__/schema.test.ts
+++ b/packages/cli/src/__tests__/schema.test.ts
@@ -343,4 +343,23 @@ describe("createSchemaCommand", () => {
 
     expect(options).toContain("--output");
   });
+
+  it("diff subcommand has --against option", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry, { surface: {} });
+    const diffCmd = cmd.commands.find((c) => c.name() === "diff");
+    const options = diffCmd?.options.map((o) => o.long) ?? [];
+
+    expect(options).toContain("--against");
+  });
+
+  it("diff subcommand has --from and --to options", () => {
+    const registry = createTestRegistry();
+    const cmd = createSchemaCommand(registry, { surface: {} });
+    const diffCmd = cmd.commands.find((c) => c.name() === "diff");
+    const options = diffCmd?.options.map((o) => o.long) ?? [];
+
+    expect(options).toContain("--from");
+    expect(options).toContain("--to");
+  });
 });

--- a/packages/schema/src/__tests__/snapshot-diff.test.ts
+++ b/packages/schema/src/__tests__/snapshot-diff.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createActionRegistry,
+  defineAction,
+  Result,
+} from "@outfitter/contracts";
+import { z } from "zod";
+import { diffSurfaceMaps } from "../diff.js";
+import {
+  generateSurfaceMap,
+  readSurfaceMap,
+  resolveSnapshotPath,
+} from "../surface.js";
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const tmpDir = join(import.meta.dir, "__tmp_snapshot_diff__");
+
+function createV1Registry() {
+  return createActionRegistry().add(
+    defineAction({
+      id: "init",
+      description: "Create a new project",
+      surfaces: ["cli"],
+      input: z.object({ name: z.string().optional() }),
+      cli: { command: "init [name]", description: "Create a new project" },
+      handler: async () => Result.ok({ ok: true }),
+    })
+  );
+}
+
+function createV2Registry() {
+  return createActionRegistry()
+    .add(
+      defineAction({
+        id: "init",
+        description: "Create a new project",
+        surfaces: ["cli"],
+        input: z.object({
+          name: z.string().optional(),
+          force: z.boolean().optional(),
+        }),
+        cli: {
+          command: "init [name]",
+          description: "Create a new project",
+        },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    )
+    .add(
+      defineAction({
+        id: "check",
+        description: "Run checks",
+        surfaces: ["cli"],
+        input: z.object({}),
+        cli: { command: "check" },
+        handler: async () => Result.ok({ ok: true }),
+      })
+    );
+}
+
+function writeSnapshot(
+  version: string,
+  registry: ReturnType<typeof createV1Registry>
+) {
+  const map = generateSurfaceMap(registry, { generator: "build" });
+  const snapshotPath = resolveSnapshotPath(tmpDir, ".outfitter", version);
+  mkdirSync(join(tmpDir, ".outfitter", "snapshots"), { recursive: true });
+  writeFileSync(snapshotPath, JSON.stringify(map, null, 2));
+  return snapshotPath;
+}
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// resolveSnapshotPath
+// =============================================================================
+
+describe("resolveSnapshotPath", () => {
+  it("resolves to .outfitter/snapshots/<version>.json", () => {
+    const path = resolveSnapshotPath("/project", ".outfitter", "v1.0.0");
+    expect(path).toBe("/project/.outfitter/snapshots/v1.0.0.json");
+  });
+
+  it("works with custom outputDir", () => {
+    const path = resolveSnapshotPath("/project", ".custom", "v2");
+    expect(path).toBe("/project/.custom/snapshots/v2.json");
+  });
+});
+
+// =============================================================================
+// Snapshot-to-runtime diff (--against)
+// =============================================================================
+
+describe("snapshot-to-runtime diff", () => {
+  it("detects changes between snapshot and runtime", async () => {
+    writeSnapshot("v1", createV1Registry());
+
+    const snapshotPath = resolveSnapshotPath(tmpDir, ".outfitter", "v1");
+    const committed = await readSurfaceMap(snapshotPath);
+    const current = generateSurfaceMap(createV2Registry(), {
+      generator: "runtime",
+    });
+    const diff = diffSurfaceMaps(committed, current);
+
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0]?.id).toBe("check");
+    expect(diff.modified).toHaveLength(1);
+    expect(diff.modified[0]?.id).toBe("init");
+  });
+
+  it("reports no changes when snapshot matches runtime", async () => {
+    writeSnapshot("v1", createV1Registry());
+
+    const snapshotPath = resolveSnapshotPath(tmpDir, ".outfitter", "v1");
+    const committed = await readSurfaceMap(snapshotPath);
+    const current = generateSurfaceMap(createV1Registry(), {
+      generator: "runtime",
+    });
+    const diff = diffSurfaceMaps(committed, current);
+
+    expect(diff.hasChanges).toBe(false);
+  });
+});
+
+// =============================================================================
+// Snapshot-to-snapshot diff (--from / --to)
+// =============================================================================
+
+describe("snapshot-to-snapshot diff", () => {
+  it("detects changes between two snapshots", async () => {
+    writeSnapshot("v1", createV1Registry());
+    writeSnapshot("v2", createV2Registry());
+
+    const fromPath = resolveSnapshotPath(tmpDir, ".outfitter", "v1");
+    const toPath = resolveSnapshotPath(tmpDir, ".outfitter", "v2");
+    const from = await readSurfaceMap(fromPath);
+    const to = await readSurfaceMap(toPath);
+    const diff = diffSurfaceMaps(from, to);
+
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0]?.id).toBe("check");
+    expect(diff.modified).toHaveLength(1);
+    expect(diff.modified[0]?.id).toBe("init");
+  });
+
+  it("reports no changes between identical snapshots", async () => {
+    writeSnapshot("v1", createV1Registry());
+    writeSnapshot("v1-copy", createV1Registry());
+
+    const fromPath = resolveSnapshotPath(tmpDir, ".outfitter", "v1");
+    const toPath = resolveSnapshotPath(tmpDir, ".outfitter", "v1-copy");
+    const from = await readSurfaceMap(fromPath);
+    const to = await readSurfaceMap(toPath);
+    const diff = diffSurfaceMaps(from, to);
+
+    expect(diff.hasChanges).toBe(false);
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -29,6 +29,7 @@ export {
   type GenerateSurfaceMapOptions,
   generateSurfaceMap,
   readSurfaceMap,
+  resolveSnapshotPath,
   type SurfaceMap,
   writeSurfaceMap,
 } from "./surface.js";

--- a/packages/schema/src/surface.ts
+++ b/packages/schema/src/surface.ts
@@ -8,7 +8,7 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import {
   type ActionManifest,
   type ActionSource,
@@ -87,4 +87,24 @@ export async function writeSurfaceMap(
 export async function readSurfaceMap(inputPath: string): Promise<SurfaceMap> {
   const content = await readFile(inputPath, "utf-8");
   return JSON.parse(content) as SurfaceMap;
+}
+
+// =============================================================================
+// Path Helpers
+// =============================================================================
+
+/**
+ * Resolve the file path for a named snapshot.
+ *
+ * @param cwd - Project root directory
+ * @param outputDir - Output directory name (e.g., ".outfitter")
+ * @param version - Snapshot version label
+ * @returns Absolute path to the snapshot file
+ */
+export function resolveSnapshotPath(
+  cwd: string,
+  outputDir: string,
+  version: string
+): string {
+  return join(cwd, outputDir, "snapshots", `${version}.json`);
 }


### PR DESCRIPTION
## Summary

- Add `--against <version>` flag to `schema diff` for comparing runtime against a named snapshot
- Add `--from <version>` and `--to <version>` flags for snapshot-to-snapshot comparison
- Export `resolveSnapshotPath()` from `@outfitter/schema` for consistent path resolution
- Default behavior (runtime vs `surface.json`) unchanged

Three diff modes:
```bash
mycli schema diff                           # runtime vs surface.json (default)
mycli schema diff --against v1.0.0          # runtime vs snapshot
mycli schema diff --from v1.0.0 --to v2.0.0 # snapshot vs snapshot
```

Closes OS-196.

## Test plan

- [x] 2 CLI tests: `--against` option present, `--from`/`--to` options present
- [x] 2 `resolveSnapshotPath` tests: standard and custom outputDir
- [x] 2 snapshot-to-runtime tests: detects changes, reports no changes when matching
- [x] 2 snapshot-to-snapshot tests: detects changes, reports no changes for identical snapshots
- [x] Full monorepo suite green (40/40 Turbo tasks)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)