### PR TITLE
fix(ci): use RELEASE_PLEASE_TOKEN and harden auto-changeset workflow

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Determine release type
         id: release-type
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-
           if echo "$LABELS" | grep -q "release:major"; then
             echo "type=major" >> $GITHUB_OUTPUT
           elif echo "$LABELS" | grep -q "release:minor"; then
@@ -44,8 +44,9 @@ jobs:
 
       - name: Detect affected packages
         id: packages
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
           PACKAGES=""
 
           # Map labels to package names
@@ -80,20 +81,22 @@ jobs:
           echo "Detected packages: $PACKAGES"
 
       - name: Validate package labels
+        env:
+          PACKAGES: ${{ steps.packages.outputs.packages }}
         run: |
-          if [ -z "${{ steps.packages.outputs.packages }}" ]; then
+          if [ -z "$PACKAGES" ]; then
             echo "::error::PR has a release:* label but no package/* labels were detected. Add package labels to indicate which packages are affected."
             exit 1
           fi
 
       - name: Generate changeset
+        env:
+          RELEASE_TYPE: ${{ steps.release-type.outputs.type }}
+          PACKAGES: ${{ steps.packages.outputs.packages }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          RELEASE_TYPE="${{ steps.release-type.outputs.type }}"
-          PACKAGES="${{ steps.packages.outputs.packages }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-
           # Generate a unique filename
           FILENAME=".changeset/pr-${PR_NUMBER}-$(date +%s).md"
 
@@ -116,6 +119,8 @@ jobs:
           cat "$FILENAME"
 
       - name: Commit changeset
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -128,5 +133,5 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: add changeset for PR #${{ github.event.pull_request.number }}"
+          git commit -m "chore: add changeset for PR #${PR_NUMBER}"
           git push


### PR DESCRIPTION
## Summary

- Switch from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` so the auto-changeset workflow can push directly to `main` without being blocked by branch protection rules
- Move all `${{ }}` expressions into `env:` blocks to prevent command injection via PR titles or other untrusted input

## Test plan

- [ ] Merge a PR with `release:*` and `package/*` labels and verify the changeset commit lands on `main`

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)

Closes: OS-209