### PR TITLE
docs(architecture): align AGENTS.md and linked docs with current inventory [OS-206]

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,3 +40,5 @@ Check `TaskList` to find unblocked tasks ready for work.
 - [AGENTS.md](../AGENTS.md) — Full development guide
 - [docs/PATTERNS.md](../docs/PATTERNS.md) — Handler contract, Result types
 - [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) — Package relationships
+- [docs/CLI-CONVENTIONS.md](../docs/CLI-CONVENTIONS.md) — Flag presets and command conventions
+- [docs/GETTING-STARTED.md](../docs/GETTING-STARTED.md) — Setup and tutorials

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,18 +78,28 @@ bunx @outfitter/tooling upgrade-bun        # Upgrade to latest
 - `@outfitter/state` — Pagination state, cursor persistence
 - `@outfitter/index` — SQLite FTS5 with WAL
 - `@outfitter/daemon` — Daemon lifecycle, IPC, health checks
-- `@outfitter/testing` — Test harnesses for MCP and CLI
+- `@outfitter/schema` — Schema introspection, surface maps, drift detection
+- `@outfitter/tui` — Terminal UI rendering (tables, lists, boxes, trees, spinners, themes, prompts, streaming)
 
 **Tooling (Early)** — APIs will change:
 
 - `outfitter` — Umbrella CLI for scaffolding
+- `@outfitter/testing` — Test harnesses for MCP and CLI
+
+**Deprecated**:
+
+- `@outfitter/agents` — Deprecated. Use `npx outfitter add scaffolding` instead
 
 ### Handler Contract
 
 All domain logic uses transport-agnostic handlers returning `Result<T, E>`:
 
 ```typescript
-type Handler<TInput, TOutput, TError> = (
+type Handler<
+  TInput,
+  TOutput,
+  TError extends OutfitterError = OutfitterError,
+> = (
   input: TInput,
   ctx: HandlerContext
 ) => Promise<Result<TOutput, TError>>;
@@ -178,11 +188,11 @@ OUTFITTER_LOG_LEVEL / OUTFITTER_VERBOSE    ← env var override
 
 | Concern | Package |
 |---------|---------|
-| Result type | `better-result` |
-| Schema validation | `zod` (v4) |
-| CLI parsing | `commander` (v14+) |
-| Logging | `@logtape/logtape` |
-| MCP protocol | `@modelcontextprotocol/sdk` |
+| Result type | `better-result` (`^2.5.0`) |
+| Schema validation | `zod` (`^4.3.5`) |
+| CLI parsing | `commander` (`^14.0.2`) |
+| Logging | `@logtape/logtape` (`^2.0.0`) |
+| MCP protocol | `@modelcontextprotocol/sdk` (`^1.12.1`) |
 | Prompts | `@clack/prompts` |
 
 ## Code Style

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -12,7 +12,11 @@ The handler contract is the core abstraction. Handlers are pure functions that:
 ### Signature
 
 ```typescript
-type Handler<TInput, TOutput, TError extends OutfitterError> = (
+type Handler<
+  TInput,
+  TOutput,
+  TError extends OutfitterError = OutfitterError,
+> = (
   input: TInput,
   ctx: HandlerContext
 ) => Promise<Result<TOutput, TError>>;


### PR DESCRIPTION
## Summary

Audits `AGENTS.md`, `.claude/CLAUDE.md`, `docs/ARCHITECTURE.md`, and `docs/PATTERNS.md` to reflect the current package inventory.

- Add `@outfitter/schema` and `@outfitter/tui` to Runtime tier
- Move `@outfitter/testing` to Tooling tier
- Mark `@outfitter/agents` as deprecated with migration hint (`npx outfitter add scaffolding`)
- Remove dead `@outfitter/kit` references (unused facade package)
- Align handler signature docs to match source (`TError extends OutfitterError = OutfitterError`)
- Add version hints for blessed dependencies in `AGENTS.md`
- Expand `.claude/CLAUDE.md` key references

## Test plan

- [x] `bun run docs:check:ci` passes
- [x] Pre-push hooks pass
- [x] Package inventory in AGENTS.md matches ARCHITECTURE.md

Addresses [OS-206](https://linear.app/outfitter/issue/OS-206)

---
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b839adec832094992ec685a35b75)