### PR TITLE
feat(upgrade): wire codemods into upgrade flow [OS-76]

### DIFF
--- a/apps/outfitter/src/__tests__/actions.test.ts
+++ b/apps/outfitter/src/__tests__/actions.test.ts
@@ -87,4 +87,33 @@ describe("outfitter action mapping", () => {
     expect(mapped.noTooling).toBe(false);
     expect(mapped.with).toBe("claude,biome");
   });
+
+  test("maps update --no-codemods across commander flag shapes", () => {
+    const action = outfitterActions.get("update");
+    expect(action?.cli?.mapInput).toBeDefined();
+
+    const mappedKebab = action?.cli?.mapInput?.({
+      args: [],
+      flags: { "no-codemods": true },
+    }) as { noCodemods: boolean };
+    expect(mappedKebab.noCodemods).toBe(true);
+
+    const mappedCamel = action?.cli?.mapInput?.({
+      args: [],
+      flags: { noCodemods: true },
+    }) as { noCodemods: boolean };
+    expect(mappedCamel.noCodemods).toBe(true);
+
+    const mappedPositive = action?.cli?.mapInput?.({
+      args: [],
+      flags: { codemods: false },
+    }) as { noCodemods: boolean };
+    expect(mappedPositive.noCodemods).toBe(true);
+
+    const mappedDefault = action?.cli?.mapInput?.({
+      args: [],
+      flags: {},
+    }) as { noCodemods: boolean };
+    expect(mappedDefault.noCodemods).toBe(false);
+  });
 });

--- a/apps/outfitter/src/__tests__/update-codemods-integration.test.ts
+++ b/apps/outfitter/src/__tests__/update-codemods-integration.test.ts
@@ -167,6 +167,31 @@ import { confirmDestructive } from "@outfitter/cli/input";
     }
   });
 
+  test("does not rewrite plain string literals outside import statements", async () => {
+    const targetDir = join(tempDir, "project");
+    mkdirSync(join(targetDir, "src"), { recursive: true });
+
+    const source = `const docsRef = "@outfitter/cli/render";
+const message = "replace @outfitter/cli/streaming manually";
+`;
+    writeFileSync(join(targetDir, "src/notes.ts"), source);
+
+    const codemodPath = join(
+      import.meta.dir,
+      "../../../../plugins/outfitter/shared/codemods/cli/0.4.0-move-tui-imports.ts"
+    );
+
+    const result = await runCodemod(codemodPath, targetDir, false);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.changedFiles).toHaveLength(0);
+    }
+
+    const updated = readFileSync(join(targetDir, "src/notes.ts"), "utf-8");
+    expect(updated).toBe(source);
+  });
+
   test("skips node_modules and dist directories", async () => {
     const targetDir = join(tempDir, "project");
     mkdirSync(join(targetDir, "src"), { recursive: true });

--- a/apps/outfitter/src/__tests__/update-guide.test.ts
+++ b/apps/outfitter/src/__tests__/update-guide.test.ts
@@ -514,4 +514,38 @@ describe("printUpdateResults human output with guides", () => {
     // The structured guides section should NOT appear without --guide
     expect(captured).not.toContain("Update import paths");
   });
+
+  test("shows codemod execution summary when codemods were run", async () => {
+    const result: UpdateResult = {
+      packages: [
+        {
+          name: "@outfitter/contracts",
+          current: "0.1.0",
+          latest: "0.1.1",
+          updateAvailable: true,
+          breaking: false,
+        },
+      ],
+      total: 1,
+      updatesAvailable: 1,
+      hasBreaking: false,
+      applied: true,
+      appliedPackages: ["@outfitter/contracts"],
+      skippedBreaking: [],
+      codemods: {
+        codemodCount: 2,
+        changedFiles: ["src/a.ts", "src/b.ts", "src/a.ts"],
+        errors: ["Could not parse src/c.ts"],
+      },
+    };
+
+    const captured = await captureOutput(result, { applied: true });
+
+    expect(captured).toContain("Ran 2 codemod(s).");
+    expect(captured).toContain("Codemods changed 2 file(s):");
+    expect(captured).toContain("src/a.ts");
+    expect(captured).toContain("src/b.ts");
+    expect(captured).toContain("Codemod errors (1):");
+    expect(captured).toContain("Could not parse src/c.ts");
+  });
 });

--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -186,6 +186,20 @@ function resolveLocalFlag(flags: {
   return undefined;
 }
 
+function resolveNoCodemodsFlag(flags: Record<string, unknown>): boolean {
+  const kebab = flags["no-codemods"];
+  if (typeof kebab === "boolean") return kebab;
+
+  const camel = flags["noCodemods"];
+  if (typeof camel === "boolean") return camel;
+
+  // Commander may expose a positive flag name for --no-* options.
+  const positive = flags["codemods"];
+  if (typeof positive === "boolean") return !positive;
+
+  return false;
+}
+
 function resolveInitOptions(
   context: ActionCliInputContext,
   presetOverride?: "minimal" | "cli" | "mcp" | "daemon"
@@ -867,9 +881,7 @@ const updateAction = defineAction({
         ...(guidePackages !== undefined ? { guidePackages } : {}),
         apply: Boolean(context.flags["apply"]),
         breaking: Boolean(context.flags["breaking"]),
-        noCodemods: Boolean(
-          context.flags["no-codemods"] ?? context.flags["noCodemods"]
-        ),
+        noCodemods: resolveNoCodemodsFlag(context.flags),
         outputMode,
       };
     },

--- a/apps/outfitter/src/commands/update.ts
+++ b/apps/outfitter/src/commands/update.ts
@@ -840,6 +840,7 @@ export async function runUpdate(
   }
 
   // Run codemods for applied packages (unless --no-codemods)
+  const codemodTargetDir = scan.workspaceRoot ?? cwd;
   let codemodSummary: CodemodSummary | undefined;
   if (applied && options.noCodemods !== true && migrationsDir !== null) {
     const codemodsDir = findCodemodsDir(cwd);
@@ -1041,6 +1042,33 @@ export async function printUpdateResults(
         "Use 'outfitter update --apply --breaking' to include breaking updates."
       )
     );
+    lines.push("");
+  }
+
+  if (result.codemods !== undefined) {
+    const uniqueChangedFiles = [
+      ...new Set(result.codemods.changedFiles),
+    ].sort();
+    lines.push(theme.info(`Ran ${result.codemods.codemodCount} codemod(s).`));
+
+    if (uniqueChangedFiles.length > 0) {
+      lines.push(
+        theme.success(`Codemods changed ${uniqueChangedFiles.length} file(s):`)
+      );
+      for (const file of uniqueChangedFiles) {
+        lines.push(`  - ${file}`);
+      }
+    }
+
+    if (result.codemods.errors.length > 0) {
+      lines.push(
+        theme.error(`Codemod errors (${result.codemods.errors.length}):`)
+      );
+      for (const error of result.codemods.errors) {
+        lines.push(`  - ${error}`);
+      }
+    }
+
     lines.push("");
   }
 


### PR DESCRIPTION
## Summary

- Integrates codemod discovery/execution into the `outfitter upgrade` mutation flow.
- Adds `--no-codemods` to explicitly skip codemod execution.
- Includes codemod summary reporting in upgrade results/output.
- Adds a reference codemod for import migration (`@outfitter/cli/*` → `@outfitter/tui/*`).

## Upgrade Flow

1. Run `outfitter upgrade --yes` (or `--yes --all` when explicitly opting into breaking updates).
2. Bump dependencies and install.
3. Discover codemods for crossed versions.
4. Execute mechanical codemods.
5. Report codemod outcomes in structured results.

## Test Plan

- [x] Added integration coverage for codemod discovery/execution and opt-out behavior.
- [x] Existing `outfitter` tests remain green.
- [x] Typecheck clean.

## Linear

Closes: OS-76
