### PR TITLE
fix(release): recover schema publish with fresh version bump

### DIFF
--- a/.changeset/schema-publish-recovery.md
+++ b/.changeset/schema-publish-recovery.md
@@ -1,0 +1,8 @@
+---
+"@outfitter/schema": patch
+---
+
+fix(release): recover schema publish after blocked 0.2.0 version
+
+`@outfitter/schema@0.2.0` is currently unavailable from npm while the version is no longer publishable.
+This patch bump advances to a fresh publishable version so release automation can recover.


### PR DESCRIPTION
## Summary

- Adds a manual changeset to patch-bump `@outfitter/schema`.
- This is a release recovery step for a blocked `0.2.0` publish state.

## Why

`Release` is repeatedly failing on `main` while trying to publish `@outfitter/schema@0.2.0`.
NPM rejects republishing that exact version (`cannot publish over previously published versions: 0.2.0`), leaving release automation stuck.

By advancing schema to a fresh patch version through the normal Changesets flow, we can recover publishing and restore installability for consumers depending on `@outfitter/schema`.

## Validation

- `Build & Test` check passed on this PR.
- Full pre-push verification passed locally via Lefthook (`bun run verify:ci`).

## Follow-up Sequence

1. Merge this PR.
2. Merge the generated "Version Packages" PR.
3. Confirm `Release` succeeds and `npm install @outfitter/cli@0.5.0` (or latest) resolves `@outfitter/schema` correctly.
