### PR TITLE
feat(rules): establish TSDoc convention via agent rule

### DIFF
--- a/.claude/rules/tsdoc.md
+++ b/.claude/rules/tsdoc.md
@@ -1,0 +1,104 @@
+---
+paths:
+  - "packages/*/src/**/*.ts"
+---
+
+# TSDoc Convention
+
+All exported declarations in `packages/*/src/` require TSDoc comments. This enables agent comprehension and generated API reference docs.
+
+## What Requires TSDoc
+
+Every exported function, class, interface, type alias, and enum must have a TSDoc comment. Re-exports from barrel files (`export { foo } from "./foo.js"`) do not need TSDoc at the re-export site — document at the definition.
+
+## Quality Bar
+
+- **Description** — First line is a concise summary of what the declaration does
+- **`@param`** — Document non-obvious parameters (skip `options` bags where Zod schema is self-documenting)
+- **`@returns`** — Document non-void return values, especially `Result<T, E>` types
+- **`@example`** — Required for public API entry points (functions users import directly)
+
+## Standard
+
+Use TSDoc syntax. Do not include JSDoc-style `{type}` annotations — TypeScript types handle that.
+
+```typescript
+// Good
+/** @param name - The user's display name */
+
+// Bad — redundant type annotation
+/** @param {string} name - The user's display name */
+```
+
+## Examples
+
+### Exported function
+
+```typescript
+/**
+ * Load configuration from XDG-compliant paths with schema validation.
+ *
+ * @param appName - Application name used as subdirectory under XDG paths
+ * @param schema - Zod schema to validate the loaded configuration
+ * @returns Result containing validated config or a ConfigError
+ *
+ * @example
+ * ```typescript
+ * const result = await loadConfig("myapp", AppConfigSchema);
+ * if (result.isOk()) {
+ *   console.log(result.value.apiKey);
+ * }
+ * ```
+ */
+export async function loadConfig<T>(
+  appName: string,
+  schema: ZodSchema<T>,
+): Promise<Result<T, ConfigError>> { ... }
+```
+
+### Exported interface
+
+```typescript
+/**
+ * Options for the check-exports command.
+ */
+export interface CheckExportsOptions {
+  /** Output results as JSON instead of human-readable format. */
+  readonly json?: boolean;
+}
+```
+
+### Exported type alias
+
+```typescript
+/** Handler function that processes input and returns a Result. */
+export type Handler<TInput, TOutput, TError extends OutfitterError = OutfitterError> = (
+  input: TInput,
+  ctx: HandlerContext,
+) => Promise<Result<TOutput, TError>>;
+```
+
+### Package entry point (`index.ts`)
+
+```typescript
+/**
+ * @outfitter/config
+ *
+ * XDG-compliant configuration loading with schema validation.
+ *
+ * @example
+ * ```typescript
+ * import { loadConfig } from "@outfitter/config";
+ * ```
+ *
+ * @packageDocumentation
+ */
+```
+
+## Exemplary Packages
+
+Reference these packages for TSDoc patterns: `config`, `logging`, `state`.
+
+## Verification
+
+Run `bunx @outfitter/tooling check-tsdoc` to report coverage. Use `--strict` to fail on missing docs.


### PR DESCRIPTION
## Summary

Establishes the TSDoc convention for all `@outfitter/*` packages via a scoped agent rule at `.claude/rules/tsdoc.md`. This is the foundation for the TSDoc coverage initiative — agents editing package source will now follow consistent documentation standards.

### What the rule covers

- **Scope**: All exported functions, classes, interfaces, type aliases, and enums in `packages/*/src/**/*.ts`
- **Quality bar**: Description line + `@param` for non-obvious params + `@returns` for non-void + `@example` for public API entry points
- **Standard**: TSDoc syntax (no JSDoc-style `{type}` annotations — TypeScript handles that)
- **Exemplary packages**: `config`, `logging`, `state` as reference implementations

### Why

Two reasons: (1) AI agents work better with well-documented APIs — TSDoc is how they understand what functions do, and (2) we want to generate API reference docs from source via TypeDoc.

## Changed files

- `.claude/rules/tsdoc.md` — New rule with `paths:` frontmatter scoped to package source

## Test plan

- [ ] Rule file has proper `paths:` frontmatter targeting `packages/*/src/**/*.ts`
- [ ] Examples cover functions, interfaces, type aliases, and package entry points
- [ ] No impact on existing behavior (read-only convention file)

Closes OS-222