### PR TITLE
feat(cli): expose TSDoc check in outfitter CLI

### DIFF
--- a/apps/outfitter/src/__tests__/check-tsdoc.test.ts
+++ b/apps/outfitter/src/__tests__/check-tsdoc.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for check-tsdoc action registration and command wrapper.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, expect, test } from "bun:test";
+import { outfitterActions } from "../actions.js";
+import { buildCheckTsdocArgs } from "../commands/check-tsdoc.js";
+
+// ---------------------------------------------------------------------------
+// Action registration
+// ---------------------------------------------------------------------------
+
+describe("check-tsdoc action registration", () => {
+  test("check.tsdoc action is registered in the action registry", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    expect(action).toBeDefined();
+  });
+
+  test("check.tsdoc action belongs to the check group", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    expect(action?.cli?.group).toBe("check");
+  });
+
+  test("check.tsdoc action uses tsdoc subcommand", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    expect(action?.cli?.command).toBe("tsdoc");
+  });
+
+  test("check.tsdoc action is CLI-only", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    expect(action?.surfaces).toEqual(["cli"]);
+  });
+
+  test("existing check action is preserved with group structure", () => {
+    const action = outfitterActions.get("check");
+    expect(action).toBeDefined();
+    expect(action?.cli?.group).toBe("check");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input mapping
+// ---------------------------------------------------------------------------
+
+describe("check-tsdoc mapInput", () => {
+  test("maps default flags", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    expect(action?.cli?.mapInput).toBeDefined();
+
+    const mapped = action?.cli?.mapInput?.({
+      args: [],
+      flags: {},
+    }) as {
+      strict: boolean;
+      minCoverage: number;
+      cwd: string;
+      outputMode: string;
+    };
+
+    expect(mapped.strict).toBe(false);
+    expect(mapped.minCoverage).toBe(0);
+    expect(typeof mapped.cwd).toBe("string");
+    expect(mapped.outputMode).toBe("human");
+  });
+
+  test("maps --strict flag", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    const mapped = action?.cli?.mapInput?.({
+      args: [],
+      flags: { strict: true },
+    }) as { strict: boolean };
+
+    expect(mapped.strict).toBe(true);
+  });
+
+  test("maps --min-coverage flag", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    const mapped = action?.cli?.mapInput?.({
+      args: [],
+      flags: { minCoverage: "80" },
+    }) as { minCoverage: number };
+
+    expect(mapped.minCoverage).toBe(80);
+  });
+
+  test("maps --json flag to outputMode", () => {
+    const action = outfitterActions.get("check.tsdoc");
+    const mapped = action?.cli?.mapInput?.({
+      args: [],
+      flags: { json: true },
+    }) as { outputMode: string };
+
+    expect(mapped.outputMode).toBe("json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Args builder
+// ---------------------------------------------------------------------------
+
+describe("buildCheckTsdocArgs", () => {
+  test("returns base args with no options", () => {
+    const args = buildCheckTsdocArgs({
+      strict: false,
+      minCoverage: 0,
+      cwd: "/tmp/test",
+      outputMode: "human",
+    });
+
+    expect(args).toEqual(["check-tsdoc"]);
+  });
+
+  test("adds --strict flag when enabled", () => {
+    const args = buildCheckTsdocArgs({
+      strict: true,
+      minCoverage: 0,
+      cwd: "/tmp/test",
+      outputMode: "human",
+    });
+
+    expect(args).toContain("--strict");
+  });
+
+  test("adds --min-coverage flag when above zero", () => {
+    const args = buildCheckTsdocArgs({
+      strict: false,
+      minCoverage: 80,
+      cwd: "/tmp/test",
+      outputMode: "human",
+    });
+
+    expect(args).toContain("--min-coverage");
+    expect(args).toContain("80");
+  });
+
+  test("adds --json flag for json output mode", () => {
+    const args = buildCheckTsdocArgs({
+      strict: false,
+      minCoverage: 0,
+      cwd: "/tmp/test",
+      outputMode: "json",
+    });
+
+    expect(args).toContain("--json");
+  });
+
+  test("does not add --json for human output mode", () => {
+    const args = buildCheckTsdocArgs({
+      strict: false,
+      minCoverage: 0,
+      cwd: "/tmp/test",
+      outputMode: "human",
+    });
+
+    expect(args).not.toContain("--json");
+  });
+
+  test("combines all flags correctly", () => {
+    const args = buildCheckTsdocArgs({
+      strict: true,
+      minCoverage: 75,
+      cwd: "/tmp/test",
+      outputMode: "json",
+    });
+
+    expect(args).toEqual([
+      "check-tsdoc",
+      "--strict",
+      "--min-coverage",
+      "75",
+      "--json",
+    ]);
+  });
+});

--- a/apps/outfitter/src/commands/check-tsdoc.ts
+++ b/apps/outfitter/src/commands/check-tsdoc.ts
@@ -1,0 +1,124 @@
+/**
+ * `outfitter check tsdoc` - Check TSDoc coverage on exported declarations.
+ *
+ * Thin wrapper that delegates to the `check-tsdoc` command in
+ * `@outfitter/tooling`. Spawns the tooling CLI as a subprocess to
+ * avoid `process.exit()` side effects in the action handler.
+ *
+ * @packageDocumentation
+ */
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { Result } from "@outfitter/contracts";
+import type { CliOutputMode } from "../output-mode.js";
+
+const require = createRequire(import.meta.url);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Validated input for the check-tsdoc action handler. */
+export interface CheckTsDocInput {
+  readonly strict: boolean;
+  readonly minCoverage: number;
+  readonly cwd: string;
+  readonly outputMode: CliOutputMode;
+}
+
+/** Result of running check-tsdoc. */
+export interface CheckTsDocRunResult {
+  readonly exitCode: number;
+}
+
+// ---------------------------------------------------------------------------
+// Args builder (pure, testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the CLI argument array for the tooling `check-tsdoc` command.
+ *
+ * @param input - Validated action input
+ * @returns Argument array starting with the command name
+ */
+export function buildCheckTsdocArgs(input: CheckTsDocInput): string[] {
+  const args: string[] = ["check-tsdoc"];
+
+  if (input.strict) {
+    args.push("--strict");
+  }
+
+  if (input.minCoverage > 0) {
+    args.push("--min-coverage", String(input.minCoverage));
+  }
+
+  if (input.outputMode === "json" || input.outputMode === "jsonl") {
+    args.push("--json");
+  }
+
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// Tooling entrypoint resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the `@outfitter/tooling` CLI entrypoint path.
+ *
+ * Prefers the source entrypoint in monorepo dev so new commands are
+ * immediately available without a build step.
+ */
+function resolveToolingEntrypoint(): string {
+  const packageJsonPath = require.resolve("@outfitter/tooling/package.json");
+  const packageRoot = dirname(packageJsonPath);
+
+  const srcEntrypoint = join(packageRoot, "src", "cli", "index.ts");
+  if (existsSync(srcEntrypoint)) {
+    return srcEntrypoint;
+  }
+
+  const distEntrypoint = join(packageRoot, "dist", "cli", "index.js");
+  if (existsSync(distEntrypoint)) {
+    return distEntrypoint;
+  }
+
+  throw new Error(
+    "Unable to resolve @outfitter/tooling CLI entrypoint (expected dist/cli/index.js or src/cli/index.ts)."
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the `check-tsdoc` command via the tooling CLI subprocess.
+ *
+ * @param input - Validated action input
+ * @returns Result containing the subprocess exit code
+ */
+export async function runCheckTsdoc(
+  input: CheckTsDocInput
+): Promise<Result<CheckTsDocRunResult, Error>> {
+  try {
+    const entrypoint = resolveToolingEntrypoint();
+    const args = buildCheckTsdocArgs(input);
+
+    const child = Bun.spawn([process.execPath, entrypoint, ...args], {
+      cwd: input.cwd,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const exitCode = await child.exited;
+    return Result.ok({ exitCode });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to run check-tsdoc";
+    return Result.err(new Error(message));
+  }
+}


### PR DESCRIPTION
## Summary

Wires the TSDoc coverage check into the `outfitter` CLI via the action registry as `outfitter check tsdoc`. Promotes `check` from a single command to a command group, preserving the existing block drift check alongside the new TSDoc check.

### Changes

- **Command group promotion**: `check` action changes from `command: "check"` to `group: "check"`, with the existing drift check becoming `outfitter check` (default) and TSDoc becoming `outfitter check tsdoc`
- **Subprocess delegation**: Spawns `bunx @outfitter/tooling check-tsdoc` rather than importing `runCheckTsdoc` directly (since it uses `process.exit()`)
- **Flag forwarding**: `--strict` and `--min-coverage` flags forwarded to the tooling subprocess

### Usage

```bash
outfitter check tsdoc                          # Warning mode
outfitter check tsdoc --strict --min-coverage 80  # Strict enforcement
```

## Changed files

- `apps/outfitter/src/commands/check-tsdoc.ts` — Command wrapper with `buildCheckTsdocArgs()` pure function
- `apps/outfitter/src/actions.ts` — Add `checkTsdocAction`, promote check to group
- `apps/outfitter/src/__tests__/check-tsdoc.test.ts` — 15 tests for action registration and input mapping

## Test plan

- [x] 15 unit tests pass
- [ ] `outfitter check tsdoc` produces coverage report
- [ ] Existing `outfitter check` behavior unchanged
- [ ] `--strict` and `--min-coverage` flags forward correctly

Closes OS-224