### PR TITLE
feat(tooling): integrate pre-push hook for TSDoc coverage summary

### DIFF
--- a/packages/tooling/src/__tests__/pre-push.test.ts
+++ b/packages/tooling/src/__tests__/pre-push.test.ts
@@ -192,7 +192,7 @@ describe("hasPackageSourceChanges", () => {
 		).toBe(false);
 	});
 
-	test("returns false for test files within packages", () => {
+	test("returns true for test files within packages", () => {
 		expect(
 			hasPackageSourceChanges({
 				files: ["packages/cli/src/__tests__/cli.test.ts"],

--- a/packages/tooling/src/cli/pre-push.ts
+++ b/packages/tooling/src/cli/pre-push.ts
@@ -491,7 +491,11 @@ export async function runPrePush(options: PrePushOptions = {}): Promise<void> {
 	// TSDoc coverage summary (warning only, does not affect exit code)
 	const changedFiles = getChangedFilesForPush();
 	if (hasPackageSourceChanges(changedFiles)) {
-		await printTsdocSummary();
+		try {
+			await printTsdocSummary();
+		} catch {
+			// Advisory only — never block push on TSDoc summary failure
+		}
 	}
 
 	log("");


### PR DESCRIPTION
## Summary

Integrates TSDoc coverage reporting into the pre-push verification hook. When package source files (`packages/*/src/`) are in the push diff, the hook runs a one-line coverage summary after all verification passes. Advisory only — does not block pushes regardless of coverage level.

### How it works

1. After the existing verification (typecheck, lint, build, test) passes, checks if any changed files match `packages/*/src/`
2. If yes, runs `analyzeSourceFile` + `calculateCoverage` across all package entry points
3. Prints a single summary line: `TSDoc: 82% coverage (83 documented, 4 partial, 17 undocumented of 104)`
4. Exits 0 regardless — this is informational only

### New functions

- `hasPackageSourceChanges(files)` — Check if push includes package source changes
- `printTsdocSummary()` — Run analysis and print one-line summary

## Changed files

- `packages/tooling/src/cli/pre-push.ts` — Add TSDoc summary after verification
- `packages/tooling/src/__tests__/pre-push.test.ts` — 6 new tests for `hasPackageSourceChanges`

## Test plan

- [x] 6 new tests pass for `hasPackageSourceChanges`
- [ ] Pre-push shows coverage summary when source files changed
- [ ] Pre-push does NOT block on low coverage
- [ ] No summary shown when only non-source files changed

Closes OS-225