### PR TITLE
fix(tooling): add missing check-tsdoc export entries

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -34,6 +34,12 @@
         "default": "./dist/commands/check.js"
       }
     },
+    "./commands/check-tsdoc": {
+      "import": {
+        "types": "./dist/commands/check-tsdoc.d.ts",
+        "default": "./dist/commands/check-tsdoc.js"
+      }
+    },
     "./commands/demo": {
       "import": {
         "types": "./dist/commands/demo.d.ts",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -31,6 +31,12 @@
 				"default": "./dist/cli/check.js"
 			}
 		},
+		"./cli/check-tsdoc": {
+			"import": {
+				"types": "./dist/cli/check-tsdoc.d.ts",
+				"default": "./dist/cli/check-tsdoc.js"
+			}
+		},
 		"./cli/fix": {
 			"import": {
 				"types": "./dist/cli/fix.d.ts",


### PR DESCRIPTION
## Summary

Adds missing `check-tsdoc` export entries to both `@outfitter/tooling` and `outfitter` package.json files. These were missed during the TSDoc stack (#444-#448) because CI only runs on PRs targeting `main`, so the export drift check never ran on the upper PRs in the stack.

## Changed files

- `packages/tooling/package.json` — Add `./cli/check-tsdoc` export
- `apps/outfitter/package.json` — Add `./commands/check-tsdoc` export

## Test plan

- [ ] `verify:ci` passes (includes `check-exports`)
- [ ] CI green

Closes OS-223