### PR TITLE
fix(bootstrap): enforce pinned Bun version from .bun-version [OS-210]

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -42,7 +42,7 @@ if [[ "${1:-}" != "--force" ]]; then
   command -v gh &>/dev/null || all_present=false
   command -v gt &>/dev/null || all_present=false
   command -v markdownlint-cli2 &>/dev/null || all_present=false
-  [[ -d "node_modules" ]] || all_present=false
+  [[ -d "$REPO_ROOT/node_modules" ]] || all_present=false
 
   if $all_present; then
     exit 0  # All good, nothing to do
@@ -114,7 +114,15 @@ install_bun() {
   export PATH="$BUN_INSTALL/bin:$PATH"
   hash -r
 
-  success "Bun ready ($(bun --version))"
+  local resolved_bun_version
+  resolved_bun_version="$(bun --version)"
+
+  if [[ "$resolved_bun_version" != "$PINNED_BUN_VERSION" ]]; then
+    error "Expected Bun $PINNED_BUN_VERSION but found $resolved_bun_version after install"
+    exit 1
+  fi
+
+  success "Bun ready ($resolved_bun_version)"
 }
 
 # -----------------------------------------------------------------------------
@@ -200,7 +208,10 @@ check_auth() {
 # -----------------------------------------------------------------------------
 install_deps() {
   info "Installing project dependencies..."
-  bun install
+  (
+    cd "$REPO_ROOT"
+    bun install
+  )
   success "Dependencies installed"
 }
 


### PR DESCRIPTION
### Motivation
- The bootstrap script previously skipped Bun installation if any Bun binary existed, ignoring the pinned version in `.bun-version` and leaving environments on a stale Bun.
- The repository requires a specific Bun runtime for builds and tests, so bootstrap must ensure the binary matches the pinned version.
- Also update the bootstrap banner copy to be consistent with branding.

### Description
- Resolve the repository root and read the pinned Bun version from `.bun-version`, failing fast if the file is missing or empty using `PINNED_BUN_VERSION`.
- Change the fast-path check to treat Bun as present only when `bun --version` exactly matches the pinned version from `.bun-version`.
- Rework `install_bun()` to install/upgrade/downgrade to the pinned version by invoking the official installer with `bash -s -- "bun-v$PINNED_BUN_VERSION"`, refresh `PATH` and run `hash -r`, and report the final `bun --version`.
- Update the banner text from `Outfitter Kit Bootstrap` to `Outfitter Bootstrap`.

### Testing
- `bash -n scripts/bootstrap.sh` (shell syntax check) succeeded.
- `bun run lint` was executed but failed in this environment because the runtime Bun is `1.2.14` while the workspace requires `>=1.3.6` (the pinned `.bun-version` is `1.3.7`).
- `bun run test` was executed but failed for the same reason as lint due to the older Bun in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ec8dd7308320a061086632af23e2)