### PR TITLE
docs(styleguide): clarify expedition layer guidance [OS-122]

### DIFF
--- a/plugins/team/skills/outfitter-styleguide/SKILL.md
+++ b/plugins/team/skills/outfitter-styleguide/SKILL.md
@@ -74,18 +74,25 @@ Every tool we build, every word we write, should respect the reader's time:
 
 ## The Expedition Layer
 
-The expedition metaphor gives Outfitter texture—but it's earned, not decorative. Use it when it clarifies; skip it when it obscures.
+The expedition layer is a brand aesthetic, not a prose checklist. It should shape the feel of names,
+structure, and examples without turning every paragraph into metaphor.
 
-### When It Works
+Use expedition language literally when it's part of the product (for example, a command, package, or
+feature name). Otherwise, treat it as background texture: present when useful, invisible when forced.
 
-| Metaphor | Use When |
-|----------|----------|
-| "Trail" / "Path" | Describing established patterns worth following |
-| "Terrain" | The technical environment or problem space |
-| "Gear" / "Provisions" | Tools, dependencies, configurations |
-| "Base camp" | Project setup, repository structure |
-| "Scout" | Research, exploration, proof-of-concept |
-| "Expedition" | A significant project or initiative |
+### Where It Shows Up Naturally
+
+| Layer | How to Apply It |
+|-------|-----------------|
+| Product terminology (literal) | Use exact expedition terms when they are official names (commands, packages, features, docs headings). |
+| Thematic vibe (atmospheric) | Let the outdoors/exploration feel influence framing and identity, but default to direct language in body copy. |
+| Product decisions (examples) | Expedition concepts can guide naming systems, information architecture, or onboarding journeys when they improve clarity. |
+
+### Practical Distinction
+
+- If the thing is literally named `scout`, write `scout`.
+- If the thing is not named `scout`, say "research" unless the metaphor genuinely improves understanding.
+- Prefer clarity first; theme is a multiplier, not the main payload.
 
 ### When to Skip It
 


### PR DESCRIPTION
### Motivation
- Clarify that the Expedition Layer is a brand aesthetic (thematic vibe) rather than a prose glossary, and to prevent authors from forcing metaphors into body copy.

### Description
- Rewrote the Expedition Layer section in `plugins/team/skills/outfitter-styleguide/SKILL.md` to frame expedition language as background texture and to treat literal product names separately.
- Replaced the old metaphor lookup table with a "Where It Shows Up Naturally" table and added a short "Practical Distinction" list (for example: use `scout` when the product/command is literally named `scout`) while keeping the existing "When to Skip It" and "The Test" subsections.

### Testing
- Ran `bunx markdownlint-cli2 plugins/team/skills/outfitter-styleguide/SKILL.md`, which reported existing markdownlint violations (line-length, table-style, duplicate headings) originating from the legacy file style and not introduced by this change.
- The lefthook pre-commit hooks executed during commit and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997854873348320ac72e377b3127b0e)