### PR TITLE
fix(outfitter): convert MCP template tagged-template logger calls to function syntax [OS-237]

### DIFF
--- a/apps/outfitter/templates/mcp/src/mcp.ts.template
+++ b/apps/outfitter/templates/mcp/src/mcp.ts.template
@@ -54,7 +54,7 @@ export function createMCPServer(): Server {
 				const greeting =
 					typeof input.name === "string" && input.name.trim().length > 0 ? input.name : "World";
 
-				logger.info`Greeting ${greeting}`;
+				logger.info(`Greeting ${greeting}`);
 				return {
 					content: [
 						{
@@ -71,7 +71,7 @@ export function createMCPServer(): Server {
 			return handler((args ?? {}) as HelloArgs);
 		}
 
-		logger.warn`Unknown tool ${name}`;
+		logger.warn(`Unknown tool: ${name}`);
 		throw new Error(`Unknown tool: ${name}`);
 	});
 


### PR DESCRIPTION
## Summary
- The MCP scaffold template used tagged-template syntax for logger calls (e.g. `` logger.info`...` ``) which TypeScript rejects with TS2345 because `@outfitter/logging` loggers do not accept tagged-template arguments
- Converted two logger call sites in `mcp.ts.template` to standard function-call syntax: `logger.info(...)` and `logger.warn(...)`
- Also tightened the unknown-tool warning message to include a colon for consistency with the thrown error message

## Test plan
- [ ] Scaffold a new MCP project with `outfitter init --template mcp`
- [ ] Run `bun run typecheck` in the scaffolded project — should pass with no TS2345 errors
- [ ] Confirm `logger.info` and `logger.warn` calls in `src/mcp.ts` use function-call syntax

Closes: OS-237

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)