### PR TITLE
fix(outfitter): convert daemon template tagged-template logger calls to function syntax [OS-247]

### DIFF
--- a/apps/outfitter/templates/daemon/src/cli.ts.template
+++ b/apps/outfitter/templates/daemon/src/cli.ts.template
@@ -30,7 +30,7 @@ program.register(
 			const foreground = Boolean((flags as { foreground?: boolean }).foreground);
 
 			if (await isDaemonAlive(lockPath)) {
-				logger.warn`Daemon is already running`;
+				logger.warn("Daemon is already running");
 				process.exit(1);
 			}
 
@@ -45,7 +45,7 @@ program.register(
 					stdio: "ignore",
 				});
 				daemon.unref();
-				logger.info`Daemon started with PID ${daemon.pid}`;
+				logger.info(`Daemon started with PID ${daemon.pid}`);
 			}
 		}),
 );
@@ -55,7 +55,7 @@ program.register(
 		.description("Stop the daemon")
 		.action(async () => {
 			if (!(await isDaemonAlive(lockPath))) {
-				logger.warn`Daemon is not running`;
+				logger.warn("Daemon is not running");
 				process.exit(1);
 			}
 			// Signal daemon to stop via HTTP
@@ -64,10 +64,10 @@ program.register(
 					method: "POST",
 				});
 				if (response.ok) {
-					logger.info`Daemon stopped`;
+					logger.info("Daemon stopped");
 				}
 			} catch {
-				logger.error`Failed to stop daemon`;
+				logger.error("Failed to stop daemon");
 				process.exit(1);
 			}
 		}),
@@ -78,17 +78,17 @@ program.register(
 		.description("Check daemon status")
 		.action(async () => {
 			if (await isDaemonAlive(lockPath)) {
-				logger.info`Daemon is running`;
+				logger.info("Daemon is running");
 				// Fetch health info
 				try {
 					const response = await fetch(`http://unix:${socketPath}:/health`);
 					const health = await response.json();
 					console.log(JSON.stringify(health, null, 2));
 				} catch {
-					logger.warn`Could not fetch health info`;
+					logger.warn("Could not fetch health info");
 				}
 			} else {
-				logger.info`Daemon is not running`;
+				logger.info("Daemon is not running");
 			}
 		}),
 );

--- a/apps/outfitter/templates/daemon/src/daemon-main.ts.template
+++ b/apps/outfitter/templates/daemon/src/daemon-main.ts.template
@@ -28,12 +28,12 @@ export async function runDaemon(): Promise<void> {
 	// Acquire lock
 	const lockResult = await acquireDaemonLock(lockPath);
 	if (!lockResult.isOk()) {
-		logger.error`Failed to acquire lock: ${lockResult.error.message}`;
+		logger.error(`Failed to acquire lock: ${lockResult.error.message}`);
 		process.exit(1);
 	}
 	const lock = lockResult.value;
 
-	logger.info`Daemon starting on ${socketPath}`;
+	logger.info(`Daemon starting on ${socketPath}`);
 
 	// Create HTTP server on Unix socket
 	const server = Bun.serve({
@@ -50,7 +50,7 @@ export async function runDaemon(): Promise<void> {
 			}
 
 			if (url.pathname === "/shutdown" && request.method === "POST") {
-				logger.info`Shutdown requested`;
+				logger.info("Shutdown requested");
 				// Schedule shutdown
 				setTimeout(async () => {
 					await releaseDaemonLock(lock);
@@ -66,7 +66,7 @@ export async function runDaemon(): Promise<void> {
 
 	// Handle signals
 	const shutdown = async () => {
-		logger.info`Received shutdown signal`;
+		logger.info("Received shutdown signal");
 		await releaseDaemonLock(lock);
 		server.stop();
 		process.exit(0);
@@ -75,5 +75,5 @@ export async function runDaemon(): Promise<void> {
 	process.on("SIGTERM", shutdown);
 	process.on("SIGINT", shutdown);
 
-	logger.info`Daemon running`;
+	logger.info("Daemon running");
 }


### PR DESCRIPTION
## Summary
- Daemon scaffold templates (`cli.ts.template` and `daemon-main.ts.template`) used tagged-template syntax for all logger calls (e.g. `` logger.info`...` ``), which TypeScript rejects with TS2345
- Converted 10 logger call sites across both templates to standard function-call syntax: `logger.info(...)`, `logger.warn(...)`, and `logger.error(...)`
- Affected call sites cover all lifecycle events: daemon start/stop/status, lock acquisition, shutdown signals, and error paths

## Test plan
- [ ] Scaffold a new daemon project with `outfitter init --template daemon`
- [ ] Run `bun run typecheck` in the scaffolded project — should pass with no TS2345 errors
- [ ] Confirm all logger calls in `src/cli.ts` and `src/daemon-main.ts` use function-call syntax

Closes: OS-247

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)