### PR TITLE
fix(outfitter): wire onError and await parse in CLI and daemon scaffold templates [OS-243]

### DIFF
--- a/apps/outfitter/templates/cli/src/cli.ts.template
+++ b/apps/outfitter/templates/cli/src/cli.ts.template
@@ -5,4 +5,4 @@
 
 import { program } from "./program.js";
 
-program.parse(process.argv);
+await program.parse(process.argv);

--- a/apps/outfitter/templates/cli/src/program.ts.template
+++ b/apps/outfitter/templates/cli/src/program.ts.template
@@ -4,14 +4,13 @@
 
 import { command, createCLI } from "@outfitter/cli/command";
 import { verbosePreset } from "@outfitter/cli/flags";
-import { createLogger } from "@outfitter/logging";
-
-const logger = createLogger({ name: "{{binName}}" });
+import { exitWithError, output } from "@outfitter/cli/output";
 
 export const program = createCLI({
 	name: "{{binName}}",
 	version: "{{version}}",
 	description: "{{description}}",
+	onError: (error) => exitWithError(error),
 });
 
 const verbose = verbosePreset();
@@ -23,9 +22,9 @@ program.register(
 		.action<{ verbose: boolean }>(async ({ args, flags }) => {
 			const { verbose: isVerbose } = verbose.resolve(flags);
 			const name = args[0] ?? "World";
-			logger.info(`Hello, ${name}!`);
+			await output(`Hello, ${name}!`);
 			if (isVerbose) {
-				logger.debug("Running in verbose mode");
+				await output({ detail: "Running in verbose mode" });
 			}
 		}),
 );

--- a/apps/outfitter/templates/daemon/src/cli.ts.template
+++ b/apps/outfitter/templates/daemon/src/cli.ts.template
@@ -6,6 +6,7 @@
  */
 
 import { command, createCLI } from "@outfitter/cli/command";
+import { exitWithError } from "@outfitter/cli/output";
 import { createLogger } from "@outfitter/logging";
 import { spawn } from "node:child_process";
 import { getSocketPath, getLockPath, isDaemonAlive } from "@outfitter/daemon";
@@ -20,6 +21,7 @@ const program = createCLI({
 	name: "{{binName}}",
 	version: "{{version}}",
 	description: "{{description}}",
+	onError: (error) => exitWithError(error),
 });
 
 program.register(
@@ -93,4 +95,4 @@ program.register(
 		}),
 );
 
-program.parse(process.argv);
+await program.parse(process.argv);


### PR DESCRIPTION
## Summary
- CLI and daemon scaffold templates did not pass `onError` to `createCLI`, so validation errors were silently swallowed rather than surfaced to the user
- `program.parse()` was called without `await`, causing async command handlers to be fire-and-forget and masking any errors they threw
- Added `onError: (error) => exitWithError(error)` to `createCLI` in both `cli/program.ts.template` and `daemon/cli.ts.template`
- Changed `program.parse(process.argv)` to `await program.parse(process.argv)` in both entry points
- Replaced the logger-based hello handler in the CLI template with `output()`/`exitWithError()` from `@outfitter/cli/output` to align with the CLI output contract

## Test plan
- [ ] Scaffold CLI and daemon projects and run `bun run typecheck` — should pass
- [ ] Invoke the scaffolded CLI with an invalid command and confirm an error message is printed and the process exits non-zero
- [ ] Confirm `program.parse` is awaited in both `src/cli.ts` files

Closes: OS-243

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)