### PR TITLE
feat(outfitter): modernize MCP scaffold to use @outfitter/mcp primitives [OS-248]

### DIFF
--- a/apps/outfitter/src/commands/scaffold.ts
+++ b/apps/outfitter/src/commands/scaffold.ts
@@ -234,7 +234,7 @@ function detectExistingCategory(pkg: PackageJsonData): "runnable" | "library" {
     ...(pkg.dependencies ?? {}),
     ...(pkg.devDependencies ?? {}),
   };
-  if (deps["@modelcontextprotocol/sdk"]) {
+  if (deps["@modelcontextprotocol/sdk"] || deps["@outfitter/mcp"]) {
     return "runnable";
   }
 

--- a/apps/outfitter/templates/mcp/package.json.template
+++ b/apps/outfitter/templates/mcp/package.json.template
@@ -26,11 +26,10 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.12.0",
 		"@outfitter/contracts": "^0.4.0",
-		"@outfitter/types": "^0.2.2",
 		"@outfitter/mcp": "^0.4.1",
-		"@outfitter/logging": "^0.4.0"
+		"@outfitter/logging": "^0.4.0",
+		"zod": "^4.3.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.0",

--- a/apps/outfitter/templates/mcp/src/index.ts.template
+++ b/apps/outfitter/templates/mcp/src/index.ts.template
@@ -4,4 +4,4 @@
  * @packageDocumentation
  */
 
-export { createMCPServer } from "./mcp.js";
+export { server, startServer } from "./mcp.js";

--- a/apps/outfitter/templates/mcp/src/mcp.ts.template
+++ b/apps/outfitter/templates/mcp/src/mcp.ts.template
@@ -2,78 +2,32 @@
  * {{projectName}} - MCP server definition
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { createLogger } from "@outfitter/logging";
+import { Result } from "@outfitter/contracts";
+import { createMcpServer, defineTool, connectStdio } from "@outfitter/mcp";
+import { z } from "zod";
 
-const logger = createLogger({ name: "{{binName}}" });
+const server = createMcpServer({
+	name: "{{binName}}",
+	version: "{{version}}",
+});
 
-type HelloArgs = {
-	name?: unknown;
-};
+const helloTool = defineTool({
+	name: "hello",
+	description: "Say hello to someone",
+	inputSchema: z.object({
+		name: z.string().default("World").describe("Name to greet"),
+	}),
+	handler: async (input, ctx) => {
+		ctx.logger.info(`Greeting ${input.name}`);
+		return Result.ok({ greeting: `Hello, ${input.name}!` });
+	},
+});
 
-export function createMCPServer(): Server {
-	const server = new Server(
-		{
-			name: "{{binName}}",
-			version: "{{version}}",
-		},
-		{
-			capabilities: {
-				tools: {},
-			},
-		}
-	);
+server.registerTool(helloTool);
 
-	// List available tools
-	server.setRequestHandler(ListToolsRequestSchema, async () => ({
-		tools: [
-			{
-				name: "hello",
-				description: "Say hello to someone",
-				inputSchema: {
-					type: "object" as const,
-					properties: {
-						name: {
-							type: "string",
-							description: "Name to greet",
-							default: "World",
-						},
-					},
-				},
-			},
-		],
-	}));
+export { server };
 
-	// Handle tool calls
-	server.setRequestHandler(CallToolRequestSchema, async (request) => {
-		const { name, arguments: args } = request.params;
-
-		const handlers: Record<string, (input: HelloArgs) => { content: { type: "text"; text: string }[] }> = {
-			hello: (input) => {
-				const greeting =
-					typeof input.name === "string" && input.name.trim().length > 0 ? input.name : "World";
-
-				logger.info(`Greeting ${greeting}`);
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: `Hello, ${greeting}!`,
-						},
-					],
-				};
-			},
-		};
-
-		const handler = handlers[name];
-		if (handler) {
-			return handler((args ?? {}) as HelloArgs);
-		}
-
-		logger.warn(`Unknown tool: ${name}`);
-		throw new Error(`Unknown tool: ${name}`);
-	});
-
-	return server;
+/** Start the MCP server over stdio transport. */
+export async function startServer(): Promise<void> {
+	await connectStdio(server);
 }

--- a/apps/outfitter/templates/mcp/src/server.ts.template
+++ b/apps/outfitter/templates/mcp/src/server.ts.template
@@ -3,13 +3,6 @@
  * {{projectName}} MCP server entry point
  */
 
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createMCPServer } from "./mcp.js";
+import { startServer } from "./mcp.js";
 
-async function main() {
-	const server = createMCPServer();
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
-}
-
-main().catch(console.error);
+startServer().catch(console.error);


### PR DESCRIPTION
## Summary
- The MCP scaffold template implemented tool registration manually using raw `@modelcontextprotocol/sdk` primitives (`Server`, `ListToolsRequestSchema`, `CallToolRequestSchema`), bypassing the `@outfitter/mcp` abstractions the rest of the stack uses
- Replaced the raw SDK approach with `createMcpServer`, `defineTool`, and `connectStdio` from `@outfitter/mcp`, reducing the template from ~78 lines to ~32 and removing all manual request-handler wiring
- Tools now declare typed `inputSchema` via Zod and return `Result.ok(...)`, matching the handler contract used by CLI and action-registry patterns
- Dropped `@modelcontextprotocol/sdk` as a direct dependency (now transitive via `@outfitter/mcp`) and added `zod` as an explicit dependency
- Updated `detectExistingCategory` in `scaffold.ts` to also recognize `@outfitter/mcp` as an MCP indicator (alongside the raw SDK)

## Test plan
- [ ] Scaffold a new MCP project and run `bun run typecheck` — should pass
- [ ] Run `bun run test --filter=outfitter` — `init.test.ts` assertions for MCP template should pass
- [ ] Manually invoke the scaffolded server and call the `hello` tool; confirm it returns `{ greeting: "Hello, World!" }`
- [ ] Run `outfitter init --template mcp` in an existing project that has `@outfitter/mcp` and confirm it is correctly classified as `runnable`

Closes: OS-248

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)