### PR TITLE
feat(outfitter): align CLI scaffold with action-registry pattern [OS-245]

### DIFF
--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -157,9 +157,9 @@ describe("init command file creation", () => {
     );
     expect(packageJson.scripts["clean:artifacts"]).toBe("rm -rf dist .turbo");
     expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.4.0");
-    expect(packageJson.dependencies["@outfitter/types"]).toBe("^0.2.2");
     expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.5.1");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.4.0");
+    expect(packageJson.dependencies.zod).toBe("^4.3.5");
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
 
     const tsconfigPath = join(tempDir, "tsconfig.json");
@@ -175,8 +175,13 @@ describe("init command file creation", () => {
 
     const programPath = join(tempDir, "src", "program.ts");
     const programContent = readFileSync(programPath, "utf-8");
-    expect(programContent).toMatch(/await output\(`Hello, \$\{name\}!`\);/);
-    expect(programContent).not.toMatch(/logger\.info/);
+    expect(programContent).toMatch(/buildCliCommands/);
+    expect(programContent).toMatch(/createContext/);
+
+    const actionsPath = join(tempDir, "src", "actions.ts");
+    const actionsContent = readFileSync(actionsPath, "utf-8");
+    expect(actionsContent).toMatch(/defineAction/);
+    expect(actionsContent).toMatch(/createActionRegistry/);
   });
 
   test("creates src directory structure", async () => {
@@ -367,7 +372,6 @@ describe("init command local dependency rewriting", () => {
     expect(packageJson.dependencies["@outfitter/contracts"]).toBe(
       "workspace:*"
     );
-    expect(packageJson.dependencies["@outfitter/types"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/cli"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();

--- a/apps/outfitter/templates/cli/package.json.template
+++ b/apps/outfitter/templates/cli/package.json.template
@@ -27,10 +27,10 @@
 	},
 	"dependencies": {
 		"@outfitter/contracts": "^0.4.0",
-		"@outfitter/types": "^0.2.2",
 		"@outfitter/cli": "^0.5.1",
 		"@outfitter/logging": "^0.4.0",
-		"commander": "^14.0.0"
+		"commander": "^14.0.0",
+		"zod": "^4.3.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.0",

--- a/apps/outfitter/templates/cli/src/actions.ts.template
+++ b/apps/outfitter/templates/cli/src/actions.ts.template
@@ -1,0 +1,53 @@
+/**
+ * {{projectName}} - Action definitions
+ *
+ * Actions are transport-agnostic handlers that can be exposed via CLI, MCP, or API.
+ * Define input/output schemas with Zod and return Result types from handlers.
+ */
+
+import {
+	createActionRegistry,
+	defineAction,
+	Result,
+} from "@outfitter/contracts";
+import { output } from "@outfitter/cli";
+import { z } from "zod";
+
+/** Greet someone by name. */
+const hello = defineAction({
+	id: "hello",
+	description: "Say hello to someone",
+	surfaces: ["cli"],
+	input: z.object({
+		name: z.string().default("World").describe("Name to greet"),
+		shout: z.boolean().default(false).describe("Greet in uppercase"),
+	}),
+	output: z.object({
+		greeting: z.string(),
+	}),
+	cli: {
+		command: "hello <name>",
+		options: [
+			{
+				flags: "--shout",
+				description: "Greet in uppercase",
+			},
+		],
+		mapInput: ({ args, flags }) => ({
+			name: args[0] ?? "World",
+			shout: Boolean(flags.shout),
+		}),
+	},
+	handler: async (input, ctx) => {
+		let greeting = `Hello, ${input.name}!`;
+		if (input.shout) {
+			greeting = greeting.toUpperCase();
+		}
+		ctx.logger.info(`Greeting ${input.name}`);
+		await output(greeting);
+		return Result.ok({ greeting });
+	},
+});
+
+/** All registered actions for this CLI. */
+export const actions = createActionRegistry().add(hello);

--- a/apps/outfitter/templates/cli/src/index.ts.template
+++ b/apps/outfitter/templates/cli/src/index.ts.template
@@ -4,4 +4,5 @@
  * @packageDocumentation
  */
 
+export { actions } from "./actions.js";
 export { program } from "./program.js";

--- a/apps/outfitter/templates/cli/src/program.ts.template
+++ b/apps/outfitter/templates/cli/src/program.ts.template
@@ -2,9 +2,11 @@
  * {{projectName}} - CLI program definition
  */
 
-import { command, createCLI } from "@outfitter/cli/command";
-import { verbosePreset } from "@outfitter/cli/flags";
+import { createContext } from "@outfitter/contracts";
+import { buildCliCommands } from "@outfitter/cli/actions";
+import { createCLI } from "@outfitter/cli/command";
 import { exitWithError, output } from "@outfitter/cli/output";
+import { actions } from "./actions.js";
 
 export const program = createCLI({
 	name: "{{binName}}",
@@ -13,18 +15,12 @@ export const program = createCLI({
 	onError: (error) => exitWithError(error),
 });
 
-const verbose = verbosePreset();
-
-program.register(
-	command("hello [name]")
-		.description("Say hello")
-		.preset(verbose)
-		.action<{ verbose: boolean }>(async ({ args, flags }) => {
-			const { verbose: isVerbose } = verbose.resolve(flags);
-			const name = args[0] ?? "World";
-			await output(`Hello, ${name}!`);
-			if (isVerbose) {
-				await output({ detail: "Running in verbose mode" });
-			}
+for (const command of buildCliCommands(actions, {
+	createContext: () =>
+		createContext({
+			cwd: process.cwd(),
+			env: process.env as Record<string, string | undefined>,
 		}),
-);
+})) {
+	program.register(command);
+}


### PR DESCRIPTION
## Summary
- The CLI scaffold template used the low-level `command()` builder pattern, which couples command parsing directly to handler logic and diverges from the action-registry approach used in `apps/outfitter` itself
- Introduced a new `src/actions.ts.template` that defines commands via `defineAction` + `createActionRegistry`, keeping input/output schemas (Zod), CLI option mappings, and handler logic co-located and transport-agnostic
- Updated `src/program.ts.template` to drive command registration from the action registry using `buildCliCommands` and `createContext`, eliminating the manual `command().action()` loop
- Removed `@outfitter/types` as a direct dependency (unused after refactor) and added `zod@^4.3.5`
- Exported `actions` from `src/index.ts.template` so scaffolded projects can reuse the registry for MCP or other surfaces
- Updated `init.test.ts` to assert the presence of `buildCliCommands`/`createContext` in `program.ts` and `defineAction`/`createActionRegistry` in `actions.ts`

## Test plan
- [ ] Scaffold a CLI project and run `bun run typecheck` — should pass
- [ ] Run `bun run test --filter=outfitter` — init test assertions for CLI template should pass
- [ ] Invoke the scaffolded CLI (`hello World` and `hello World --shout`) and confirm output is correct
- [ ] Confirm `src/actions.ts` is generated and exports a valid action registry

Closes: OS-245

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)