### PR TITLE
feat(outfitter): add starter test files to all scaffold templates [OS-240]

### DIFF
--- a/apps/outfitter/templates/basic/src/__tests__/index.test.ts.template
+++ b/apps/outfitter/templates/basic/src/__tests__/index.test.ts.template
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+
+describe("{{projectName}}", () => {
+	test("module exports are defined", async () => {
+		const mod = await import("../index.js");
+		expect(mod).toBeDefined();
+	});
+});

--- a/apps/outfitter/templates/cli/src/__tests__/actions.test.ts.template
+++ b/apps/outfitter/templates/cli/src/__tests__/actions.test.ts.template
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { actions } from "../actions.js";
+
+describe("{{projectName}} actions", () => {
+	test("hello action is registered", () => {
+		const hello = actions.get("hello");
+		expect(hello).toBeDefined();
+		expect(hello?.description).toBe("Say hello to someone");
+	});
+
+	test("action registry is not empty", () => {
+		const all = actions.list();
+		expect(all.length).toBeGreaterThan(0);
+	});
+});

--- a/apps/outfitter/templates/daemon/src/__tests__/daemon.test.ts.template
+++ b/apps/outfitter/templates/daemon/src/__tests__/daemon.test.ts.template
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+
+describe("{{projectName}} daemon", () => {
+	test("module exports are defined", async () => {
+		const mod = await import("../index.js");
+		expect(mod).toBeDefined();
+	});
+});

--- a/apps/outfitter/templates/mcp/src/__tests__/mcp.test.ts.template
+++ b/apps/outfitter/templates/mcp/src/__tests__/mcp.test.ts.template
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { server } from "../mcp.js";
+
+describe("{{projectName}} MCP server", () => {
+	test("server is configured", () => {
+		expect(server).toBeDefined();
+	});
+});

--- a/apps/outfitter/templates/minimal/src/__tests__/index.test.ts.template
+++ b/apps/outfitter/templates/minimal/src/__tests__/index.test.ts.template
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+
+describe("{{projectName}}", () => {
+	test("module exports are defined", async () => {
+		const mod = await import("../index.js");
+		expect(mod).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Every scaffold template (`basic`, `cli`, `daemon`, `mcp`, `minimal`) previously shipped with no test files, causing `bun test` and `verify:ci` to fail immediately on a freshly scaffolded project
- Added a `src/__tests__/*.test.ts.template` to each template with a minimal smoke test appropriate to each preset (module exports, action registry, MCP server instantiation)
- The `cli` template gets the most specific tests — it verifies the `hello` action is registered and the action registry is non-empty; other templates verify module-level exports are defined
- Templates use the `{{projectName}}` variable so generated test descriptions match the project name

## Test plan
- [ ] Scaffold a new project with each preset (`basic`, `cli`, `daemon`, `mcp`, `minimal`)
- [ ] Confirm `src/__tests__/` directory and a `.test.ts` file are generated in each
- [ ] Run `bun test` in each scaffolded project and confirm the starter test passes
- [ ] Confirm `verify:ci` passes end-to-end on a freshly scaffolded project

Closes: OS-240

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)