### PR TITLE
fix(outfitter): eliminate day-zero drift between init templates and block registry [OS-238]

### DIFF
--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -166,12 +166,9 @@ describe("init command file creation", () => {
     const tsconfig = JSON.parse(readFileSync(tsconfigPath, "utf-8"));
     expect(tsconfig.extends).toBeUndefined();
 
-    const biomePath = join(tempDir, "biome.json");
-    const biome = JSON.parse(readFileSync(biomePath, "utf-8"));
-    expect(biome.$schema).toBe(
-      "https://biomejs.dev/schemas/2.3.12/schema.json"
-    );
-    expect(biome.extends).toEqual(["ultracite/config/biome/core/biome.jsonc"]);
+    // biome.json is provided by the biome block, not the template.
+    // With --no-tooling, no blocks are added and no biome.json is created.
+    expect(existsSync(join(tempDir, "biome.json"))).toBe(false);
 
     const programPath = join(tempDir, "src", "program.ts");
     const programContent = readFileSync(programPath, "utf-8");
@@ -820,16 +817,16 @@ describe("init command registry blocks", () => {
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.blocksAdded).toBeDefined();
-      // Scaffolding creates files that don't exist in the template
+      // Blocks are the canonical source for tooling files — no template duplicates.
       expect(result.value.blocksAdded?.created).toContain(
         ".claude/settings.json"
       );
       expect(result.value.blocksAdded?.created).toContain("biome.json");
+      expect(result.value.blocksAdded?.created).toContain(".lefthook.yml");
       expect(result.value.blocksAdded?.created).toContain(
         "scripts/bootstrap.sh"
       );
-      // .lefthook.yml is skipped because template already creates it
-      expect(result.value.blocksAdded?.skipped).toContain(".lefthook.yml");
+      expect(result.value.blocksAdded?.skipped).toEqual([]);
     }
   });
 

--- a/apps/outfitter/templates/basic/.lefthook.yml.template
+++ b/apps/outfitter/templates/basic/.lefthook.yml.template
@@ -1,7 +1,0 @@
-# Lefthook configuration
-# https://github.com/evilmartians/lefthook
-#
-# Extends the @outfitter/tooling preset
-
-extends:
-  - node_modules/@outfitter/tooling/lefthook.yml

--- a/apps/outfitter/templates/cli/.lefthook.yml.template
+++ b/apps/outfitter/templates/cli/.lefthook.yml.template
@@ -1,7 +1,0 @@
-# Lefthook configuration
-# https://github.com/evilmartians/lefthook
-#
-# Extends the @outfitter/tooling preset
-
-extends:
-  - node_modules/@outfitter/tooling/lefthook.yml

--- a/apps/outfitter/templates/cli/biome.json.template
+++ b/apps/outfitter/templates/cli/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/apps/outfitter/templates/daemon/.lefthook.yml.template
+++ b/apps/outfitter/templates/daemon/.lefthook.yml.template
@@ -1,7 +1,0 @@
-# Lefthook configuration
-# https://github.com/evilmartians/lefthook
-#
-# Extends the @outfitter/tooling preset
-
-extends:
-  - node_modules/@outfitter/tooling/lefthook.yml

--- a/apps/outfitter/templates/daemon/biome.json.template
+++ b/apps/outfitter/templates/daemon/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/apps/outfitter/templates/mcp/.lefthook.yml.template
+++ b/apps/outfitter/templates/mcp/.lefthook.yml.template
@@ -1,7 +1,0 @@
-# Lefthook configuration
-# https://github.com/evilmartians/lefthook
-#
-# Extends the @outfitter/tooling preset
-
-extends:
-  - node_modules/@outfitter/tooling/lefthook.yml

--- a/apps/outfitter/templates/mcp/biome.json.template
+++ b/apps/outfitter/templates/mcp/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/apps/outfitter/templates/minimal/.lefthook.yml.template
+++ b/apps/outfitter/templates/minimal/.lefthook.yml.template
@@ -1,7 +1,0 @@
-# Lefthook configuration
-# https://github.com/evilmartians/lefthook
-#
-# Extends the @outfitter/tooling preset
-
-extends:
-  - node_modules/@outfitter/tooling/lefthook.yml


### PR DESCRIPTION
## Summary
- Templates for `basic`, `cli`, `daemon`, `mcp`, and `minimal` each shipped their own `biome.json` and `.lefthook.yml`, which conflicted with the versions managed by the block registry — causing the block's copy to be skipped as a duplicate on first `outfitter add`
- Removed `biome.json.template` and `.lefthook.yml.template` from all templates; the block registry is now the sole canonical source for these tooling files
- `addBlocks` now always passes `force: true` during plan execution so the block registry authoritatively writes these files on first init, with no risk of stale template copies
- Updated tests to assert that `biome.json` and `.lefthook.yml` are both `created` (not `skipped`) by the registry, and that `--no-tooling` scaffolds correctly produce no `biome.json`

## Test plan
- [ ] Run `outfitter init` with default options and confirm `biome.json` and `.lefthook.yml` are reported as `created` in `blocksAdded`, not `skipped`
- [ ] Run `outfitter init --no-tooling` and confirm `biome.json` is absent from the scaffolded directory
- [ ] Confirm `outfitter add biome` on an existing project still works (no conflict from template remnants)
- [ ] Run the full `init.test.ts` suite and confirm all assertions pass

Closes: OS-238

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)