### PR TITLE
feat(tooling): broaden check-tsdoc discovery to apps/ and single-app repos [OS-239]

### DIFF
--- a/.changeset/broaden-check-tsdoc-discovery.md
+++ b/.changeset/broaden-check-tsdoc-discovery.md
@@ -1,0 +1,5 @@
+---
+"@outfitter/tooling": patch
+---
+
+Broaden check-tsdoc package discovery to include apps/ directory and single-app repos

--- a/apps/outfitter/src/commands/check-tsdoc.ts
+++ b/apps/outfitter/src/commands/check-tsdoc.ts
@@ -324,7 +324,7 @@ export async function runCheckTsdoc(
     if (!rawResult) {
       return Result.err(
         ValidationError.fromMessage(
-          "No packages found with src/index.ts entry points.",
+          "No packages found. Searched packages/*, apps/*, and src/index.ts. Use --package <path> to specify explicitly.",
           { cwd: input.cwd }
         )
       );

--- a/packages/tooling/src/cli/check-tsdoc.ts
+++ b/packages/tooling/src/cli/check-tsdoc.ts
@@ -375,37 +375,71 @@ function bar(percentage: number, width = 20): string {
 function discoverPackages(
 	cwd: string,
 ): Array<{ name: string; path: string; entryPoint: string }> {
-	const glob = new Bun.Glob("packages/*/src/index.ts");
 	const packages: Array<{ name: string; path: string; entryPoint: string }> =
 		[];
 
-	for (const match of glob.scanSync({ cwd, dot: false })) {
-		// Extract package directory name
-		const parts = match.split("/");
-		const pkgDir = parts[1];
-		if (!pkgDir) continue;
+	// Search packages/*/ and apps/*/ for monorepo layouts
+	for (const pattern of ["packages/*/src/index.ts", "apps/*/src/index.ts"]) {
+		const glob = new Bun.Glob(pattern);
+		for (const match of glob.scanSync({ cwd, dot: false })) {
+			const parts = match.split("/");
+			const rootDir = parts[0];
+			const pkgDir = parts[1];
+			if (!rootDir || !pkgDir) continue;
+			const entryPoint = resolve(cwd, match);
+			if (seenEntryPoints.has(entryPoint)) {
+				continue;
+			}
+			seenEntryPoints.add(entryPoint);
 
-		const pkgRoot = resolve(cwd, "packages", pkgDir);
-		let pkgName = pkgDir;
+			const pkgRoot = resolve(cwd, rootDir, pkgDir);
+			let pkgName = pkgDir;
 
-		// Try to read package.json for the real name
-		try {
-			const pkgJson = JSON.parse(
-				require("node:fs").readFileSync(
-					resolve(pkgRoot, "package.json"),
-					"utf-8",
-				),
-			) as { name?: string };
-			if (pkgJson.name) pkgName = pkgJson.name;
-		} catch {
-			// Fall back to directory name
+			try {
+				const pkgJson = JSON.parse(
+					require("node:fs").readFileSync(
+						resolve(pkgRoot, "package.json"),
+						"utf-8",
+					),
+				) as { name?: string };
+				if (pkgJson.name) pkgName = pkgJson.name;
+			} catch {
+				// Fall back to directory name
+			}
+
+			packages.push({
+				name: pkgName,
+				path: pkgRoot,
+				entryPoint,
+			});
 		}
+	}
 
-		packages.push({
-			name: pkgName,
-			path: pkgRoot,
-			entryPoint: resolve(cwd, match),
-		});
+	// Single-app repo: check cwd itself for src/index.ts
+	if (packages.length === 0) {
+		const entryPoint = resolve(cwd, "src/index.ts");
+		try {
+			require("node:fs").accessSync(entryPoint);
+			let pkgName = "root";
+			try {
+				const pkgJson = JSON.parse(
+					require("node:fs").readFileSync(
+						resolve(cwd, "package.json"),
+						"utf-8",
+					),
+				) as { name?: string };
+				if (pkgJson.name) pkgName = pkgJson.name;
+			} catch {
+				// Fall back to "root"
+			}
+			packages.push({
+				name: pkgName,
+				path: cwd,
+				entryPoint,
+			});
+		} catch {
+			// No src/index.ts in cwd
+		}
 	}
 
 	return packages.sort((a, b) => a.name.localeCompare(b.name));
@@ -693,7 +727,11 @@ export async function runCheckTsdoc(
 	const result = analyzeCheckTsdoc(options);
 
 	if (!result) {
-		process.stderr.write("No packages found with src/index.ts entry points.\n");
+		process.stderr.write(
+			"No packages found with src/index.ts entry points.\n" +
+				"Searched: packages/*/src/index.ts, apps/*/src/index.ts, src/index.ts\n" +
+				"Use --package <path> to specify a package path explicitly.\n",
+		);
 		process.exit(1);
 	}
 


### PR DESCRIPTION
## Summary
- `check-tsdoc` previously only globbed `packages/*/src/index.ts`, so it silently found nothing (and errored) when run in app-oriented monorepos or single-package repos without a `packages/` directory
- Discovery now searches both `packages/*/src/index.ts` and `apps/*/src/index.ts`, covering the dual-directory layout used by this monorepo
- Added a single-app fallback: if no packages are found under `packages/` or `apps/`, the tool checks for `src/index.ts` in the working directory itself, using the root `package.json` name
- Improved the "nothing found" error message in both `@outfitter/tooling` and `apps/outfitter` to enumerate the paths that were searched and suggest `--package <path>` for explicit targeting

## Test plan
- [ ] Run `check-tsdoc` from an `apps/`-only monorepo root and confirm all apps are discovered
- [ ] Run `check-tsdoc` from a single-package repo (no `packages/` or `apps/` dir) and confirm `src/index.ts` is picked up
- [ ] Run `check-tsdoc` from a directory with no matching entry points and confirm the improved error message lists searched paths
- [ ] Run `check-tsdoc` from the monorepo root of this repo and confirm `packages/*` and `apps/*` are both scanned

Closes: OS-239

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)