### PR TITLE
feat(outfitter): improve workspace-root UX for doctor and check [OS-241]

### DIFF
--- a/apps/outfitter/src/__tests__/check.test.ts
+++ b/apps/outfitter/src/__tests__/check.test.ts
@@ -375,6 +375,22 @@ describe("runCheck", () => {
   });
 
   // =========================================================================
+  // Empty result at workspace root (no blocks detected)
+  // =========================================================================
+
+  test("empty directory with no manifest returns 0 blocks", async () => {
+    const result = await runCheck({ cwd: testDir });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.totalChecked).toBe(0);
+      expect(result.value.currentCount).toBe(0);
+      expect(result.value.driftedCount).toBe(0);
+      expect(result.value.missingCount).toBe(0);
+    }
+  });
+
+  // =========================================================================
   // String comparison for non-JSON files
   // =========================================================================
 

--- a/apps/outfitter/src/__tests__/doctor.test.ts
+++ b/apps/outfitter/src/__tests__/doctor.test.ts
@@ -355,3 +355,102 @@ describe("doctor command result structure", () => {
     expect(result.checks).toHaveProperty("directories");
   });
 });
+
+// =============================================================================
+// Doctor Command Workspace Root Tests
+// =============================================================================
+
+describe("doctor command workspace root handling", () => {
+  test("excludes tsconfig and src from scoring at workspace root", async () => {
+    const { runDoctor } = await import("../commands/doctor.js");
+
+    // Workspace root: has workspaces field, no tsconfig or src/
+    const packageJson = {
+      name: "my-workspace",
+      version: "1.0.0",
+      workspaces: ["apps/*", "packages/*"],
+    };
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify(packageJson, null, 2)
+    );
+    mkdirSync(join(tempDir, "node_modules"), { recursive: true });
+
+    const result = runDoctor({ cwd: tempDir });
+
+    // Workspace root: only bun, package.json, deps checked (3 total)
+    expect(result.isWorkspaceRoot).toBe(true);
+    expect(result.summary.total).toBe(3);
+    expect(result.exitCode).toBe(0);
+    expect(result.checks.configFiles.tsconfig).toBe(true);
+    expect(result.checks.directories.src).toBe(true);
+    expect(result.skippedChecks).toEqual([
+      "checks.configFiles.tsconfig",
+      "checks.directories.src",
+    ]);
+  });
+
+  test("non-workspace projects check tsconfig and src", async () => {
+    const { runDoctor } = await import("../commands/doctor.js");
+
+    const packageJson = {
+      name: "my-app",
+      version: "1.0.0",
+    };
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify(packageJson, null, 2)
+    );
+
+    const result = runDoctor({ cwd: tempDir });
+
+    // Non-workspace: bun, package.json, deps, tsconfig, src checked (5 total)
+    expect(result.isWorkspaceRoot).toBeUndefined();
+    expect(result.summary.total).toBe(5);
+  });
+
+  test("null workspaces field is not treated as workspace root", async () => {
+    const { runDoctor } = await import("../commands/doctor.js");
+
+    const packageJson = {
+      name: "my-app",
+      version: "1.0.0",
+      workspaces: null,
+    };
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify(packageJson, null, 2)
+    );
+
+    const result = runDoctor({ cwd: tempDir });
+
+    // workspaces: null should NOT be treated as workspace root
+    expect(result.isWorkspaceRoot).toBeUndefined();
+    expect(result.summary.total).toBe(5);
+  });
+
+  test("workspace root with object-style workspaces field", async () => {
+    const { runDoctor } = await import("../commands/doctor.js");
+
+    // npm workspaces can also be an object with packages key
+    const packageJson = {
+      name: "my-workspace",
+      version: "1.0.0",
+      workspaces: { packages: ["apps/*", "packages/*"] },
+    };
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify(packageJson, null, 2)
+    );
+    mkdirSync(join(tempDir, "node_modules"), { recursive: true });
+
+    const result = runDoctor({ cwd: tempDir });
+
+    expect(result.isWorkspaceRoot).toBe(true);
+    expect(result.summary.total).toBe(3);
+    expect(result.skippedChecks).toEqual([
+      "checks.configFiles.tsconfig",
+      "checks.directories.src",
+    ]);
+  });
+});

--- a/apps/outfitter/src/commands/check.ts
+++ b/apps/outfitter/src/commands/check.ts
@@ -609,5 +609,14 @@ export async function printCheckResults(
     );
   }
 
+  if (result.totalChecked === 0) {
+    lines.push("");
+    lines.push(
+      theme.muted(
+        "No blocks found. If this is a workspace root, run 'outfitter check' from an app or package directory."
+      )
+    );
+  }
+
   await output(lines, { mode: "human" });
 }

--- a/apps/outfitter/src/engine/workspace.ts
+++ b/apps/outfitter/src/engine/workspace.ts
@@ -71,7 +71,7 @@ interface PackageDeps {
   [key: string]: unknown;
 }
 
-function hasWorkspacesField(pkg: PackageDeps): boolean {
+export function hasWorkspacesField(pkg: PackageDeps): boolean {
   const workspaces = pkg.workspaces;
 
   if (Array.isArray(workspaces) && workspaces.length > 0) {


### PR DESCRIPTION
## Summary
- `doctor` previously scored `tsconfig.json` and `src/` as failures at a workspace root, where neither is expected — producing noisy, misleading output
- `doctor` now detects workspace roots via the shared `hasWorkspacesField` helper (exported from `engine/workspace.ts`) and skips those two checks, showing `[SKIP]` with an explanatory note instead; the `DoctorResult` type gains an `isWorkspaceRoot` flag
- `check` now shows a contextual hint when zero blocks are found, guiding the user to run the command from an app or package subdirectory rather than the workspace root
- Added tests for `doctor` covering array workspaces, object-style workspaces, `null` workspaces (must not be treated as workspace root), and non-workspace projects; added a test for `runCheck` confirming that an empty directory returns zero blocks cleanly

## Test plan
- [ ] Run `outfitter doctor` from a workspace root and confirm `tsconfig.json` and `src/` show `[SKIP]`, exit code is 0, and only 3 checks contribute to the score
- [ ] Run `outfitter doctor` from a regular package directory and confirm all 5 checks appear as before
- [ ] Run `outfitter check` from a workspace root with no `.outfitter/` manifest and confirm the hint message is displayed
- [ ] Confirm `workspaces: null` in `package.json` is not treated as a workspace root
- [ ] Run the full `doctor.test.ts` and `check.test.ts` suites green

Closes: OS-241

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)