### PR TITLE
fix(outfitter): fix upgrade package filtering [OS-254]

### DIFF
--- a/apps/outfitter/src/commands/upgrade.ts
+++ b/apps/outfitter/src/commands/upgrade.ts
@@ -878,24 +878,13 @@ export async function runUpgrade(
       : breakingUpgradable.map((a) => a.name);
 
     // Build structured migration guides when --guide is requested
-    let guidesData =
+    const guidesData =
       options.guide === true
         ? buildMigrationGuides(packages, migrationsDir)
         : undefined;
 
-    // Filter guides to specific packages when --guide packages are specified
-    if (
-      guidesData !== undefined &&
-      options.guidePackages !== undefined &&
-      options.guidePackages.length > 0
-    ) {
-      const filterSet = new Set(
-        options.guidePackages.map((p) =>
-          p.startsWith("@") ? p : `@outfitter/${p}`
-        )
-      );
-      guidesData = guidesData.filter((g) => filterSet.has(g.packageName));
-    }
+    // Note: guide filter is unnecessary here — `buildMigrationGuides` already
+    // operates on the filtered `packages` list from the scan filter above.
 
     const buildResult = (
       overrides: Partial<UpgradeResult> = {}


### PR DESCRIPTION
## Summary
- `outfitter upgrade [packages...]` positional arguments previously only filtered the migration guide output (`guidePackages`), leaving the workspace scan and version report unfiltered — running `outfitter upgrade cli` would report on every installed `@outfitter/*` package, not just `@outfitter/cli`
- The scan result is now filtered to only the requested packages before version checks, npm queries, and report generation; bare names are expanded to `@outfitter/<name>` automatically
- Packages named in positional args that are not found in the workspace are collected as `unknownPackages` and surfaced in human output and the `UpgradeReport` JSON, so users get a clear error instead of a silent empty result

## Test plan
- [ ] `outfitter upgrade cli` scans and reports only `@outfitter/cli`, not all packages
- [ ] `outfitter upgrade @outfitter/cli` (fully-qualified) behaves the same
- [ ] `outfitter upgrade nonexistent` prints an "Unknown package(s) not found in workspace" error
- [ ] `outfitter upgrade` with no args continues to scan all packages as before
- [ ] `outfitter upgrade cli --output json` includes `unknownPackages` in JSON output when the package is not found
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-254

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)