### PR TITLE
fix(outfitter): resolve template dependency versions dynamically

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "files": [
     "dist",
-    "templates"
+    "templates",
+    "template-versions.json"
   ],
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -154,6 +155,12 @@
         "default": "./dist/engine/config.js"
       }
     },
+    "./engine/dependency-versions": {
+      "import": {
+        "types": "./dist/engine/dependency-versions.d.ts",
+        "default": "./dist/engine/dependency-versions.js"
+      }
+    },
     "./engine/executor": {
       "import": {
         "types": "./dist/engine/executor.d.ts",
@@ -220,7 +227,9 @@
         "types": "./dist/targets/types.d.ts",
         "default": "./dist/targets/types.js"
       }
-    }
+    },
+    "./template-versions": "./template-versions.json",
+    "./template-versions.json": "./template-versions.json"
   },
   "bin": {
     "outfitter": "./dist/cli.js",

--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -151,7 +151,7 @@ describe("init command file creation", () => {
 
     const packageJsonPath = join(tempDir, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-    expect(packageJson.devDependencies["@outfitter/tooling"]).toBe("^0.2.1");
+    expect(packageJson.devDependencies["@outfitter/tooling"]).toBe("^0.2.4");
     expect(packageJson.scripts["verify:ci"]).toBe(
       "bun run typecheck && bun run check && bun run build && bun run test"
     );
@@ -159,6 +159,7 @@ describe("init command file creation", () => {
     expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.4.0");
     expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.5.1");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.4.0");
+    expect(packageJson.dependencies.commander).toBe("^14.0.2");
     expect(packageJson.dependencies.zod).toBe("^4.3.5");
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
 
@@ -391,7 +392,7 @@ describe("init command local dependency rewriting", () => {
     expect(packageJson.dependencies["@outfitter/cli"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("workspace:*");
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
-    expect(packageJson.dependencies.commander).toBe("^14.0.0");
+    expect(packageJson.dependencies.commander).toBe("^14.0.2");
   });
 });
 

--- a/apps/outfitter/src/__tests__/template-dependency-policy.test.ts
+++ b/apps/outfitter/src/__tests__/template-dependency-policy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import templateVersions from "../../template-versions.json";
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+interface TemplateManifest {
+  readonly internalDependencies: Record<string, string>;
+  readonly externalDependencies: Record<string, string>;
+}
+
+function getTemplatePackageJsonPaths(rootDir: string): readonly string[] {
+  return readdirSync(rootDir)
+    .map((entry) => join(rootDir, entry, "package.json.template"))
+    .filter((path) => existsSync(path))
+    .sort();
+}
+
+describe("template dependency policy", () => {
+  test("all template package.json files use workspace protocol for @outfitter deps and manifest versions for external deps", () => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const packageRoot = join(currentDir, "..", "..");
+    const repoRoot = join(packageRoot, "..", "..");
+    const manifest = templateVersions as TemplateManifest;
+
+    const templateRoots = [
+      join(repoRoot, "templates"),
+      join(packageRoot, "templates"),
+    ] as const;
+
+    for (const templateRoot of templateRoots) {
+      const packageTemplates = getTemplatePackageJsonPaths(templateRoot);
+      for (const templatePath of packageTemplates) {
+        const parsed = JSON.parse(
+          readFileSync(templatePath, "utf-8")
+        ) as Record<string, unknown>;
+
+        for (const section of DEPENDENCY_SECTIONS) {
+          const sectionValue = parsed[section];
+          if (
+            !sectionValue ||
+            typeof sectionValue !== "object" ||
+            Array.isArray(sectionValue)
+          ) {
+            continue;
+          }
+
+          for (const [name, value] of Object.entries(
+            sectionValue as Record<string, unknown>
+          )) {
+            if (name.startsWith("@outfitter/")) {
+              expect(value).toBe("workspace:*");
+            }
+
+            const expectedExternal = manifest.externalDependencies[name];
+            if (expectedExternal) {
+              expect(value).toBe(expectedExternal);
+            }
+          }
+        }
+      }
+    }
+  });
+});

--- a/apps/outfitter/src/commands/shared-deps.ts
+++ b/apps/outfitter/src/commands/shared-deps.ts
@@ -7,20 +7,63 @@
  * @packageDocumentation
  */
 
+import type { ResolvedTemplateDependencyVersions } from "../engine/dependency-versions.js";
+import { resolveTemplateDependencyVersions } from "../engine/dependency-versions.js";
+
+let _dependencyVersions: ResolvedTemplateDependencyVersions | undefined;
+function getDependencyVersions(): ResolvedTemplateDependencyVersions {
+  if (!_dependencyVersions) {
+    _dependencyVersions = resolveTemplateDependencyVersions();
+  }
+  return _dependencyVersions;
+}
+
+function pickVersion(
+  source: Record<string, string>,
+  name: string,
+  fallback: string
+): string {
+  return source[name] ?? fallback;
+}
+
 /**
  * Shared devDependencies injected into all scaffolded projects.
  * Template-specific devDependencies take precedence over these defaults.
  *
  * Keep these in sync with the root package.json versions.
  */
-export const SHARED_DEV_DEPS = {
-  "@biomejs/biome": "^2.3.12",
-  "@outfitter/tooling": "^0.2.1",
-  "@types/bun": "^1.3.7",
-  lefthook: "^2.0.16",
-  typescript: "^5.9.3",
-  ultracite: "^7.1.1",
-} as const;
+export const SHARED_DEV_DEPS: Readonly<Record<string, string>> = {
+  "@biomejs/biome": pickVersion(
+    getDependencyVersions().external,
+    "@biomejs/biome",
+    "^2.3.12"
+  ),
+  "@outfitter/tooling": pickVersion(
+    getDependencyVersions().internal,
+    "@outfitter/tooling",
+    "^0.2.4"
+  ),
+  "@types/bun": pickVersion(
+    getDependencyVersions().external,
+    "@types/bun",
+    "^1.3.7"
+  ),
+  lefthook: pickVersion(
+    getDependencyVersions().external,
+    "lefthook",
+    "^2.0.16"
+  ),
+  typescript: pickVersion(
+    getDependencyVersions().external,
+    "typescript",
+    "^5.9.3"
+  ),
+  ultracite: pickVersion(
+    getDependencyVersions().external,
+    "ultracite",
+    "^7.1.1"
+  ),
+};
 
 /**
  * Shared scripts injected into all scaffolded projects.

--- a/apps/outfitter/src/engine/config.ts
+++ b/apps/outfitter/src/engine/config.ts
@@ -2,6 +2,10 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Result } from "@outfitter/contracts";
 import { SHARED_DEV_DEPS, SHARED_SCRIPTS } from "../commands/shared-deps.js";
+import {
+  applyResolvedDependencyVersions,
+  resolveTemplateDependencyVersions,
+} from "./dependency-versions.js";
 import { ScaffoldError } from "./types.js";
 
 const DEPENDENCY_SECTIONS = [
@@ -22,6 +26,8 @@ export function injectSharedConfig(
   try {
     const content = readFileSync(packageJsonPath, "utf-8");
     const parsed = JSON.parse(content) as Record<string, unknown>;
+    const dependencyVersions = resolveTemplateDependencyVersions();
+    applyResolvedDependencyVersions(parsed, dependencyVersions);
 
     const existingDevDeps =
       (parsed["devDependencies"] as Record<string, unknown>) ?? {};

--- a/apps/outfitter/src/engine/dependency-versions.ts
+++ b/apps/outfitter/src/engine/dependency-versions.ts
@@ -1,0 +1,242 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+export interface TemplateVersionManifest {
+  readonly internalDependencies: Record<string, string>;
+  readonly externalDependencies: Record<string, string>;
+}
+
+export interface ResolvedTemplateDependencyVersions {
+  readonly internal: Record<string, string>;
+  readonly external: Record<string, string>;
+}
+
+let cachedResolvedVersions: ResolvedTemplateDependencyVersions | undefined;
+
+export function clearResolvedVersionsCache(): void {
+  cachedResolvedVersions = undefined;
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeRange(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === "workspace:*") {
+    return undefined;
+  }
+  if (/^\d+\.\d+\.\d+(?:[-+].+)?$/.test(trimmed)) {
+    return `^${trimmed}`;
+  }
+  return trimmed;
+}
+
+function findOutfitterPackageRoot(): string {
+  let currentDir = dirname(fileURLToPath(import.meta.url));
+
+  for (let i = 0; i < 10; i += 1) {
+    const packageJsonPath = join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        const parsed = readJsonFile(packageJsonPath);
+        if (
+          isRecord(parsed) &&
+          typeof parsed["name"] === "string" &&
+          parsed["name"] === "outfitter"
+        ) {
+          return currentDir;
+        }
+      } catch {
+        // Continue walking up.
+      }
+    }
+    currentDir = dirname(currentDir);
+  }
+
+  throw new Error(
+    `Unable to find outfitter package root (walked 10 levels up from ${dirname(fileURLToPath(import.meta.url))}). ` +
+      "Ensure this module is running from within the outfitter package tree."
+  );
+}
+
+function collectDependencyRangesFromPackageJson(
+  packageJson: Record<string, unknown>
+): Record<string, string> {
+  const collected: Record<string, string> = {};
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const sectionValue = packageJson[section];
+    if (!isRecord(sectionValue)) {
+      continue;
+    }
+
+    for (const [name, value] of Object.entries(sectionValue)) {
+      if (typeof value !== "string" || !name.startsWith("@outfitter/")) {
+        continue;
+      }
+      const normalized = normalizeRange(value);
+      if (normalized) {
+        collected[name] = normalized;
+      }
+    }
+  }
+
+  return collected;
+}
+
+function collectWorkspacePackageRanges(
+  packageRoot: string
+): Record<string, string> {
+  const repoRoot = resolve(packageRoot, "..", "..");
+  const expectedPackageRoot = join(repoRoot, "apps", "outfitter");
+  if (resolve(expectedPackageRoot) !== resolve(packageRoot)) {
+    return {};
+  }
+
+  const packagesDir = join(repoRoot, "packages");
+  if (!existsSync(packagesDir)) {
+    return {};
+  }
+
+  const collected: Record<string, string> = {};
+  for (const entry of readdirSync(packagesDir)) {
+    const packageJsonPath = join(packagesDir, entry, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    try {
+      const parsed = readJsonFile(packageJsonPath);
+      if (!isRecord(parsed)) {
+        continue;
+      }
+
+      const name = parsed["name"];
+      const version = parsed["version"];
+      if (
+        typeof name === "string" &&
+        typeof version === "string" &&
+        name.startsWith("@outfitter/")
+      ) {
+        const normalized = normalizeRange(version);
+        if (normalized) {
+          collected[name] = normalized;
+        }
+      }
+    } catch {
+      // Ignore malformed workspace package.json entries.
+    }
+  }
+
+  return collected;
+}
+
+function loadTemplateVersionManifest(
+  packageRoot: string
+): TemplateVersionManifest {
+  const manifestPath = join(packageRoot, "template-versions.json");
+  const parsed = readJsonFile(manifestPath);
+  if (!isRecord(parsed)) {
+    throw new Error("template-versions.json must be a JSON object");
+  }
+
+  const internalDependencies = parsed["internalDependencies"];
+  const externalDependencies = parsed["externalDependencies"];
+  if (!(isRecord(internalDependencies) && isRecord(externalDependencies))) {
+    throw new Error(
+      "template-versions.json must include internalDependencies and externalDependencies objects"
+    );
+  }
+
+  return {
+    internalDependencies: Object.fromEntries(
+      Object.entries(internalDependencies).filter(
+        ([, value]) => typeof value === "string"
+      ) as readonly (readonly [string, string])[]
+    ),
+    externalDependencies: Object.fromEntries(
+      Object.entries(externalDependencies).filter(
+        ([, value]) => typeof value === "string"
+      ) as readonly (readonly [string, string])[]
+    ),
+  };
+}
+
+export function resolveTemplateDependencyVersions(): ResolvedTemplateDependencyVersions {
+  if (cachedResolvedVersions) {
+    return cachedResolvedVersions;
+  }
+
+  const packageRoot = findOutfitterPackageRoot();
+  const manifest = loadTemplateVersionManifest(packageRoot);
+
+  const packageJsonPath = join(packageRoot, "package.json");
+  const raw = existsSync(packageJsonPath)
+    ? readJsonFile(packageJsonPath)
+    : undefined;
+  const fromOutfitterPackage =
+    raw !== undefined && isRecord(raw)
+      ? collectDependencyRangesFromPackageJson(raw)
+      : {};
+  const fromWorkspacePackages = collectWorkspacePackageRanges(packageRoot);
+
+  const internal: Record<string, string> = {};
+  for (const [name, fallbackRange] of Object.entries(
+    manifest.internalDependencies
+  )) {
+    internal[name] =
+      fromOutfitterPackage[name] ??
+      fromWorkspacePackages[name] ??
+      fallbackRange;
+  }
+
+  cachedResolvedVersions = {
+    internal,
+    external: { ...manifest.externalDependencies },
+  };
+  return cachedResolvedVersions;
+}
+
+export function applyResolvedDependencyVersions(
+  parsedPackageJson: Record<string, unknown>,
+  versions: ResolvedTemplateDependencyVersions
+): void {
+  for (const section of DEPENDENCY_SECTIONS) {
+    const sectionValue = parsedPackageJson[section];
+    if (!isRecord(sectionValue)) {
+      continue;
+    }
+
+    for (const [name, value] of Object.entries(sectionValue)) {
+      if (typeof value !== "string") {
+        continue;
+      }
+
+      if (name.startsWith("@outfitter/")) {
+        const resolvedInternal = versions.internal[name];
+        if (resolvedInternal) {
+          sectionValue[name] = resolvedInternal;
+        }
+        continue;
+      }
+
+      const resolvedExternal = versions.external[name];
+      if (resolvedExternal) {
+        sectionValue[name] = resolvedExternal;
+      }
+    }
+  }
+}

--- a/apps/outfitter/template-versions.json
+++ b/apps/outfitter/template-versions.json
@@ -1,0 +1,21 @@
+{
+  "internalDependencies": {
+    "@outfitter/contracts": "^0.4.0",
+    "@outfitter/types": "^0.2.2",
+    "@outfitter/cli": "^0.5.1",
+    "@outfitter/logging": "^0.4.0",
+    "@outfitter/mcp": "^0.4.1",
+    "@outfitter/daemon": "^0.2.3",
+    "@outfitter/tooling": "^0.2.4"
+  },
+  "externalDependencies": {
+    "@biomejs/biome": "^2.3.12",
+    "@types/bun": "^1.3.7",
+    "commander": "^14.0.2",
+    "lefthook": "^2.0.16",
+    "typescript": "^5.9.3",
+    "ultracite": "^7.1.1",
+    "zod": "^4.3.5",
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  }
+}

--- a/apps/outfitter/templates/basic/package.json.template
+++ b/apps/outfitter/templates/basic/package.json.template
@@ -29,9 +29,9 @@
 		"clean": "rm -rf dist"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.0",
-		"@types/bun": "^1.3.0",
-		"typescript": "^5.9.0"
+		"@biomejs/biome": "^2.3.12",
+		"@types/bun": "^1.3.7",
+		"typescript": "^5.9.3"
 	},
 	"engines": {
 		"bun": ">=1.0.0"

--- a/apps/outfitter/templates/cli/package.json.template
+++ b/apps/outfitter/templates/cli/package.json.template
@@ -26,16 +26,16 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@outfitter/contracts": "^0.4.0",
-		"@outfitter/cli": "^0.5.1",
-		"@outfitter/logging": "^0.4.0",
-		"commander": "^14.0.0",
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/cli": "workspace:*",
+		"@outfitter/logging": "workspace:*",
+		"commander": "^14.0.2",
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.0",
-		"@types/bun": "^1.3.0",
-		"typescript": "^5.9.0"
+		"@biomejs/biome": "^2.3.12",
+		"@types/bun": "^1.3.7",
+		"typescript": "^5.9.3"
 	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/daemon/package.json.template
+++ b/apps/outfitter/templates/daemon/package.json.template
@@ -28,17 +28,17 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@outfitter/contracts": "^0.4.0",
-		"@outfitter/types": "^0.2.2",
-		"@outfitter/daemon": "^0.2.3",
-		"@outfitter/cli": "^0.5.1",
-		"@outfitter/logging": "^0.4.0",
-		"commander": "^14.0.0"
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/types": "workspace:*",
+		"@outfitter/daemon": "workspace:*",
+		"@outfitter/cli": "workspace:*",
+		"@outfitter/logging": "workspace:*",
+		"commander": "^14.0.2"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.0",
-		"@types/bun": "^1.3.0",
-		"typescript": "^5.9.0"
+		"@biomejs/biome": "^2.3.12",
+		"@types/bun": "^1.3.7",
+		"typescript": "^5.9.3"
 	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/mcp/package.json.template
+++ b/apps/outfitter/templates/mcp/package.json.template
@@ -26,15 +26,15 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@outfitter/contracts": "^0.4.0",
-		"@outfitter/mcp": "^0.4.1",
-		"@outfitter/logging": "^0.4.0",
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/mcp": "workspace:*",
+		"@outfitter/logging": "workspace:*",
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.0",
-		"@types/bun": "^1.3.0",
-		"typescript": "^5.9.0"
+		"@biomejs/biome": "^2.3.12",
+		"@types/bun": "^1.3.7",
+		"typescript": "^5.9.3"
 	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/minimal/package.json.template
+++ b/apps/outfitter/templates/minimal/package.json.template
@@ -29,9 +29,9 @@
 		"clean": "rm -rf dist"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.0",
-		"@types/bun": "^1.3.0",
-		"typescript": "^5.9.0"
+		"@biomejs/biome": "^2.3.12",
+		"@types/bun": "^1.3.7",
+		"typescript": "^5.9.3"
 	},
 	"engines": {
 		"bun": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   ],
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
-    "verify:ci": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run docs:check:ci && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations && bun run test",
+    "verify:ci": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run check-template-dependency-versions && bun run docs:check:ci && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations && bun run test",
     "check-changeset": "bun run apps/outfitter/src/commands/repo.ts check changeset --cwd .",
     "check-publish-guardrails": "bun run scripts/check-publish-guardrails.ts",
     "check-bunup-registry": "bun run apps/outfitter/src/commands/repo.ts check registry --cwd .",
+    "check-template-dependency-versions": "bun run scripts/check-template-dependency-versions.ts",
     "check-exports": "bun run apps/outfitter/src/commands/repo.ts check exports --cwd .",
     "check-readme-imports": "bun run apps/outfitter/src/commands/repo.ts check readme --cwd .",
     "check-clean-tree": "bun run apps/outfitter/src/commands/repo.ts check tree --cwd .",

--- a/scripts/check-template-dependency-versions.ts
+++ b/scripts/check-template-dependency-versions.ts
@@ -1,0 +1,113 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface TemplateVersionManifest {
+  readonly internalDependencies: Record<string, string>;
+  readonly externalDependencies: Record<string, string>;
+}
+
+const DEPENDENCY_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function loadManifest(): TemplateVersionManifest {
+  const raw: unknown = JSON.parse(
+    readFileSync("apps/outfitter/template-versions.json", "utf-8")
+  );
+  if (!isRecord(raw)) {
+    throw new Error("template-versions.json must be a JSON object");
+  }
+
+  const internalDependencies = raw["internalDependencies"];
+  const externalDependencies = raw["externalDependencies"];
+
+  return {
+    internalDependencies: isRecord(internalDependencies)
+      ? Object.fromEntries(
+          Object.entries(internalDependencies).filter(
+            ([, v]) => typeof v === "string"
+          )
+        )
+      : {},
+    externalDependencies: isRecord(externalDependencies)
+      ? Object.fromEntries(
+          Object.entries(externalDependencies).filter(
+            ([, v]) => typeof v === "string"
+          )
+        )
+      : {},
+  };
+}
+
+function getTemplatePackageJsonPaths(rootDir: string): readonly string[] {
+  return readdirSync(rootDir)
+    .map((entry) => join(rootDir, entry, "package.json.template"))
+    .filter((path) => existsSync(path))
+    .sort();
+}
+
+function main(): number {
+  const manifest = loadManifest();
+  const internal = new Set(Object.keys(manifest.internalDependencies));
+  const external = manifest.externalDependencies;
+
+  const templateRoots = ["templates", "apps/outfitter/templates"] as const;
+  const problems: string[] = [];
+
+  for (const templateRoot of templateRoots) {
+    for (const templatePath of getTemplatePackageJsonPaths(templateRoot)) {
+      const parsed: unknown = JSON.parse(readFileSync(templatePath, "utf-8"));
+      if (!isRecord(parsed)) {
+        continue;
+      }
+
+      for (const section of DEPENDENCY_SECTIONS) {
+        const sectionValue = parsed[section];
+        if (!isRecord(sectionValue)) {
+          continue;
+        }
+
+        for (const [name, value] of Object.entries(sectionValue)) {
+          if (typeof value !== "string") {
+            continue;
+          }
+
+          if (internal.has(name) && value !== "workspace:*") {
+            problems.push(
+              `${templatePath}: ${name} must use workspace:* in templates (found ${value})`
+            );
+          }
+
+          const expectedExternal = external[name];
+          if (expectedExternal && value !== expectedExternal) {
+            problems.push(
+              `${templatePath}: ${name} expected ${expectedExternal} (found ${value})`
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    process.stderr.write(
+      `Template dependency version drift detected (${problems.length} issue(s)):\n`
+    );
+    for (const problem of problems) {
+      process.stderr.write(`- ${problem}\n`);
+    }
+    return 1;
+  }
+
+  process.stdout.write("Template dependency versions are in sync.\n");
+  return 0;
+}
+
+process.exit(main());

--- a/templates/basic/package.json.template
+++ b/templates/basic/package.json.template
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.12",
-		"@outfitter/tooling": "^0.2.1",
+		"@outfitter/tooling": "workspace:*",
 		"@types/bun": "^1.3.7",
 		"lefthook": "^2.0.16",
 		"typescript": "^5.9.3",

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -28,15 +28,15 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@outfitter/contracts": "^0.2.0",
-		"@outfitter/types": "^0.2.0",
-		"@outfitter/cli": "^0.4.0",
-		"@outfitter/logging": "^0.1.0-rc.0",
-		"commander": "^12.0.0"
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/types": "workspace:*",
+		"@outfitter/cli": "workspace:*",
+		"@outfitter/logging": "workspace:*",
+		"commander": "^14.0.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.12",
-		"@outfitter/tooling": "^0.2.1",
+		"@outfitter/tooling": "workspace:*",
 		"@types/bun": "^1.3.7",
 		"lefthook": "^2.0.16",
 		"typescript": "^5.9.3",

--- a/templates/daemon/package.json.template
+++ b/templates/daemon/package.json.template
@@ -30,16 +30,16 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@outfitter/contracts": "^0.2.0",
-		"@outfitter/types": "^0.2.0",
-		"@outfitter/daemon": "^0.1.0-rc.0",
-		"@outfitter/cli": "^0.1.0-rc.0",
-		"@outfitter/logging": "^0.1.0-rc.0",
-		"commander": "^12.0.0"
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/types": "workspace:*",
+		"@outfitter/daemon": "workspace:*",
+		"@outfitter/cli": "workspace:*",
+		"@outfitter/logging": "workspace:*",
+		"commander": "^14.0.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.12",
-		"@outfitter/tooling": "^0.2.1",
+		"@outfitter/tooling": "workspace:*",
 		"@types/bun": "^1.3.7",
 		"lefthook": "^2.0.16",
 		"typescript": "^5.9.3",

--- a/templates/mcp/package.json.template
+++ b/templates/mcp/package.json.template
@@ -28,15 +28,15 @@
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.0.0",
-		"@outfitter/contracts": "^0.2.0",
-		"@outfitter/types": "^0.2.0",
-		"@outfitter/mcp": "^0.1.0-rc.0",
-		"@outfitter/logging": "^0.1.0-rc.0"
+		"@modelcontextprotocol/sdk": "^1.12.1",
+		"@outfitter/contracts": "workspace:*",
+		"@outfitter/types": "workspace:*",
+		"@outfitter/mcp": "workspace:*",
+		"@outfitter/logging": "workspace:*"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.12",
-		"@outfitter/tooling": "^0.2.1",
+		"@outfitter/tooling": "workspace:*",
 		"@types/bun": "^1.3.7",
 		"lefthook": "^2.0.16",
 		"typescript": "^5.9.3",

--- a/templates/minimal/package.json.template
+++ b/templates/minimal/package.json.template
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.12",
-		"@outfitter/tooling": "^0.2.1",
+		"@outfitter/tooling": "workspace:*",
 		"@types/bun": "^1.3.7",
 		"lefthook": "^2.0.16",
 		"typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- Replaced hard-coded scaffold dependency versions with a runtime resolver backed by `apps/outfitter/template-versions.json`, so template dependency pins come from one source of truth
- Wired template version resolution into scaffold/template generation paths and added policy coverage to prevent template dependency drift from reappearing
- Added export and post-build normalization fixes so `template-versions.json` and its short alias stay present in `apps/outfitter/package.json` exports after `bunup`, keeping `check-exports` and clean-tree verification stable

## Test plan
- [ ] Run `bun test apps/outfitter/src/__tests__/template-dependency-policy.test.ts` — template dependency policy passes
- [ ] Run `bun test apps/outfitter/src/__tests__/scaffold.test.ts` — scaffolded templates use resolved dependency versions
- [ ] Run `bun run check-template-dependency-versions` — no drift reported
- [ ] Run `bun run check-exports` — `outfitter` exports are in sync (including `template-versions` aliases)
- [ ] Run `bun run build` followed by `bun run apps/outfitter/src/commands/repo.ts check tree --cwd .` — tree remains clean
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-257

🤘🏻 In-collaboration-with: [Codex](https://openai.com)
