### PR TITLE
test(outfitter): add env-gated scaffold e2e verification

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -241,6 +241,7 @@
     "postbuild": "bun link",
     "dev": "bun run src/cli.ts",
     "test": "bun test",
+    "test:scaffold-e2e": "OUTFITTER_RUN_SCAFFOLD_E2E=1 bun test ./src/__tests__/scaffold-e2e.test.ts",
     "test:watch": "bun test --watch",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",

--- a/apps/outfitter/src/__tests__/scaffold-e2e.test.ts
+++ b/apps/outfitter/src/__tests__/scaffold-e2e.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Optional scaffold end-to-end tests.
+ *
+ * These tests execute real installs and test runs in generated projects.
+ * Enable with OUTFITTER_RUN_SCAFFOLD_E2E=1.
+ *
+ * @packageDocumentation
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInit } from "../commands/init.js";
+
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+const SCAFFOLD_E2E_ENABLED = process.env["OUTFITTER_RUN_SCAFFOLD_E2E"] === "1";
+
+function createTempDir(): string {
+  const dir = join(
+    tmpdir(),
+    `outfitter-scaffold-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupTempDir(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function runCommand(
+  cwd: string,
+  command: readonly string[],
+  timeoutMs = 180_000
+): Promise<CommandResult> {
+  const proc = Bun.spawn(command, {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const timeout = new Promise<"timeout">((resolveTimeout) => {
+    const timer = setTimeout(() => resolveTimeout("timeout"), timeoutMs);
+    proc.exited.finally(() => clearTimeout(timer));
+  });
+
+  const race = await Promise.race([proc.exited.then(() => "exit"), timeout]);
+  if (race === "timeout") {
+    proc.kill();
+  }
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    timedOut: race === "timeout",
+  };
+}
+
+function assertCommandSuccess(
+  preset: string,
+  step: string,
+  result: CommandResult
+): void {
+  if (result.timedOut) {
+    throw new Error(
+      `[${preset}] ${step} timed out.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `[${preset}] ${step} failed with exit code ${result.exitCode}.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = createTempDir();
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+
+describe("scaffold e2e verification", () => {
+  if (!SCAFFOLD_E2E_ENABLED) {
+    test("is disabled unless OUTFITTER_RUN_SCAFFOLD_E2E=1", () => {
+      expect(SCAFFOLD_E2E_ENABLED).toBe(false);
+    });
+    return;
+  }
+
+  test(
+    "scaffolds each supported preset and runs generated tests",
+    async () => {
+      const presets = ["minimal", "basic", "cli", "mcp", "daemon"] as const;
+
+      for (const preset of presets) {
+        const targetDir = join(tempDir, preset);
+        const name = `scaffold-e2e-${preset}`;
+        const initBase = {
+          targetDir,
+          name,
+          force: false,
+          yes: true,
+          skipInstall: true,
+          skipGit: true,
+          skipCommit: true,
+          noTooling: true,
+        } as const;
+
+        const result = await runInit({ ...initBase, preset });
+
+        if (result.isErr()) {
+          throw new Error(
+            `[${preset}] init failed: ${result.error.message ?? "unknown error"}`
+          );
+        }
+
+        const install = await runCommand(targetDir, ["bun", "install"]);
+        assertCommandSuccess(preset, "bun install", install);
+
+        const tests = await runCommand(targetDir, ["bun", "test"]);
+        assertCommandSuccess(preset, "bun test", tests);
+      }
+    },
+    { timeout: 600_000 }
+  );
+});


### PR DESCRIPTION
## Summary
- Added an end-to-end scaffold verification test (`scaffold-e2e.test.ts`) for generated projects
- Gated the test behind `OUTFITTER_RUN_SCAFFOLD_E2E=1` so default local/CI test runs stay fast and deterministic
- The e2e path exercises real scaffold output and runs generated project tests to catch integration regressions not visible in unit tests

## Test plan
- [ ] Run `bun test apps/outfitter/src/__tests__/scaffold-e2e.test.ts` with no env var — test is skipped/disabled by default
- [ ] Run `OUTFITTER_RUN_SCAFFOLD_E2E=1 bun test apps/outfitter/src/__tests__/scaffold-e2e.test.ts` — scaffold e2e flow executes and passes
- [ ] Confirm generated project `bun test` step succeeds during the e2e run
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-260

🤘🏻 In-collaboration-with: [Codex](https://openai.com)
