### PR TITLE
test(outfitter): run scaffold e2e build step

### DIFF
--- a/apps/outfitter/src/__tests__/scaffold-e2e.test.ts
+++ b/apps/outfitter/src/__tests__/scaffold-e2e.test.ts
@@ -108,7 +108,7 @@ describe("scaffold e2e verification", () => {
   }
 
   test(
-    "scaffolds each supported preset and runs generated tests",
+    "scaffolds each supported preset and runs generated build + tests",
     async () => {
       const presets = ["minimal", "basic", "cli", "mcp", "daemon"] as const;
 
@@ -136,6 +136,9 @@ describe("scaffold e2e verification", () => {
 
         const install = await runCommand(targetDir, ["bun", "install"]);
         assertCommandSuccess(preset, "bun install", install);
+
+        const build = await runCommand(targetDir, ["bun", "run", "build"]);
+        assertCommandSuccess(preset, "bun run build", build);
 
         const tests = await runCommand(targetDir, ["bun", "test"]);
         assertCommandSuccess(preset, "bun test", tests);


### PR DESCRIPTION
## Summary
- Extended the scaffold e2e verification flow to include a real build check (`bun run build`) for generated projects
- Ensures scaffolded output is not only testable but also compilable/buildable in a clean install path
- Keeps the same env-gated execution model so deeper e2e checks remain opt-in

## Test plan
- [ ] Run `OUTFITTER_RUN_SCAFFOLD_E2E=1 bun test apps/outfitter/src/__tests__/scaffold-e2e.test.ts`
- [ ] Verify the e2e flow runs `bun install`, `bun run build`, and `bun test` on the scaffolded project
- [ ] Confirm the command exits successfully with all scaffold verification steps passing
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-262

🤘🏻 In-collaboration-with: [Codex](https://openai.com)
