### PR TITLE
feat(outfitter): add template metadata for kind detection [OS-258]

### DIFF
--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -162,6 +162,9 @@ describe("init command file creation", () => {
     expect(packageJson.dependencies.commander).toBe("^14.0.2");
     expect(packageJson.dependencies.zod).toBe("^4.3.5");
     expect(packageJson.dependencies["@outfitter/config"]).toBeUndefined();
+    expect(packageJson.outfitter.template.kind).toBe("runnable");
+    expect(packageJson.outfitter.template.placement).toBe("apps");
+    expect(packageJson.outfitter.template.surfaces).toEqual(["cli"]);
 
     const tsconfigPath = join(tempDir, "tsconfig.json");
     const tsconfig = JSON.parse(readFileSync(tsconfigPath, "utf-8"));
@@ -205,6 +208,9 @@ describe("init command file creation", () => {
     expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.4.0");
     expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.4.0");
     expect(packageJson.dependencies.zod).toBe("^4.3.5");
+    expect(packageJson.outfitter.template.kind).toBe("library");
+    expect(packageJson.outfitter.template.placement).toBe("packages");
+    expect(packageJson.outfitter.template.surfaces).toEqual([]);
 
     const indexPath = join(tempDir, "src", "index.ts");
     const indexContent = readFileSync(indexPath, "utf-8");

--- a/apps/outfitter/templates/cli/package.json.template
+++ b/apps/outfitter/templates/cli/package.json.template
@@ -37,5 +37,12 @@
 		"@types/bun": "^1.3.7",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["cli"]
+		}
+	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/daemon/package.json.template
+++ b/apps/outfitter/templates/daemon/package.json.template
@@ -40,5 +40,12 @@
 		"@types/bun": "^1.3.7",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["cli", "daemon"]
+		}
+	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/library/package.json.template
+++ b/apps/outfitter/templates/library/package.json.template
@@ -40,6 +40,13 @@
 		"bunup": "^0.16.20",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "library",
+			"placement": "packages",
+			"surfaces": []
+		}
+	},
 	"engines": {
 		"bun": ">=1.3.7"
 	},

--- a/apps/outfitter/templates/mcp/package.json.template
+++ b/apps/outfitter/templates/mcp/package.json.template
@@ -36,5 +36,12 @@
 		"@types/bun": "^1.3.7",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["mcp"]
+		}
+	},
 	"license": "MIT"
 }

--- a/apps/outfitter/templates/minimal/package.json.template
+++ b/apps/outfitter/templates/minimal/package.json.template
@@ -33,6 +33,13 @@
 		"@types/bun": "^1.3.7",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "library",
+			"placement": "packages",
+			"surfaces": []
+		}
+	},
 	"engines": {
 		"bun": ">=1.0.0"
 	},

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -42,5 +42,12 @@
 		"typescript": "^5.9.3",
 		"ultracite": "^7.1.1"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["cli"]
+		}
+	},
 	"license": "MIT"
 }

--- a/templates/daemon/package.json.template
+++ b/templates/daemon/package.json.template
@@ -45,5 +45,12 @@
 		"typescript": "^5.9.3",
 		"ultracite": "^7.1.1"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["cli", "daemon"]
+		}
+	},
 	"license": "MIT"
 }

--- a/templates/library/package.json.template
+++ b/templates/library/package.json.template
@@ -40,6 +40,13 @@
 		"bunup": "^0.16.20",
 		"typescript": "^5.9.3"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "library",
+			"placement": "packages",
+			"surfaces": []
+		}
+	},
 	"engines": {
 		"bun": ">=1.3.7"
 	},

--- a/templates/mcp/package.json.template
+++ b/templates/mcp/package.json.template
@@ -42,5 +42,12 @@
 		"typescript": "^5.9.3",
 		"ultracite": "^7.1.1"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "runnable",
+			"placement": "apps",
+			"surfaces": ["mcp"]
+		}
+	},
 	"license": "MIT"
 }

--- a/templates/minimal/package.json.template
+++ b/templates/minimal/package.json.template
@@ -38,6 +38,13 @@
 		"typescript": "^5.9.3",
 		"ultracite": "^7.1.1"
 	},
+	"outfitter": {
+		"template": {
+			"kind": "library",
+			"placement": "packages",
+			"surfaces": []
+		}
+	},
 	"engines": {
 		"bun": ">=1.3.7"
 	},


### PR DESCRIPTION
## Summary
- Added explicit template metadata (`kind`/surface classification) to scaffold target definitions so project type detection is declaration-driven
- Updated scaffold conversion logic to use metadata-first classification with fallback heuristics when metadata is missing/invalid
- Added/updated tests around target registry metadata and scaffold conversion behavior

## Test plan
- [ ] Run `bun test apps/outfitter/src/targets/__tests__/registry.test.ts` — metadata wiring validates
- [ ] Run `bun test apps/outfitter/src/__tests__/scaffold.test.ts` — metadata-first classification path passes
- [ ] Verify invalid metadata falls back to legacy heuristics without regression
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-258

🤘🏻 In-collaboration-with: [Codex](https://openai.com)
