### PR TITLE
refactor(outfitter): remove unused doctor detail fields [OS-266]

### DIFF
--- a/apps/outfitter/src/__tests__/doctor.test.ts
+++ b/apps/outfitter/src/__tests__/doctor.test.ts
@@ -369,6 +369,20 @@ describe("doctor command result structure", () => {
     expect(result.checks).toHaveProperty("directories");
   });
 
+  test("omits non-scored config and directory detail fields", async () => {
+    const { runDoctor } = await import("../commands/doctor.js");
+
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({ name: "my-app", version: "1.0.0" }, null, 2)
+    );
+
+    const result = runDoctor({ cwd: tempDir });
+
+    expect(result.checks.configFiles).not.toHaveProperty("biome");
+    expect(result.checks.directories).not.toHaveProperty("tests");
+  });
+
   test("reads target package.json at most once per run", async () => {
     const fs = await import("node:fs");
     const { runDoctor } = await import("../commands/doctor.js");

--- a/apps/outfitter/src/commands/doctor.ts
+++ b/apps/outfitter/src/commands/doctor.ts
@@ -75,8 +75,6 @@ export interface DependenciesCheck extends CheckResult {
 export interface ConfigFilesCheck {
   /** Whether tsconfig.json exists */
   readonly tsconfig: boolean;
-  /** Whether biome.json exists */
-  readonly biome?: boolean;
 }
 
 /**
@@ -85,8 +83,6 @@ export interface ConfigFilesCheck {
 export interface DirectoriesCheck {
   /** Whether src directory exists */
   readonly src: boolean;
-  /** Whether tests directory exists */
-  readonly tests?: boolean;
 }
 
 /**
@@ -336,7 +332,6 @@ function checkDependencies(
 function checkConfigFiles(cwd: string): ConfigFilesCheck {
   return {
     tsconfig: existsSync(join(cwd, "tsconfig.json")),
-    biome: existsSync(join(cwd, "biome.json")),
   };
 }
 
@@ -346,9 +341,6 @@ function checkConfigFiles(cwd: string): ConfigFilesCheck {
 function checkDirectories(cwd: string): DirectoriesCheck {
   return {
     src: existsSync(join(cwd, "src")),
-    tests:
-      existsSync(join(cwd, "src", "__tests__")) ||
-      existsSync(join(cwd, "tests")),
   };
 }
 


### PR DESCRIPTION
## Summary
- Removed dead/unused doctor detail fields that were computed but not surfaced (`configFiles.biome`, `directories.tests`)
- Simplified doctor result/detail internals to only retain fields with user-visible or contract value
- Updated tests to assert these removed fields are no longer present

## Test plan
- [ ] Run `bun test apps/outfitter/src/__tests__/doctor.test.ts` — doctor contract and output tests pass
- [ ] Verify doctor output remains unchanged for end users except removal of non-surfaced internal detail fields
- [ ] Run `bun run typecheck` — no type errors

Closes: OS-266

🤘🏻 In-collaboration-with: [Codex](https://openai.com)
