### PR TITLE
fix(changesets): remove @outfitter/agents from mixed changesets

### DIFF
--- a/.changeset/decouple-bootstrap-graphite.md
+++ b/.changeset/decouple-bootstrap-graphite.md
@@ -1,5 +1,4 @@
 ---
-"@outfitter/agents": patch
 "@outfitter/tooling": patch
 ---
 

--- a/.changeset/update-deps-biome-formatting.md
+++ b/.changeset/update-deps-biome-formatting.md
@@ -1,5 +1,4 @@
 ---
-"@outfitter/agents": patch
 "@outfitter/cli": patch
 "@outfitter/config": patch
 "@outfitter/contracts": patch


### PR DESCRIPTION
## Summary

- Remove `@outfitter/agents` from two changesets that mixed ignored and non-ignored packages
- `@outfitter/agents` is deprecated and in the changeset `ignore` list, but two changesets still referenced it alongside non-ignored packages
- This caused the release workflow to fail with "Mixed changesets that contain both ignored and not ignored packages are not allowed"

## Test plan

- [x] `bun run verify:ci` passes (pre-push)
- [x] Release workflow should now succeed on merge

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)