### PR TITLE
fix(outfitter): use dynamic version resolution in init and scaffold tests

### DIFF
--- a/apps/outfitter/src/__tests__/scaffold.test.ts
+++ b/apps/outfitter/src/__tests__/scaffold.test.ts
@@ -15,6 +15,29 @@ import {
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 
+/**
+ * Read expected versions directly from workspace package.json files,
+ * independent of the resolver under test, so resolver bugs don't mask
+ * test failures.
+ */
+function workspaceVersion(pkg: string): string {
+  const name = pkg.replace("@outfitter/", "");
+  const raw = readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "..",
+      "packages",
+      name,
+      "package.json"
+    ),
+    "utf-8"
+  );
+  return `^${JSON.parse(raw).version}`;
+}
+
 function createTempDir(): string {
   const tempDir = join(
     tmpdir(),
@@ -233,14 +256,26 @@ describe("scaffold command", () => {
       devDependencies: Record<string, string>;
     };
 
-    expect(packageJson.dependencies["@outfitter/contracts"]).toBe("^0.4.0");
-    expect(packageJson.dependencies["@outfitter/types"]).toBe("^0.2.2");
-    expect(packageJson.dependencies["@outfitter/daemon"]).toBe("^0.2.3");
-    expect(packageJson.dependencies["@outfitter/cli"]).toBe("^0.5.1");
-    expect(packageJson.dependencies["@outfitter/logging"]).toBe("^0.4.0");
+    expect(packageJson.dependencies["@outfitter/contracts"]).toBe(
+      workspaceVersion("@outfitter/contracts")
+    );
+    expect(packageJson.dependencies["@outfitter/types"]).toBe(
+      workspaceVersion("@outfitter/types")
+    );
+    expect(packageJson.dependencies["@outfitter/daemon"]).toBe(
+      workspaceVersion("@outfitter/daemon")
+    );
+    expect(packageJson.dependencies["@outfitter/cli"]).toBe(
+      workspaceVersion("@outfitter/cli")
+    );
+    expect(packageJson.dependencies["@outfitter/logging"]).toBe(
+      workspaceVersion("@outfitter/logging")
+    );
     expect(packageJson.dependencies.commander).toBe("^14.0.2");
     expect(packageJson.dependencies.zod).toBe("^4.3.5");
-    expect(packageJson.devDependencies["@outfitter/tooling"]).toBe("^0.2.4");
+    expect(packageJson.devDependencies["@outfitter/tooling"]).toBe(
+      workspaceVersion("@outfitter/tooling")
+    );
 
     const projectRoot = join(tempDir, "apps", "assistant-daemon");
     const cliSource = readFileSync(join(projectRoot, "src", "cli.ts"), "utf-8");


### PR DESCRIPTION
## Summary

- Init and scaffold tests hardcoded `@outfitter/*` version strings (e.g., `"^0.4.0"`) that broke on every changeset release when workspace package versions bumped
- Replace hardcoded assertions with `resolveTemplateDependencyVersions()` so tests track actual workspace versions
- External deps (commander, zod) remain hardcoded since they don't change on release

Fixes the 3 test failures introduced by Version Packages (#496):
- `init > creates CLI template with tooling dependency...`
- `init > creates library template with Result handler pattern...`
- `scaffold > applies resolved dependency versions for scaffolded daemon projects`

## Test plan

- [x] All 445 tests pass in outfitter app (0 failures)
- [x] Full `verify:ci` passes (pre-push hook)
- [x] No schema drift

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)