### PR TITLE
feat(monorepo): add Bun workspace catalog to root package.json [OS-295]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -348,6 +348,23 @@
   "trustedDependencies": [
     "@biomejs/biome",
   ],
+  "catalog": {
+    "@biomejs/biome": "2.4.4",
+    "@clack/prompts": "^1.0.1",
+    "@logtape/logtape": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@types/bun": "^1.3.9",
+    "@types/node": "^25.3.0",
+    "better-result": "^2.5.1",
+    "bunup": "^0.16.29",
+    "commander": "^14.0.2",
+    "lefthook": "^2.1.1",
+    "smol-toml": "^1.6.0",
+    "typescript": "^5.9.3",
+    "ultracite": "7.2.3",
+    "yaml": "^2.8.2",
+    "zod": "^4.3.5",
+  },
   "packages": {
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,23 @@
     "node": ">=24.0.0",
     "bun": ">=1.3.9"
   },
+  "catalog": {
+    "@biomejs/biome": "2.4.4",
+    "@clack/prompts": "^1.0.1",
+    "@logtape/logtape": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@types/bun": "^1.3.9",
+    "@types/node": "^25.3.0",
+    "better-result": "^2.5.1",
+    "bunup": "^0.16.29",
+    "commander": "^14.0.2",
+    "lefthook": "^2.1.1",
+    "smol-toml": "^1.6.0",
+    "typescript": "^5.9.3",
+    "ultracite": "7.2.3",
+    "yaml": "^2.8.2",
+    "zod": "^4.3.5"
+  },
   "trustedDependencies": [
     "@biomejs/biome"
   ],


### PR DESCRIPTION
## Summary

- Add `catalog` field to root `package.json` with shared dependency versions
- Catalog entries for all blessed dependencies: zod, commander, better-result, logtape, biome, etc.
- Enables `catalog:` protocol for single-source version management across workspace packages

Part of: https://linear.app/outfitter/project/version-sync-bun-catalogs-outfitterpresets-af1550ca03ce

## Test plan

- [x] `bun install` resolves all catalog references
- [x] All tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)