### PR TITLE
chore(templates): strip shared devDep versions from template files [OS-302]

### DIFF
--- a/packages/presets/presets/basic/package.json.template
+++ b/packages/presets/presets/basic/package.json.template
@@ -30,14 +30,7 @@
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"engines": {
 		"bun": ">=1.3.9"
 	},

--- a/packages/presets/presets/cli/package.json.template
+++ b/packages/presets/presets/cli/package.json.template
@@ -34,14 +34,7 @@
 		"@outfitter/logging": "workspace:*",
 		"commander": "^14.0.2"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/packages/presets/presets/daemon/package.json.template
+++ b/packages/presets/presets/daemon/package.json.template
@@ -37,14 +37,7 @@
 		"@outfitter/logging": "workspace:*",
 		"commander": "^14.0.2"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/packages/presets/presets/full-stack/apps/cli/package.json.template
+++ b/packages/presets/presets/full-stack/apps/cli/package.json.template
@@ -30,10 +30,6 @@
 		"@outfitter/cli": "workspace:*",
 		"@outfitter/contracts": "workspace:*"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/packages/presets/presets/full-stack/apps/mcp/package.json.template
+++ b/packages/presets/presets/full-stack/apps/mcp/package.json.template
@@ -31,10 +31,6 @@
 		"@outfitter/mcp": "workspace:*",
 		"zod": "^4.3.5"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/packages/presets/presets/full-stack/packages/core/package.json.template
+++ b/packages/presets/presets/full-stack/packages/core/package.json.template
@@ -27,10 +27,6 @@
 		"@outfitter/logging": "workspace:*",
 		"zod": "^4.3.5"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/packages/presets/presets/library/package.json.template
+++ b/packages/presets/presets/library/package.json.template
@@ -35,10 +35,7 @@
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"bunup": "^0.16.29",
-		"typescript": "^5.9.3"
+		"bunup": "^0.16.29"
 	},
 	"outfitter": {
 		"template": {

--- a/packages/presets/presets/mcp/package.json.template
+++ b/packages/presets/presets/mcp/package.json.template
@@ -34,14 +34,7 @@
 		"@outfitter/mcp": "workspace:*",
 		"@outfitter/logging": "workspace:*"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/packages/presets/presets/minimal/package.json.template
+++ b/packages/presets/presets/minimal/package.json.template
@@ -30,14 +30,7 @@
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "library",

--- a/templates/basic/package.json.template
+++ b/templates/basic/package.json.template
@@ -30,14 +30,7 @@
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"engines": {
 		"bun": ">=1.3.9"
 	},

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -34,14 +34,7 @@
 		"@outfitter/logging": "workspace:*",
 		"commander": "^14.0.2"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/templates/daemon/package.json.template
+++ b/templates/daemon/package.json.template
@@ -37,14 +37,7 @@
 		"@outfitter/logging": "workspace:*",
 		"commander": "^14.0.2"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/templates/full-stack/apps/cli/package.json.template
+++ b/templates/full-stack/apps/cli/package.json.template
@@ -30,10 +30,6 @@
 		"@outfitter/cli": "workspace:*",
 		"@outfitter/contracts": "workspace:*"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/templates/full-stack/apps/mcp/package.json.template
+++ b/templates/full-stack/apps/mcp/package.json.template
@@ -31,10 +31,6 @@
 		"@outfitter/mcp": "workspace:*",
 		"zod": "^4.3.5"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/templates/full-stack/packages/core/package.json.template
+++ b/templates/full-stack/packages/core/package.json.template
@@ -27,10 +27,6 @@
 		"@outfitter/logging": "workspace:*",
 		"zod": "^4.3.5"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"typescript": "^5.9.3"
-	},
+	"devDependencies": {},
 	"license": "MIT"
 }

--- a/templates/library/package.json.template
+++ b/templates/library/package.json.template
@@ -35,10 +35,7 @@
 		"zod": "^4.3.5"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@types/bun": "^1.3.9",
-		"bunup": "^0.16.29",
-		"typescript": "^5.9.3"
+		"bunup": "^0.16.29"
 	},
 	"outfitter": {
 		"template": {

--- a/templates/mcp/package.json.template
+++ b/templates/mcp/package.json.template
@@ -34,14 +34,7 @@
 		"@outfitter/mcp": "workspace:*",
 		"@outfitter/logging": "workspace:*"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "runnable",

--- a/templates/minimal/package.json.template
+++ b/templates/minimal/package.json.template
@@ -30,14 +30,7 @@
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.4",
-		"@outfitter/tooling": "workspace:*",
-		"@types/bun": "^1.3.9",
-		"lefthook": "^2.1.1",
-		"typescript": "^5.9.3",
-		"ultracite": "^7.2.3"
-	},
+	"devDependencies": {},
 	"outfitter": {
 		"template": {
 			"kind": "library",


### PR DESCRIPTION
## Summary

- Remove hardcoded shared dependency versions from preset `package.json` template files
- Versions are now injected at scaffold time by the engine reading from `@outfitter/presets`
- Template files only retain `@outfitter/*` dependencies (resolved via `workspace:*`/latest at install time)

Part of: https://linear.app/outfitter/project/version-sync-bun-catalogs-outfitterpresets-af1550ca03ce

## Test plan

- [x] Scaffolded projects still get correct versions
- [x] Template files contain no hardcoded shared dep versions
- [x] All tests pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)