### PR TITLE
feat(release): add canary release workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,73 @@
+name: Canary Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".changeset/*.md"
+
+concurrency:
+  group: canary-release
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Publish Canary
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for changesets
+        id: check
+        run: |
+          COUNT=$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No changesets found, skipping canary release"
+          else
+            echo "Found $COUNT changeset(s)"
+          fi
+
+      - name: Setup Bun
+        if: steps.check.outputs.count != '0'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        if: steps.check.outputs.count != '0'
+        run: bun install --frozen-lockfile
+
+      - name: Setup Node (for npm OIDC publish)
+        if: steps.check.outputs.count != '0'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for OIDC support
+        if: steps.check.outputs.count != '0'
+        run: npm install -g npm@latest
+
+      # OIDC handles npm auth by default (id-token: write).
+      # To use token-based auth instead, add NPM_TOKEN to the npm-publish environment.
+      - name: Set npm auth token (if not using OIDC)
+        if: steps.check.outputs.count != '0'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "NODE_AUTH_TOKEN=$NPM_TOKEN" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish canary
+        if: steps.check.outputs.count != '0'
+        run: bun run release:canary
+        env:
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

New workflow that publishes snapshot versions to `@canary` npm tag on every push to `main` that includes changeset files.

- Triggers on `push` to `main` with path filter `.changeset/*.md`
- Runs `changeset version --snapshot canary` for ephemeral version bumps (not committed)
- Publishes to `@canary` npm tag with OIDC provenance
- Concurrency group prevents parallel canary publishes
- No-op when no changesets exist

## Linear

https://linear.app/outfitter/issue/OS-318

## Test plan

- [ ] Merge a PR with a changeset to main → canary versions published
- [ ] Merge a PR without a changeset → workflow doesn't trigger
- [ ] `npm install @outfitter/cli@canary` gets snapshot version

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automated canary release workflow that publishes snapshot versions tagged `@canary` to npm whenever changesets are merged to main. The workflow implements dual auth (OIDC primary, token fallback), includes changeset detection to prevent no-op runs, and uses concurrency controls to prevent parallel publishes. The implementation follows the existing release workflow pattern with appropriate permissions for OIDC provenance.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The workflow follows established patterns from the existing release workflow, implements proper authentication (OIDC with token fallback), includes appropriate safeguards (changeset detection, concurrency controls), and aligns with the documented release strategy in package.json
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/canary.yml | Adds GitHub Actions workflow that publishes snapshot versions to `@canary` npm tag on pushes to main containing changesets |

</details>


</details>


<sub>Last reviewed commit: 0600852</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->