### PR TITLE
fix(docs): reconcile release docs with current package inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ bunx @outfitter/tooling upgrade-bun        # Upgrade to latest
 
 - `outfitter` — Umbrella CLI for scaffolding
 - `@outfitter/presets` — Scaffold presets and shared dependency versions (catalog-resolved)
+- `@outfitter/docs` — Docs CLI, core assembly primitives, freshness checks, and host adapter
+- `@outfitter/tooling` — Dev tooling presets and CLI workflows (biome, typescript, lefthook, markdownlint)
 - `@outfitter/testing` — Test harnesses for MCP and CLI
 
 **Deprecated**:

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outfitter/docs",
-  "description": "CLI and host command adapter for Outfitter docs workflows",
+  "description": "Docs CLI, core assembly primitives, freshness checks, and host adapter for Outfitter docs workflows",
   "version": "0.1.2",
   "type": "module",
   "files": [

--- a/plugins/outfitter/README.md
+++ b/plugins/outfitter/README.md
@@ -106,8 +106,7 @@ Write handlers once, expose via CLI, MCP, or HTTP.
 | `@outfitter/config` | XDG-compliant config loading with schema validation for Outfitter |
 | `@outfitter/contracts` | Result/Error patterns, error taxonomy, and handler contracts for Outfitter |
 | `@outfitter/daemon` | Daemon lifecycle, IPC, and health checks for Outfitter |
-| `@outfitter/docs` | CLI and host command adapter for Outfitter docs workflows |
-| `@outfitter/docs-core` | Core docs assembly and freshness checks for Outfitter projects |
+| `@outfitter/docs` | Docs CLI, core assembly primitives, freshness checks, and host adapter for Outfitter docs workflows |
 | `@outfitter/file-ops` | Workspace detection, secure path handling, and file locking for Outfitter |
 | `@outfitter/index` | SQLite FTS5 full-text search indexing for Outfitter |
 | `@outfitter/logging` | Structured logging via logtape with redaction support for Outfitter |

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,7 +7,6 @@
     "packages/contracts",
     "packages/daemon",
     "packages/docs",
-    "packages/docs-core",
     "packages/file-ops",
     "packages/index",
     "packages/logging",


### PR DESCRIPTION
## Summary

- Reconciles release/package docs after `@outfitter/docs-core` consolidation into `@outfitter/docs`
- Removes stale `packages/docs-core` references from docs and API-doc generation config
- Aligns `@outfitter/docs` package description with current scope

## Test plan

- [x] Verified no `docs-core` references remain in `typedoc.json`
- [x] Verified package inventory/docs links resolve in updated docs
- [x] Ran repo checks during stack submit (`verify:ci`)

Closes OS-275

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Completes the consolidation of `@outfitter/docs-core` into `@outfitter/docs` by removing stale references and aligning package descriptions.

- Removed `packages/docs-core` from TypeDoc API generation config
- Updated `@outfitter/docs` description across all documentation to reflect expanded scope (core assembly primitives, freshness checks, host adapter)
- Removed duplicate `@outfitter/docs-core` entry from plugin README package table
- Added missing `@outfitter/docs` and `@outfitter/tooling` entries to AGENTS.md tooling tier list

All descriptions are now consistent across AGENTS.md, package.json, and README files. No stale `docs-core` references remain in active configuration or documentation.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation-only changes with no runtime impact
- All changes are documentation updates that remove stale references and align descriptions after package consolidation. No code logic, dependencies, or runtime behavior affected. Changes are consistent and complete.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Added `@outfitter/docs` and `@outfitter/tooling` entries to tooling tier package list |
| packages/docs/package.json | Updated description to reflect expanded scope after docs-core consolidation |
| plugins/outfitter/README.md | Removed `@outfitter/docs-core` row, updated `@outfitter/docs` description to match new scope |
| typedoc.json | Removed `packages/docs-core` from API doc generation entryPoints |

</details>


</details>


<sub>Last reviewed commit: ec9064f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->