### PR TITLE
feat(docs): define docs map schema and doc kind taxonomy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -159,6 +159,7 @@
       "dependencies": {
         "better-result": "catalog:",
         "commander": "catalog:",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,6 +21,12 @@
         "default": "./dist/core/index.js"
       }
     },
+    "./core/docs-map-schema": {
+      "import": {
+        "types": "./dist/core/docs-map-schema.d.ts",
+        "default": "./dist/core/docs-map-schema.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "bin": {
@@ -38,7 +44,8 @@
   },
   "dependencies": {
     "better-result": "catalog:",
-    "commander": "catalog:"
+    "commander": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/docs/src/__tests__/docs-map-schema.test.ts
+++ b/packages/docs/src/__tests__/docs-map-schema.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type DocKind,
+  DocKindSchema,
+  type DocsMap,
+  type DocsMapEntry,
+  DocsMapEntrySchema,
+  DocsMapSchema,
+} from "../core/docs-map-schema.js";
+
+// =============================================================================
+// DocKindSchema
+// =============================================================================
+
+describe("DocKindSchema", () => {
+  it("accepts all expected document kinds", () => {
+    const expectedKinds: readonly string[] = [
+      "readme",
+      "guide",
+      "reference",
+      "architecture",
+      "release",
+      "convention",
+      "deep",
+      "generated",
+    ];
+
+    for (const kind of expectedKinds) {
+      const result = DocKindSchema.safeParse(kind);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid document kinds", () => {
+    const result = DocKindSchema.safeParse("blog");
+    expect(result.success).toBe(false);
+  });
+
+  it("has exactly 8 members", () => {
+    expect(DocKindSchema.options).toHaveLength(8);
+  });
+});
+
+// =============================================================================
+// DocsMapEntrySchema
+// =============================================================================
+
+describe("DocsMapEntrySchema", () => {
+  const validEntry = {
+    id: "cli/README.md",
+    kind: "readme",
+    title: "CLI Package",
+    sourcePath: "packages/cli/README.md",
+    outputPath: "docs/packages/cli/README.md",
+  };
+
+  it("parses a valid entry with required fields only", () => {
+    const result = DocsMapEntrySchema.safeParse(validEntry);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("cli/README.md");
+      expect(result.data.kind).toBe("readme");
+      expect(result.data.tags).toEqual([]);
+    }
+  });
+
+  it("parses a valid entry with all optional fields", () => {
+    const fullEntry = {
+      ...validEntry,
+      package: "@outfitter/cli",
+      tags: ["api", "public"],
+    };
+    const result = DocsMapEntrySchema.safeParse(fullEntry);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.package).toBe("@outfitter/cli");
+      expect(result.data.tags).toEqual(["api", "public"]);
+    }
+  });
+
+  it("defaults tags to an empty array when omitted", () => {
+    const result = DocsMapEntrySchema.safeParse(validEntry);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tags).toEqual([]);
+    }
+  });
+
+  it("rejects an entry missing required id", () => {
+    const { id: _, ...noId } = validEntry;
+    const result = DocsMapEntrySchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry missing required kind", () => {
+    const { kind: _, ...noKind } = validEntry;
+    const result = DocsMapEntrySchema.safeParse(noKind);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry with an invalid kind", () => {
+    const result = DocsMapEntrySchema.safeParse({
+      ...validEntry,
+      kind: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry missing required title", () => {
+    const { title: _, ...noTitle } = validEntry;
+    const result = DocsMapEntrySchema.safeParse(noTitle);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry missing required sourcePath", () => {
+    const { sourcePath: _, ...noSource } = validEntry;
+    const result = DocsMapEntrySchema.safeParse(noSource);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an entry missing required outputPath", () => {
+    const { outputPath: _, ...noOutput } = validEntry;
+    const result = DocsMapEntrySchema.safeParse(noOutput);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// DocsMapSchema
+// =============================================================================
+
+describe("DocsMapSchema", () => {
+  const validMap = {
+    generatedAt: "2026-02-21T12:00:00.000Z",
+    generator: "@outfitter/docs@0.1.2",
+    entries: [
+      {
+        id: "cli/README.md",
+        kind: "readme" as const,
+        title: "CLI Package",
+        sourcePath: "packages/cli/README.md",
+        outputPath: "docs/packages/cli/README.md",
+        package: "@outfitter/cli",
+      },
+      {
+        id: "architecture",
+        kind: "architecture" as const,
+        title: "Architecture",
+        sourcePath: "docs/ARCHITECTURE.md",
+        outputPath: "docs/ARCHITECTURE.md",
+        tags: ["overview"],
+      },
+    ],
+  };
+
+  it("parses a valid docs map", () => {
+    const result = DocsMapSchema.safeParse(validMap);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.generatedAt).toBe("2026-02-21T12:00:00.000Z");
+      expect(result.data.generator).toBe("@outfitter/docs@0.1.2");
+      expect(result.data.entries).toHaveLength(2);
+    }
+  });
+
+  it("accepts an optional $schema field", () => {
+    const withSchema = {
+      ...validMap,
+      $schema: "https://outfitter.dev/docs-map/v1",
+    };
+    const result = DocsMapSchema.safeParse(withSchema);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.$schema).toBe("https://outfitter.dev/docs-map/v1");
+    }
+  });
+
+  it("parses a docs map with zero entries", () => {
+    const emptyMap = { ...validMap, entries: [] };
+    const result = DocsMapSchema.safeParse(emptyMap);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.entries).toEqual([]);
+    }
+  });
+
+  it("rejects a docs map missing generatedAt", () => {
+    const { generatedAt: _, ...noTimestamp } = validMap;
+    const result = DocsMapSchema.safeParse(noTimestamp);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a docs map missing generator", () => {
+    const { generator: _, ...noGenerator } = validMap;
+    const result = DocsMapSchema.safeParse(noGenerator);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a docs map with a non-ISO generatedAt value", () => {
+    const result = DocsMapSchema.safeParse({
+      ...validMap,
+      generatedAt: "not-a-timestamp",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a docs map missing entries", () => {
+    const { entries: _, ...noEntries } = validMap;
+    const result = DocsMapSchema.safeParse(noEntries);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a docs map with invalid entries", () => {
+    const badMap = { ...validMap, entries: [{ id: "only-id" }] };
+    const result = DocsMapSchema.safeParse(badMap);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// Type inference
+// =============================================================================
+
+describe("type inference", () => {
+  it("infers DocKind as a union of string literals", () => {
+    const kind: DocKind = "readme";
+    expect(DocKindSchema.safeParse(kind).success).toBe(true);
+  });
+
+  it("infers DocsMapEntry with correct shape", () => {
+    const entry: DocsMapEntry = {
+      id: "test",
+      kind: "guide",
+      title: "Test Guide",
+      sourcePath: "docs/test.md",
+      outputPath: "docs/test.md",
+      tags: [],
+    };
+    expect(DocsMapEntrySchema.safeParse(entry).success).toBe(true);
+  });
+
+  it("infers DocsMap with correct shape", () => {
+    const map: DocsMap = {
+      generatedAt: new Date().toISOString(),
+      generator: "@outfitter/docs@0.1.2",
+      entries: [],
+    };
+    expect(DocsMapSchema.safeParse(map).success).toBe(true);
+  });
+});

--- a/packages/docs/src/core/docs-map-schema.ts
+++ b/packages/docs/src/core/docs-map-schema.ts
@@ -1,0 +1,127 @@
+/**
+ * Docs map schema and document kind taxonomy.
+ *
+ * Defines the structure of the `.outfitter/docs-map.json` manifest
+ * that catalogs all documentation in a project. Validated at runtime
+ * with Zod; types are inferred from schemas.
+ *
+ * @packageDocumentation
+ */
+
+import { z } from "zod";
+
+// =============================================================================
+// Document Kind Taxonomy
+// =============================================================================
+
+/**
+ * Document kind taxonomy classifying documentation by purpose.
+ *
+ * @example
+ * ```typescript
+ * const kind = DocKindSchema.parse("guide"); // "guide"
+ * ```
+ */
+const docKindValues = [
+  "readme",
+  "guide",
+  "reference",
+  "architecture",
+  "release",
+  "convention",
+  "deep",
+  "generated",
+] as const;
+
+/** Document kind discriminator. */
+export type DocKind = (typeof docKindValues)[number];
+
+export const DocKindSchema: z.ZodType<DocKind> = z.enum(docKindValues);
+
+// =============================================================================
+// Docs Map Entry
+// =============================================================================
+
+/**
+ * Individual doc entry in the docs map.
+ *
+ * Each entry represents a single documentation file with its classification,
+ * source location, and output destination.
+ *
+ * @example
+ * ```typescript
+ * const entry = DocsMapEntrySchema.parse({
+ *   id: "cli/README.md",
+ *   kind: "readme",
+ *   title: "CLI Package",
+ *   sourcePath: "packages/cli/README.md",
+ *   outputPath: "docs/packages/cli/README.md",
+ *   package: "@outfitter/cli",
+ * });
+ * ```
+ */
+export const DocsMapEntrySchema: z.ZodObject<{
+  id: z.ZodString;
+  kind: typeof DocKindSchema;
+  title: z.ZodString;
+  sourcePath: z.ZodString;
+  outputPath: z.ZodString;
+  package: z.ZodOptional<z.ZodString>;
+  tags: z.ZodDefault<z.ZodArray<z.ZodString>>;
+}> = z.object({
+  /** Unique identifier (e.g. "cli/README.md"). */
+  id: z.string(),
+  /** Document kind from the taxonomy. */
+  kind: DocKindSchema,
+  /** First heading or filename used as display title. */
+  title: z.string(),
+  /** Source file path relative to workspace root. */
+  sourcePath: z.string(),
+  /** Output file path relative to workspace root. */
+  outputPath: z.string(),
+  /** Owning package name, if the doc belongs to a package. */
+  package: z.string().optional(),
+  /** Freeform classification tags. */
+  tags: z.array(z.string()).default([]),
+});
+
+/** A single documentation entry in the docs map. */
+export type DocsMapEntry = z.infer<typeof DocsMapEntrySchema>;
+
+// =============================================================================
+// Docs Map Manifest
+// =============================================================================
+
+/**
+ * Top-level docs map manifest written to `.outfitter/docs-map.json`.
+ *
+ * Contains metadata about the generation run and an array of all
+ * documentation entries discovered in the workspace.
+ *
+ * @example
+ * ```typescript
+ * const map = DocsMapSchema.parse({
+ *   generatedAt: new Date().toISOString(),
+ *   generator: "@outfitter/docs@0.1.2",
+ *   entries: [],
+ * });
+ * ```
+ */
+export const DocsMapSchema: z.ZodObject<{
+  $schema: z.ZodOptional<z.ZodString>;
+  generatedAt: z.ZodString;
+  generator: z.ZodString;
+  entries: z.ZodArray<typeof DocsMapEntrySchema>;
+}> = z.object({
+  /** Optional JSON Schema URI for editor validation. */
+  $schema: z.string().optional(),
+  /** ISO-8601 timestamp of when the map was generated. */
+  generatedAt: z.string().datetime(),
+  /** Generator identifier including package version. */
+  generator: z.string(),
+  /** All documentation entries in the workspace. */
+  entries: z.array(DocsMapEntrySchema),
+});
+
+/** The full docs map manifest shape. */
+export type DocsMap = z.infer<typeof DocsMapSchema>;

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -33,7 +33,14 @@ export {
   type ExecuteSyncCommandOptions,
   executeSyncCommand,
 } from "./commands/sync.js";
-
+export {
+  type DocKind,
+  DocKindSchema,
+  type DocsMap,
+  type DocsMapEntry,
+  DocsMapEntrySchema,
+  DocsMapSchema,
+} from "./core/docs-map-schema.js";
 export type {
   CheckLlmsDocsResult,
   CheckPackageDocsResult,


### PR DESCRIPTION
## Summary

- Creates Zod schemas for the docs map manifest in `packages/docs/src/core/docs-map-schema.ts`
- Defines `DocsMap` (top-level manifest), `DocsMapEntry` (individual doc metadata), and `DocKind` taxonomy
- Doc kinds: `readme`, `guide`, `reference`, `architecture`, `release`, `convention`, `deep`, `generated`
- Output location: `.outfitter/docs-map.json` alongside existing `surface.json`
- Full test coverage for schema validation and edge cases

## Test plan

- [ ] Schema validates well-formed docs map entries
- [ ] Schema rejects malformed entries with clear errors
- [ ] `DocKind` enum covers all expected document categories
- [ ] Exports available via `@outfitter/docs/core`

Closes OS-277



Closes: OS-277

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces foundational schema infrastructure for the docs map manifest (`.outfitter/docs-map.json`). Defines three core schemas: `DocKindSchema` (8-member taxonomy: readme, guide, reference, architecture, release, convention, deep, generated), `DocsMapEntrySchema` (individual doc metadata with id, kind, title, paths, optional package/tags), and `DocsMapSchema` (top-level manifest with timestamp, generator, and entries array).

Implementation follows established patterns:
- Uses explicit `ZodType<T>` annotations matching `apps/outfitter/src/manifest.ts` style (addressed in previous review thread)
- Comprehensive TSDoc with usage examples for each schema
- 23 passing tests covering validation, edge cases, defaults, and type inference
- Proper exports via both main entry point and direct `@outfitter/docs/core/docs-map-schema` path
- Adds `zod` as catalog dependency alongside existing `better-result` and `commander`

No logical issues, security concerns, or architectural problems identified. The PR establishes a clean foundation for docs indexing alongside the existing `surface.json` schema drift detection system.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Schema-only PR with full test coverage (23/23 passing), proper type annotations following codebase conventions, no runtime logic, no breaking changes, and addresses previous review feedback about explicit ZodType annotations
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/docs/src/core/docs-map-schema.ts | Defines Zod schemas for docs map manifest with explicit type annotations, comprehensive TSDoc, and proper taxonomy structure |
| packages/docs/src/__tests__/docs-map-schema.test.ts | Comprehensive test suite with 23 passing tests covering validation, edge cases, and type inference |
| packages/docs/src/index.ts | Adds proper exports for new schemas and types following existing package conventions |
| packages/docs/package.json | Adds zod dependency and new export path for direct schema access |

</details>


</details>


<sub>Last reviewed commit: 5f16e1e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->