### PR TITLE
feat(ci): add CLI surface drift check to pre-push and CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
     "verify:ci": "bun run verify:ci:checks && bun run test",
-    "verify:ci:checks": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run check-preset-dependency-versions && bun run docs:check:ci && bun run docs:check:links && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations",
+    "verify:ci:checks": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run check-preset-dependency-versions && bun run docs:check:ci && bun run docs:check:links && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations && bun run schema:diff",
     "check-changeset": "bun run apps/outfitter/src/commands/repo.ts check changeset --cwd .",
     "check-publish-guardrails": "bun run scripts/check-publish-guardrails.ts",
     "check-bunup-registry": "bun run apps/outfitter/src/commands/repo.ts check registry --cwd .",
@@ -20,6 +20,7 @@
     "check-readme-imports": "bun run apps/outfitter/src/commands/repo.ts check readme --cwd .",
     "check-clean-tree": "bun run apps/outfitter/src/commands/repo.ts check tree --cwd .",
     "check-boundary-invocations": "bun run apps/outfitter/src/commands/repo.ts check boundary-invocations --cwd .",
+    "schema:diff": "bun run apps/outfitter/src/cli.ts schema diff",
     "docs:check:links": "bun run apps/outfitter/src/commands/repo.ts check markdown-links --cwd .",
     "build": "bunup && bun scripts/normalize-exports.ts",
     "build:local": "bunup && bun scripts/normalize-exports.ts && cd apps/outfitter && bun link",


### PR DESCRIPTION
## Summary

- Adds `schema:diff` to the `verify:ci:checks` pipeline in root `package.json`
- Ensures `.outfitter/surface.json` is always current — drift from action registry changes is caught before merge
- Pre-push hook already runs `schema-drift` via lefthook; this adds the CI-side equivalent

## Test plan

- [ ] `bun run verify:ci:checks` includes `schema:diff` at the end
- [ ] Stale `surface.json` causes CI to fail with a clear error
- [ ] Regenerating via `outfitter schema generate` clears the drift

Closes OS-287



Closes: OS-287

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds CLI surface drift detection to CI pipeline by integrating `schema:diff` into the verification checks. The change ensures that `.outfitter/surface.json` stays synchronized with the action registry, preventing drift from being merged. This complements the existing pre-push hook that already runs schema drift checks locally.

**Key changes:**
- Added `schema:diff` script definition in `package.json:23`
- Appended `schema:diff` to the end of the `verify:ci:checks` pipeline in `package.json:14`
- Placed after build and clean-tree checks, ensuring the action registry is compiled before verification

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and follows established patterns. It adds a single check to the CI pipeline that mirrors an existing pre-push hook, improving enforcement without introducing new functionality or complexity. The placement in the pipeline is correct (after build, before final verification).
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Adds `schema:diff` script and integrates it into CI verification pipeline |

</details>


</details>


<sub>Last reviewed commit: 0de2b74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->