### PR TITLE
docs: formalize .outfitter/ directory conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,3 +314,4 @@ See [docs/RELEASES.md](./docs/RELEASES.md) for the full process.
 - [docs/reference/patterns.md](./docs/reference/patterns.md) — Handler contract, Result types, error taxonomy
 - [docs/cli/conventions.md](./docs/cli/conventions.md) — CLI flag presets, verb conventions, queryability
 - [docs/getting-started.md](./docs/getting-started.md) — Tutorials
+- [docs/reference/outfitter-directory.md](./docs/reference/outfitter-directory.md) — `.outfitter/` directory conventions

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Guides and reference documentation for the Outfitter monorepo.
 | [Result Cookbook](./reference/result-cookbook.md) | Generator-based composition with `Result.gen()` |
 | [Export Contracts](./reference/export-contracts.md) | Package export verification pipeline and tooling |
 | [TUI Stacks](./reference/tui-stacks.md) | Composable hstack/vstack primitives for CLI layouts |
+| [`.outfitter/` Directory](./reference/outfitter-directory.md) | Project directory conventions, contents, git strategy |
 
 ## Package READMEs
 

--- a/docs/reference/outfitter-directory.md
+++ b/docs/reference/outfitter-directory.md
@@ -1,0 +1,56 @@
+# `.outfitter/` Directory
+
+Project-level artifacts generated and consumed by the Outfitter CLI. Lives at the repository root alongside `package.json`.
+
+## Contents
+
+| Path | Purpose | Committed |
+|------|---------|-----------|
+| `surface.json` | CLI action surface map for drift detection | Yes |
+| `docs-map.json` | Generated docs inventory manifest used by docs-map workflows | No (generated on demand) |
+| `migration/` | Migration audit reports and upgrade plans | Yes |
+| `reports/` | Generated analysis reports (link checks, etc.) | No (gitignored) |
+
+### `surface.json`
+
+Snapshot of all registered CLI actions, their input/output schemas, and flag definitions. Used by `outfitter schema diff` to detect drift between the committed surface map and the live runtime.
+
+```bash
+# Regenerate after adding or changing actions
+outfitter schema generate
+
+# Check for drift (used in pre-push hook and CI)
+outfitter schema diff
+```
+
+### `docs-map.json`
+
+Optional docs inventory produced by docs-map generation workflows. This file is
+generated on demand and should not be committed unless a specific workflow
+explicitly requires it.
+
+### `migration/`
+
+Migration state from major version upgrades. Contains an audit report and numbered plan documents. Safe to remove after a migration is complete.
+
+### `reports/`
+
+Transient output from analysis commands (e.g., `outfitter repo check markdown-links`). Gitignored -- regenerate locally as needed.
+
+## Git Strategy
+
+Commit `surface.json` and `migration/` -- these are shared artifacts that CI and teammates depend on. The `reports/` directory is gitignored since reports are ephemeral and developer-local.
+
+The `.gitignore` entry:
+
+```
+.outfitter/reports/
+```
+
+## When to Regenerate
+
+| Trigger | Command |
+|---------|---------|
+| Added or changed a CLI action | `outfitter schema generate` |
+| Pre-push hook fails with drift | `outfitter schema generate` then re-push |
+| Stale migration state | Remove `migration/` after completing upgrade |


### PR DESCRIPTION
## Summary

- Creates `docs/reference/outfitter-directory.md` documenting the `.outfitter/` directory structure
- Covers `surface.json` (CLI surface map), `docs-map.json` (docs inventory), and future artifacts
- References from `AGENTS.md` and `docs/README.md` for discoverability
- Establishes conventions for generated vs committed artifacts in the directory

## Test plan

- [ ] `docs/reference/outfitter-directory.md` exists with complete documentation
- [ ] `AGENTS.md` references the new doc
- [ ] All relative links in the new doc resolve correctly

Closes OS-289



Closes: OS-289

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Formalizes conventions for the `.outfitter/` directory at the repository root via comprehensive reference documentation.

- Created `docs/reference/outfitter-directory.md` documenting directory structure, contents, git strategy, and regeneration workflows
- Covers `surface.json` (committed CLI surface map), `docs-map.json` (generated-on-demand docs inventory), `migration/` (upgrade artifacts), and `reports/` (gitignored analysis output)
- Added references from `AGENTS.md` Key Files section and `docs/README.md` reference table for discoverability

Previous reviewer comments on missing `docs-map.json` entry and incorrect command syntax have been addressed in the current version.

<h3>Confidence Score: 5/5</h3>

- Documentation-only PR with no code changes - safe to merge
- Pure documentation change establishing conventions for the `.outfitter/` directory. All content is accurate, well-structured, and aligns with existing repository patterns. Previous reviewer feedback has been incorporated. No code logic, security, or runtime concerns.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/reference/outfitter-directory.md | New documentation for `.outfitter/` directory conventions - comprehensive and well-structured |
| AGENTS.md | Added reference link to new `.outfitter/` directory documentation in Key Files section |
| docs/README.md | Added table entry for new `.outfitter/` directory reference documentation |

</details>


</details>


<sub>Last reviewed commit: 84104cd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->