### PR TITLE
chore(schema): stabilize surface map formatting contract

### DIFF
--- a/.outfitter/surface.json
+++ b/.outfitter/surface.json
@@ -1,12 +1,16 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-02-22T23:24:34.890Z",
-  "surfaces": ["cli"],
+  "generatedAt": "2026-02-23T21:19:55.121Z",
+  "surfaces": [
+    "cli"
+  ],
   "actions": [
     {
       "id": "create",
       "description": "Removed - use 'outfitter init' instead",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {}
@@ -19,7 +23,9 @@
     {
       "id": "scaffold",
       "description": "Add a capability to an existing project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -55,11 +61,21 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["target", "force", "skipInstall", "dryRun", "cwd"]
+        "required": [
+          "target",
+          "force",
+          "skipInstall",
+          "dryRun",
+          "cwd"
+        ]
       },
       "cli": {
         "command": "scaffold <target> [name]",
@@ -102,7 +118,9 @@
     {
       "id": "init",
       "description": "Create a new Outfitter project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -129,7 +147,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -166,11 +187,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -253,7 +281,9 @@
     {
       "id": "init.cli",
       "description": "Create a new CLI project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -280,7 +310,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -317,11 +350,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -400,7 +440,9 @@
     {
       "id": "init.mcp",
       "description": "Create a new MCP server",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -427,7 +469,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -464,11 +509,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -547,7 +599,9 @@
     {
       "id": "init.daemon",
       "description": "Create a new daemon project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -574,7 +628,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -611,11 +668,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -694,7 +758,9 @@
     {
       "id": "init.library",
       "description": "Create a new library project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -721,7 +787,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -758,11 +827,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -841,7 +917,9 @@
     {
       "id": "init.full-stack",
       "description": "Create a full-stack workspace",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -868,7 +946,10 @@
           },
           "structure": {
             "type": "string",
-            "enum": ["single", "workspace"]
+            "enum": [
+              "single",
+              "workspace"
+            ]
           },
           "workspaceName": {
             "type": "string"
@@ -905,11 +986,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["targetDir", "force"]
+        "required": [
+          "targetDir",
+          "force"
+        ]
       },
       "cli": {
         "group": "init",
@@ -988,7 +1076,9 @@
     {
       "id": "demo",
       "description": "Run the CLI demo app",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1003,7 +1093,11 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         }
@@ -1028,7 +1122,9 @@
     {
       "id": "doctor",
       "description": "Validate environment and dependencies",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1037,11 +1133,17 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["cwd"]
+        "required": [
+          "cwd"
+        ]
       },
       "cli": {
         "command": "doctor",
@@ -1057,7 +1159,9 @@
     {
       "id": "add",
       "description": "Add a block from the registry to your project",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1075,11 +1179,19 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["block", "force", "dryRun"]
+        "required": [
+          "block",
+          "force",
+          "dryRun"
+        ]
       },
       "cli": {
         "group": "add",
@@ -1106,13 +1218,19 @@
     {
       "id": "add.list",
       "description": "List available blocks",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         }
@@ -1126,7 +1244,9 @@
     {
       "id": "check",
       "description": "Compare local config blocks against the registry for drift detection",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1141,11 +1261,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["cwd", "verbose"]
+        "required": [
+          "cwd",
+          "verbose"
+        ]
       },
       "cli": {
         "group": "check",
@@ -1180,7 +1307,9 @@
     {
       "id": "check.tsdoc",
       "description": "Check TSDoc coverage on exported declarations",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1195,7 +1324,11 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           },
           "jq": {
@@ -1206,7 +1339,11 @@
           },
           "level": {
             "type": "string",
-            "enum": ["documented", "partial", "undocumented"]
+            "enum": [
+              "documented",
+              "partial",
+              "undocumented"
+            ]
           },
           "packages": {
             "type": "array",
@@ -1215,7 +1352,13 @@
             }
           }
         },
-        "required": ["strict", "minCoverage", "cwd", "summary", "packages"]
+        "required": [
+          "strict",
+          "minCoverage",
+          "cwd",
+          "summary",
+          "packages"
+        ]
       },
       "output": {
         "type": "object",
@@ -1247,7 +1390,11 @@
                       },
                       "level": {
                         "type": "string",
-                        "enum": ["documented", "partial", "undocumented"]
+                        "enum": [
+                          "documented",
+                          "partial",
+                          "undocumented"
+                        ]
                       },
                       "file": {
                         "type": "string"
@@ -1256,7 +1403,13 @@
                         "type": "number"
                       }
                     },
-                    "required": ["name", "kind", "level", "file", "line"]
+                    "required": [
+                      "name",
+                      "kind",
+                      "level",
+                      "file",
+                      "line"
+                    ]
                   }
                 },
                 "documented": {
@@ -1315,7 +1468,11 @@
             ]
           }
         },
-        "required": ["ok", "packages", "summary"]
+        "required": [
+          "ok",
+          "packages",
+          "summary"
+        ]
       },
       "cli": {
         "group": "check",
@@ -1359,7 +1516,9 @@
     {
       "id": "upgrade",
       "description": "Check for @outfitter/* package updates and migration guidance",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1392,7 +1551,11 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
@@ -1453,7 +1616,9 @@
     {
       "id": "docs.list",
       "description": "List documentation entries from the docs map",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1471,11 +1636,17 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["cwd"]
+        "required": [
+          "cwd"
+        ]
       },
       "cli": {
         "group": "docs",
@@ -1509,7 +1680,9 @@
     {
       "id": "docs.show",
       "description": "Show a specific documentation entry and its content",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1524,11 +1697,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["id", "cwd"]
+        "required": [
+          "id",
+          "cwd"
+        ]
       },
       "cli": {
         "group": "docs",
@@ -1554,7 +1734,9 @@
     {
       "id": "docs.search",
       "description": "Search documentation content for a query string",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1575,11 +1757,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["query", "cwd"]
+        "required": [
+          "query",
+          "cwd"
+        ]
       },
       "cli": {
         "group": "docs",
@@ -1613,7 +1802,9 @@
     {
       "id": "docs.api",
       "description": "Extract API reference from TSDoc coverage data",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1622,7 +1813,11 @@
           },
           "level": {
             "type": "string",
-            "enum": ["documented", "partial", "undocumented"]
+            "enum": [
+              "documented",
+              "partial",
+              "undocumented"
+            ]
           },
           "packages": {
             "type": "array",
@@ -1635,11 +1830,18 @@
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["cwd", "packages"]
+        "required": [
+          "cwd",
+          "packages"
+        ]
       },
       "output": {
         "type": "object",
@@ -1671,7 +1873,11 @@
                       },
                       "level": {
                         "type": "string",
-                        "enum": ["documented", "partial", "undocumented"]
+                        "enum": [
+                          "documented",
+                          "partial",
+                          "undocumented"
+                        ]
                       },
                       "file": {
                         "type": "string"
@@ -1680,7 +1886,13 @@
                         "type": "number"
                       }
                     },
-                    "required": ["name", "kind", "level", "file", "line"]
+                    "required": [
+                      "name",
+                      "kind",
+                      "level",
+                      "file",
+                      "line"
+                    ]
                   }
                 },
                 "documented": {
@@ -1739,7 +1951,11 @@
             ]
           }
         },
-        "required": ["ok", "packages", "summary"]
+        "required": [
+          "ok",
+          "packages",
+          "summary"
+        ]
       },
       "cli": {
         "group": "docs",
@@ -1773,7 +1989,9 @@
     {
       "id": "docs.export",
       "description": "Export documentation to packages, llms.txt, or both",
-      "surfaces": ["cli"],
+      "surfaces": [
+        "cli"
+      ],
       "input": {
         "type": "object",
         "properties": {
@@ -1782,16 +2000,27 @@
           },
           "target": {
             "type": "string",
-            "enum": ["packages", "llms", "llms-full", "all"],
+            "enum": [
+              "packages",
+              "llms",
+              "llms-full",
+              "all"
+            ],
             "default": "all"
           },
           "outputMode": {
             "type": "string",
-            "enum": ["human", "json", "jsonl"],
+            "enum": [
+              "human",
+              "json",
+              "jsonl"
+            ],
             "default": "human"
           }
         },
-        "required": ["cwd"]
+        "required": [
+          "cwd"
+        ]
       },
       "cli": {
         "group": "docs",
@@ -1857,7 +2086,13 @@
       "http": 499
     }
   },
-  "outputModes": ["human", "json", "jsonl", "tree", "table"],
+  "outputModes": [
+    "human",
+    "json",
+    "jsonl",
+    "tree",
+    "table"
+  ],
   "$schema": "https://outfitter.dev/surface/v1",
   "generator": "build"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Actions are the canonical unit of CLI and MCP functionality. Each action is defi
 
 **Introspection**: `outfitter schema` shows all registered actions. `outfitter schema <action-id> --output json` returns the full schema including input/output shapes.
 
-**Surface maps**: `outfitter schema generate` writes `.outfitter/surface.json` for drift detection. `outfitter schema diff` compares committed surface map against runtime, exiting non-zero on drift. The committed source of truth is root `.outfitter/surface.json` only; do not commit `apps/outfitter/.outfitter/surface.json`.
+**Surface maps**: `outfitter schema generate` writes `.outfitter/surface.json` for drift detection. `outfitter schema diff` compares committed surface map against runtime, exiting non-zero on drift. The committed source of truth is root `.outfitter/surface.json` only; do not commit `apps/outfitter/.outfitter/surface.json`. Surface map formatting is also enforced via `bun run check-surface-map-format`.
 
 #### Adding a New CLI Command
 

--- a/apps/outfitter/README.md
+++ b/apps/outfitter/README.md
@@ -233,6 +233,7 @@ outfitter schema diff --output json       # Structured diff as JSON
 
 Canonical artifact policy: commit root `.outfitter/surface.json` only. Do not
 commit `apps/outfitter/.outfitter/surface.json`.
+Surface map formatting is enforced by `bun run check-surface-map-format`.
 
 ### `check`
 

--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,13 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["!**/node_modules", "!**/dist", "!**/.turbo", "!**/*.gen.ts"]
+    "includes": [
+      "!**/node_modules",
+      "!**/dist",
+      "!**/.turbo",
+      "!**/*.gen.ts",
+      "!**/.outfitter/surface.json"
+    ]
   },
   "overrides": [
     {

--- a/docs/reference/outfitter-directory.md
+++ b/docs/reference/outfitter-directory.md
@@ -16,6 +16,7 @@ Project-level artifacts generated and consumed by the Outfitter CLI. Lives at th
 Snapshot of all registered CLI actions, their input/output schemas, and flag definitions. Used by `outfitter schema diff` to detect drift between the committed surface map and the live runtime.
 
 Canonical policy: root `.outfitter/surface.json` is the only committed surface map. Do not commit `apps/outfitter/.outfitter/surface.json`.
+Formatting policy: `.outfitter/surface.json` is serialized by `schema generate` (two-space JSON with trailing newline) and checked by `check-surface-map-format`. Do not run generic formatter rewrites on this file.
 
 ```bash
 # Regenerate after adding or changing actions
@@ -54,6 +55,7 @@ CI/pre-push guard:
 
 ```bash
 bun run check-canonical-surface-map
+bun run check-surface-map-format
 ```
 
 ## When to Regenerate

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prebuild": "./scripts/prebuild.sh",
     "verify:ci": "bun run verify:ci:checks && bun run test",
-    "verify:ci:checks": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run check-preset-dependency-versions && bun run docs:check:ci && bun run docs:check:links && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations && bun run check-canonical-surface-map && bun run schema:diff",
+    "verify:ci:checks": "bun run typecheck && bun run check && bun run check-publish-guardrails && bun run check-changeset && bun run check-bunup-registry && bun run check-preset-dependency-versions && bun run docs:check:ci && bun run docs:check:links && bun run check-exports && bun run check-readme-imports && bun run build && bun run check-clean-tree && bun run check-boundary-invocations && bun run check-canonical-surface-map && bun run check-surface-map-format && bun run schema:diff",
     "check-changeset": "bun run apps/outfitter/src/commands/repo.ts check changeset --cwd .",
     "check-publish-guardrails": "bun run scripts/check-publish-guardrails.ts",
     "check-bunup-registry": "bun run apps/outfitter/src/commands/repo.ts check registry --cwd .",
@@ -21,6 +21,7 @@
     "check-clean-tree": "bun run apps/outfitter/src/commands/repo.ts check tree --cwd .",
     "check-boundary-invocations": "bun run apps/outfitter/src/commands/repo.ts check boundary-invocations --cwd .",
     "check-canonical-surface-map": "if git ls-files --error-unmatch 'apps/outfitter/.outfitter/surface.json' >/dev/null 2>&1; then echo \"apps/outfitter/.outfitter/surface.json must not be tracked. Canonical surface map is .outfitter/surface.json.\" && exit 1; fi",
+    "check-surface-map-format": "bun run scripts/check-surface-map-format.ts",
     "schema:diff": "bun run apps/outfitter/src/cli.ts schema diff",
     "docs:check:links": "bun run apps/outfitter/src/commands/repo.ts check markdown-links --cwd .",
     "build": "bunup && bun scripts/normalize-exports.ts",

--- a/scripts/check-surface-map-format.test.ts
+++ b/scripts/check-surface-map-format.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeJson,
+  checkSurfaceMapFormat,
+} from "./check-surface-map-format";
+
+describe("checkSurfaceMapFormat", () => {
+  test("passes for canonical two-space JSON with trailing newline", () => {
+    const canonical = '{\n  "a": 1,\n  "b": [\n    1,\n    2\n  ]\n}\n';
+
+    const result = checkSurfaceMapFormat(canonical, "/tmp/surface.json");
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("fails for compact-array formatting drift", () => {
+    const nonCanonical = '{\n  "a": 1,\n  "b": [1, 2]\n}\n';
+
+    const result = checkSurfaceMapFormat(nonCanonical, "/tmp/surface.json");
+
+    expect(result.ok).toBe(false);
+    expect(result.expected).toBe(canonicalizeJson(nonCanonical));
+  });
+});

--- a/scripts/check-surface-map-format.ts
+++ b/scripts/check-surface-map-format.ts
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface SurfaceMapFormatCheckResult {
+  readonly actual: string;
+  readonly expected: string;
+  readonly filePath: string;
+  readonly ok: boolean;
+}
+
+export function canonicalizeJson(content: string): string {
+  const parsed = JSON.parse(content) as unknown;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+export function checkSurfaceMapFormat(
+  content: string,
+  filePath: string
+): SurfaceMapFormatCheckResult {
+  const expected = canonicalizeJson(content);
+
+  return {
+    filePath,
+    actual: content,
+    expected,
+    ok: content === expected,
+  };
+}
+
+function run(): void {
+  const filePath = resolve(process.cwd(), ".outfitter", "surface.json");
+  if (!existsSync(filePath)) {
+    console.error(
+      `[surface-map-format] Missing ${filePath}\nRun 'bun run apps/outfitter/src/cli.ts schema generate' from repo root.`
+    );
+    process.exit(1);
+    return;
+  }
+
+  const content = readFileSync(filePath, "utf-8");
+  const result = checkSurfaceMapFormat(content, filePath);
+  if (result.ok) {
+    console.log(
+      `[surface-map-format] ${filePath} matches canonical formatting`
+    );
+    return;
+  }
+
+  console.error(
+    [
+      `[surface-map-format] ${filePath} is not canonically formatted.`,
+      "Run 'bun run apps/outfitter/src/cli.ts schema generate' from repo root to rewrite .outfitter/surface.json.",
+    ].join("\n")
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  run();
+}


### PR DESCRIPTION
## Summary
Reduce non-semantic `surface.json` formatting churn during schema regeneration.

## Changes
- Stabilized formatting contract for generated surface-map output.
- Added/updated formatting guardrail script coverage.
- Updated docs references to reinforce deterministic regeneration expectations.

## Validation
- Stack pre-push verification passed (`bun run verify:ci`).
- Schema drift/format checks passed in submit gate.

Closes OS-359

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stabilizes `.outfitter/surface.json` formatting by enforcing canonical `JSON.stringify(_, null, 2)` output and adding a CI guardrail script to prevent formatting drift from Biome or other tools.

- Reformatted `surface.json` from compact single-line arrays to expanded multi-line canonical JSON (no semantic changes)
- Added `scripts/check-surface-map-format.ts` guardrail script with round-trip JSON parse/stringify check, following the same pattern as existing check scripts
- Added tests for the formatter check covering pass and fail cases
- Excluded `.outfitter/surface.json` from Biome via `biome.json` to prevent formatter conflicts
- Wired `check-surface-map-format` into `verify:ci:checks` pipeline in `package.json`
- Updated documentation in `AGENTS.md`, `apps/outfitter/README.md`, and `docs/reference/outfitter-directory.md` to reference the new enforcement

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only formatting stabilization, a new CI check, and documentation updates with no behavioral changes.
- All changes are infrastructure/formatting related: surface.json is purely reformatted (verified against canonical output), the new check script is simple and well-tested, Biome exclusion prevents future conflicts, and documentation is consistent across all three updated files. The CI pipeline ordering is correct (canonical check → format check → schema diff). No logic changes, no new dependencies, no security implications.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .outfitter/surface.json | Pure formatting change: arrays expanded from compact single-line to multi-line canonical `JSON.stringify(_, null, 2)` format. Timestamp updated from regeneration. No semantic changes. |
| scripts/check-surface-map-format.ts | New formatting guardrail script. Round-trips surface.json through JSON.parse/stringify to verify canonical two-space format. Follows same pattern as other check scripts (exported functions + `import.meta.main` guard). |
| scripts/check-surface-map-format.test.ts | Tests for the format checker covering canonical pass and compact-array drift detection fail cases. |
| biome.json | Excludes `**/.outfitter/surface.json` from Biome formatting to prevent conflicts with the canonical format enforced by the new check script. |
| package.json | Adds `check-surface-map-format` script and wires it into `verify:ci:checks` pipeline between `check-canonical-surface-map` and `schema:diff`. |
| AGENTS.md | Documents the new `check-surface-map-format` enforcement in the surface maps section. |
| apps/outfitter/README.md | Adds formatting enforcement note to the schema section documentation. |
| docs/reference/outfitter-directory.md | Adds formatting policy and `check-surface-map-format` to the CI guard commands section. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[schema generate] -->|writes| B[.outfitter/surface.json\ncanonical JSON.stringify _ null 2]
    B --> C{verify:ci:checks pipeline}
    C --> D[check-canonical-surface-map\nEnsure correct file is tracked]
    D --> E[check-surface-map-format\nRound-trip JSON parse/stringify]
    E --> F[schema:diff\nCompare committed vs runtime]
    G[biome.json] -->|excludes| B
    E -->|pass| H[CI green]
    E -->|fail| I[Error: rerun schema generate]
```
</details>


<sub>Last reviewed commit: 7768cdf</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=72547e9f-8b5f-445c-8c17-1a4d83251bbf))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=932599f7-b078-4efb-b9bc-ffc13b03c8a0))

<!-- /greptile_comment -->