### PR TITLE
refactor(outfitter): dedupe docs output mode resolution

### DIFF
--- a/apps/outfitter/src/__tests__/docs-list.test.ts
+++ b/apps/outfitter/src/__tests__/docs-list.test.ts
@@ -81,4 +81,46 @@ describe("docs.list action", () => {
 
     expect(mapped.jq).toBe(".entries[0]");
   });
+
+  test("mapInput uses OUTFITTER_JSONL env fallback when --output is omitted", () => {
+    const originalJsonl = process.env["OUTFITTER_JSONL"];
+    process.env["OUTFITTER_JSONL"] = "1";
+
+    try {
+      const action = outfitterActions.get("docs.list");
+      const mapped = action?.cli?.mapInput?.({
+        args: [],
+        flags: {},
+      }) as { outputMode: string };
+
+      expect(mapped.outputMode).toBe("jsonl");
+    } finally {
+      if (originalJsonl === undefined) {
+        delete process.env["OUTFITTER_JSONL"];
+      } else {
+        process.env["OUTFITTER_JSONL"] = originalJsonl;
+      }
+    }
+  });
+
+  test("mapInput explicit --output overrides OUTFITTER_JSONL fallback", () => {
+    const originalJsonl = process.env["OUTFITTER_JSONL"];
+    process.env["OUTFITTER_JSONL"] = "1";
+
+    try {
+      const action = outfitterActions.get("docs.list");
+      const mapped = action?.cli?.mapInput?.({
+        args: [],
+        flags: { output: "human" },
+      }) as { outputMode: string };
+
+      expect(mapped.outputMode).toBe("human");
+    } finally {
+      if (originalJsonl === undefined) {
+        delete process.env["OUTFITTER_JSONL"];
+      } else {
+        process.env["OUTFITTER_JSONL"] = originalJsonl;
+      }
+    }
+  });
 });

--- a/apps/outfitter/src/__tests__/docs-output-mode.test.ts
+++ b/apps/outfitter/src/__tests__/docs-output-mode.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for docs output mode resolution helper.
+ *
+ * @packageDocumentation
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resolveDocsOutputMode } from "../actions/docs-output-mode.js";
+
+describe("resolveDocsOutputMode", () => {
+  test("uses explicit --output when present", () => {
+    const originalJson = process.env["OUTFITTER_JSON"];
+    process.env["OUTFITTER_JSON"] = "1";
+
+    try {
+      const mode = resolveDocsOutputMode({ output: "json" }, "json");
+      expect(mode).toBe("json");
+    } finally {
+      if (originalJson === undefined) {
+        delete process.env["OUTFITTER_JSON"];
+      } else {
+        process.env["OUTFITTER_JSON"] = originalJson;
+      }
+    }
+  });
+
+  test("falls back to human for invalid explicit output", () => {
+    const mode = resolveDocsOutputMode({ output: "nope" }, "human");
+
+    expect(mode).toBe("human");
+  });
+
+  test("falls back to human for explicit non-structured preset mode", () => {
+    const mode = resolveDocsOutputMode({ output: "table" }, "table");
+
+    expect(mode).toBe("human");
+  });
+
+  test("uses OUTFITTER_JSONL when output is omitted", () => {
+    const originalJsonl = process.env["OUTFITTER_JSONL"];
+    const originalJson = process.env["OUTFITTER_JSON"];
+    process.env["OUTFITTER_JSONL"] = "1";
+    process.env["OUTFITTER_JSON"] = "1";
+
+    try {
+      const mode = resolveDocsOutputMode({}, "human");
+      expect(mode).toBe("jsonl");
+    } finally {
+      if (originalJsonl === undefined) {
+        delete process.env["OUTFITTER_JSONL"];
+      } else {
+        process.env["OUTFITTER_JSONL"] = originalJsonl;
+      }
+
+      if (originalJson === undefined) {
+        delete process.env["OUTFITTER_JSON"];
+      } else {
+        process.env["OUTFITTER_JSON"] = originalJson;
+      }
+    }
+  });
+
+  test("uses OUTFITTER_JSON when OUTFITTER_JSONL is not set", () => {
+    const originalJsonl = process.env["OUTFITTER_JSONL"];
+    const originalJson = process.env["OUTFITTER_JSON"];
+    delete process.env["OUTFITTER_JSONL"];
+    process.env["OUTFITTER_JSON"] = "1";
+
+    try {
+      const mode = resolveDocsOutputMode({}, "human");
+      expect(mode).toBe("json");
+    } finally {
+      if (originalJsonl === undefined) {
+        delete process.env["OUTFITTER_JSONL"];
+      } else {
+        process.env["OUTFITTER_JSONL"] = originalJsonl;
+      }
+
+      if (originalJson === undefined) {
+        delete process.env["OUTFITTER_JSON"];
+      } else {
+        process.env["OUTFITTER_JSON"] = originalJson;
+      }
+    }
+  });
+
+  test("defaults to human when no explicit output or env flags exist", () => {
+    const originalJsonl = process.env["OUTFITTER_JSONL"];
+    const originalJson = process.env["OUTFITTER_JSON"];
+    delete process.env["OUTFITTER_JSONL"];
+    delete process.env["OUTFITTER_JSON"];
+
+    try {
+      const mode = resolveDocsOutputMode({}, "human");
+      expect(mode).toBe("human");
+    } finally {
+      if (originalJsonl === undefined) {
+        delete process.env["OUTFITTER_JSONL"];
+      } else {
+        process.env["OUTFITTER_JSONL"] = originalJsonl;
+      }
+
+      if (originalJson === undefined) {
+        delete process.env["OUTFITTER_JSON"];
+      } else {
+        process.env["OUTFITTER_JSON"] = originalJson;
+      }
+    }
+  });
+});

--- a/apps/outfitter/src/actions/docs-output-mode.ts
+++ b/apps/outfitter/src/actions/docs-output-mode.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared output mode resolver for docs actions.
+ *
+ * @packageDocumentation
+ */
+
+import type { OutputMode } from "@outfitter/cli/types";
+import type { CliOutputMode } from "../output-mode.js";
+
+export function resolveDocsOutputMode(
+  flags: Record<string, unknown>,
+  presetOutputMode: OutputMode
+): CliOutputMode {
+  const explicitOutput = typeof flags["output"] === "string";
+  if (explicitOutput) {
+    return presetOutputMode === "json" || presetOutputMode === "jsonl"
+      ? presetOutputMode
+      : "human";
+  }
+
+  if (process.env["OUTFITTER_JSONL"] === "1") {
+    return "jsonl";
+  }
+
+  if (process.env["OUTFITTER_JSON"] === "1") {
+    return "json";
+  }
+
+  return "human";
+}

--- a/apps/outfitter/src/actions/docs.ts
+++ b/apps/outfitter/src/actions/docs.ts
@@ -35,11 +35,8 @@ import {
   printDocsShowResults,
   runDocsShow,
 } from "../commands/docs-show.js";
-import {
-  type CliOutputMode,
-  resolveStructuredOutputMode,
-} from "../output-mode.js";
 import { checkTsdocOutputSchema } from "./check.js";
+import { resolveDocsOutputMode } from "./docs-output-mode.js";
 import { outputModeSchema, resolveStringFlag } from "./shared.js";
 
 const docsListInputSchema = z.object({
@@ -82,17 +79,7 @@ export const docsListAction = defineAction({
         context.flags
       );
       const { jq } = docsListJq.resolve(context.flags);
-      const explicitOutput = typeof context.flags["output"] === "string";
-      let outputMode: CliOutputMode;
-      if (explicitOutput) {
-        outputMode = resolveStructuredOutputMode(presetOutputMode) ?? "human";
-      } else if (process.env["OUTFITTER_JSONL"] === "1") {
-        outputMode = "jsonl";
-      } else if (process.env["OUTFITTER_JSON"] === "1") {
-        outputMode = "json";
-      } else {
-        outputMode = "human";
-      }
+      const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
       const { cwd: rawCwd } = docsListCwd.resolve(context.flags);
       const cwd = resolve(process.cwd(), rawCwd);
       const kind = resolveStringFlag(context.flags["kind"]);
@@ -150,17 +137,7 @@ export const docsShowAction = defineAction({
         context.flags
       );
       const { jq } = docsShowJq.resolve(context.flags);
-      const explicitOutput = typeof context.flags["output"] === "string";
-      let outputMode: CliOutputMode;
-      if (explicitOutput) {
-        outputMode = resolveStructuredOutputMode(presetOutputMode) ?? "human";
-      } else if (process.env["OUTFITTER_JSONL"] === "1") {
-        outputMode = "jsonl";
-      } else if (process.env["OUTFITTER_JSON"] === "1") {
-        outputMode = "json";
-      } else {
-        outputMode = "human";
-      }
+      const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
       const { cwd: rawCwd } = docsShowCwd.resolve(context.flags);
       const cwd = resolve(process.cwd(), rawCwd);
 
@@ -226,17 +203,7 @@ export const docsSearchAction = defineAction({
         context.flags
       );
       const { jq } = docsSearchJq.resolve(context.flags);
-      const explicitOutput = typeof context.flags["output"] === "string";
-      let outputMode: CliOutputMode;
-      if (explicitOutput) {
-        outputMode = resolveStructuredOutputMode(presetOutputMode) ?? "human";
-      } else if (process.env["OUTFITTER_JSONL"] === "1") {
-        outputMode = "jsonl";
-      } else if (process.env["OUTFITTER_JSON"] === "1") {
-        outputMode = "json";
-      } else {
-        outputMode = "human";
-      }
+      const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
       const { cwd: rawCwd } = docsSearchCwd.resolve(context.flags);
       const cwd = resolve(process.cwd(), rawCwd);
       const kind = resolveStringFlag(context.flags["kind"]);
@@ -306,17 +273,7 @@ export const docsApiAction = defineAction({
         context.flags
       );
       const { jq } = docsApiJq.resolve(context.flags);
-      const explicitOutput = typeof context.flags["output"] === "string";
-      let outputMode: CliOutputMode;
-      if (explicitOutput) {
-        outputMode = resolveStructuredOutputMode(presetOutputMode) ?? "human";
-      } else if (process.env["OUTFITTER_JSONL"] === "1") {
-        outputMode = "jsonl";
-      } else if (process.env["OUTFITTER_JSON"] === "1") {
-        outputMode = "json";
-      } else {
-        outputMode = "human";
-      }
+      const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
       const { cwd: rawCwd } = docsApiCwd.resolve(context.flags);
       const cwd = resolve(process.cwd(), rawCwd);
 
@@ -397,17 +354,7 @@ export const docsExportAction = defineAction({
       const { outputMode: presetOutputMode } = docsExportOutputMode.resolve(
         context.flags
       );
-      const explicitOutput = typeof context.flags["output"] === "string";
-      let outputMode: CliOutputMode;
-      if (explicitOutput) {
-        outputMode = resolveStructuredOutputMode(presetOutputMode) ?? "human";
-      } else if (process.env["OUTFITTER_JSONL"] === "1") {
-        outputMode = "jsonl";
-      } else if (process.env["OUTFITTER_JSON"] === "1") {
-        outputMode = "json";
-      } else {
-        outputMode = "human";
-      }
+      const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
       const { cwd: rawCwd } = docsExportCwd.resolve(context.flags);
       const cwd = resolve(process.cwd(), rawCwd);
       const targetRaw = resolveStringFlag(context.flags["target"]);


### PR DESCRIPTION
## Summary
Remove duplicated docs action output-mode resolution logic by introducing a shared helper.

## Changes
- Added shared docs output-mode resolver helper.
- Rewired docs action `mapInput` implementations (`list`, `show`, `search`, `api`, `export`) to use shared precedence logic.
- Added helper-focused tests and representative action wiring coverage.

## Validation
- Outfitter docs-action tests/typecheck/lint passed.
- Stack pre-push verification passed (`bun run verify:ci`).

Closes OS-327

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted duplicated output mode resolution logic from 5 docs actions (`list`, `show`, `search`, `api`, `export`) into a shared `resolveDocsOutputMode` helper.

- Introduced `apps/outfitter/src/actions/docs-output-mode.ts` with consistent precedence: explicit `--output` flag > `OUTFITTER_JSONL` env > `OUTFITTER_JSON` env > `human` default
- Replaced ~65 lines of duplicated code across `docs.ts` with single function calls
- Added comprehensive unit tests for the helper function covering all precedence paths
- Added integration tests in `docs-list.test.ts` demonstrating env fallback and flag override behavior
- Maintains identical behavior to previous implementation while improving maintainability

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested refactoring with no behavioral changes
- Clean extraction of duplicated logic into a shared helper with comprehensive test coverage. The refactoring maintains identical behavior while improving code maintainability. All precedence rules are preserved and explicitly tested.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/outfitter/src/actions/docs-output-mode.ts | Introduced shared `resolveDocsOutputMode` helper with proper precedence: explicit flag > `OUTFITTER_JSONL` > `OUTFITTER_JSON` > `human` |
| apps/outfitter/src/__tests__/docs-output-mode.test.ts | Added comprehensive test coverage for output mode resolution including explicit flags, env fallbacks, and precedence rules |
| apps/outfitter/src/actions/docs.ts | Replaced duplicated output mode resolution logic across 5 actions (`list`, `show`, `search`, `api`, `export`) with shared helper |
| apps/outfitter/src/__tests__/docs-list.test.ts | Added integration tests verifying `OUTFITTER_JSONL` env fallback behavior and explicit flag override in `docs.list` action |

</details>


</details>


<sub>Last reviewed commit: 9a46f31</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->