### PR TITLE
feat(tooling): rename oxlint registry block to generic 'linter'

### DIFF
--- a/packages/tooling/src/registry/build.ts
+++ b/packages/tooling/src/registry/build.ts
@@ -188,9 +188,9 @@ function createRegistryConfig(): RegistryBuildConfig {
           ".claude/hooks/format-code-on-stop.sh",
         ],
       },
-      oxlint: {
+      linter: {
         description:
-          "oxlint/oxfmt linter and formatter configuration via Ultracite",
+          "Linter and formatter configuration (oxlint/oxfmt) via Ultracite",
         files: [".oxlintrc.json", ".oxfmtrc.jsonc"],
         devDependencies: {
           ultracite: resolveVersion(versions, "ultracite"),
@@ -227,7 +227,7 @@ function createRegistryConfig(): RegistryBuildConfig {
       scaffolding: {
         description:
           "Full starter kit: Claude settings, oxlint/oxfmt, Lefthook, markdownlint, and bootstrap script",
-        extends: ["claude", "oxlint", "lefthook", "markdownlint", "bootstrap"],
+        extends: ["claude", "linter", "lefthook", "markdownlint", "bootstrap"],
       },
     },
   };


### PR DESCRIPTION
## Summary

- Rename `oxlint` registry block to generic `linter` for future-proofing
- Update scaffolding extends from `oxlint` to `linter`

## Test plan

- [x] `bun run test --filter=@outfitter/tooling`
- [x] `outfitter add linter` resolves correctly

Closes OS-389

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed the `oxlint` registry block to a more generic `linter` name within the tooling package's registry configuration. The `scaffolding` composite block was updated to extend `linter` instead of `oxlint`. This change future-proofs the registry by decoupling the block name from the specific tool implementation (oxlint/oxfmt), making it easier to swap linting tools without breaking references.

The change is straightforward and consistent:
- Block name: `oxlint` → `linter`
- Description updated to be more generic
- `scaffolding` block's extends array updated accordingly

Tests confirm the registry builds correctly with these changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and purely rename-based. The registry block rename from `oxlint` to `linter` is internally consistent (both the block definition and its usage in the `scaffolding` block are updated). The existing test suite validates registry structure and configuration, and the PR author confirmed tests pass. No logic changes, no new dependencies, and the rename improves future maintainability.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/tooling/src/registry/build.ts | Renamed `oxlint` registry block to generic `linter` and updated description for future-proofing |

</details>


</details>


<sub>Last reviewed commit: c0e0cfc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->