### PR TITLE
feat(presets): replace biome templates with oxlint/oxfmt

### DIFF
--- a/apps/outfitter/src/engine/executor.ts
+++ b/apps/outfitter/src/engine/executor.ts
@@ -14,6 +14,9 @@ const TOOLING_PRESET_PATHS = new Set([
   ".claude/hooks/format-code-on-stop.sh",
   ".lefthook.yml",
   ".markdownlint-cli2.jsonc",
+  ".oxlintrc.json",
+  ".oxfmtrc.jsonc",
+  // Keep legacy Biome config support for older preset snapshots.
   "biome.json",
   "scripts/bootstrap.sh",
 ]);

--- a/packages/presets/presets/basic/.lefthook.yml.template
+++ b/packages/presets/presets/basic/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/packages/presets/presets/basic/package.json.template
+++ b/packages/presets/presets/basic/package.json.template
@@ -24,9 +24,9 @@
 		"typecheck": "tsc --noEmit",
 		"check": "ultracite check",
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},

--- a/packages/presets/presets/cli/.lefthook.yml.template
+++ b/packages/presets/presets/cli/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/packages/presets/presets/cli/biome.json.template
+++ b/packages/presets/presets/cli/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/packages/presets/presets/cli/package.json.template
+++ b/packages/presets/presets/cli/package.json.template
@@ -22,9 +22,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/daemon/.lefthook.yml.template
+++ b/packages/presets/presets/daemon/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/packages/presets/presets/daemon/biome.json.template
+++ b/packages/presets/presets/daemon/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/packages/presets/presets/daemon/package.json.template
+++ b/packages/presets/presets/daemon/package.json.template
@@ -24,9 +24,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/full-stack/apps/cli/package.json.template
+++ b/packages/presets/presets/full-stack/apps/cli/package.json.template
@@ -20,9 +20,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/full-stack/apps/mcp/package.json.template
+++ b/packages/presets/presets/full-stack/apps/mcp/package.json.template
@@ -20,9 +20,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/full-stack/packages/core/package.json.template
+++ b/packages/presets/presets/full-stack/packages/core/package.json.template
@@ -17,9 +17,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/library/package.json.template
+++ b/packages/presets/presets/library/package.json.template
@@ -23,9 +23,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},

--- a/packages/presets/presets/mcp/.lefthook.yml.template
+++ b/packages/presets/presets/mcp/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/packages/presets/presets/mcp/biome.json.template
+++ b/packages/presets/presets/mcp/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/packages/presets/presets/mcp/package.json.template
+++ b/packages/presets/presets/mcp/package.json.template
@@ -22,9 +22,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/packages/presets/presets/minimal/.lefthook.yml.template
+++ b/packages/presets/presets/minimal/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/packages/presets/presets/minimal/package.json.template
+++ b/packages/presets/presets/minimal/package.json.template
@@ -24,9 +24,9 @@
 		"typecheck": "tsc --noEmit",
 		"check": "ultracite check",
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},

--- a/templates/basic/.lefthook.yml.template
+++ b/templates/basic/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/templates/basic/package.json.template
+++ b/templates/basic/package.json.template
@@ -24,9 +24,9 @@
 		"typecheck": "tsc --noEmit",
 		"check": "ultracite check",
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},

--- a/templates/cli/.lefthook.yml.template
+++ b/templates/cli/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/templates/cli/biome.json.template
+++ b/templates/cli/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/templates/cli/package.json.template
+++ b/templates/cli/package.json.template
@@ -22,9 +22,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/daemon/.lefthook.yml.template
+++ b/templates/daemon/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/templates/daemon/biome.json.template
+++ b/templates/daemon/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/templates/daemon/package.json.template
+++ b/templates/daemon/package.json.template
@@ -24,9 +24,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/full-stack/apps/cli/package.json.template
+++ b/templates/full-stack/apps/cli/package.json.template
@@ -20,9 +20,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/full-stack/apps/mcp/package.json.template
+++ b/templates/full-stack/apps/mcp/package.json.template
@@ -20,9 +20,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/full-stack/packages/core/package.json.template
+++ b/templates/full-stack/packages/core/package.json.template
@@ -17,9 +17,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/library/package.json.template
+++ b/templates/library/package.json.template
@@ -23,9 +23,9 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},

--- a/templates/mcp/.lefthook.yml.template
+++ b/templates/mcp/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/templates/mcp/biome.json.template
+++ b/templates/mcp/biome.json.template
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
-	"extends": ["ultracite/config/biome/core/biome.jsonc"]
-}

--- a/templates/mcp/package.json.template
+++ b/templates/mcp/package.json.template
@@ -22,9 +22,9 @@
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo"
 	},
 	"dependencies": {

--- a/templates/minimal/.lefthook.yml.template
+++ b/templates/minimal/.lefthook.yml.template
@@ -6,12 +6,12 @@ pre-commit:
   commands:
     format:
       glob: "*.{js,ts,tsx,json,md}"
-      run: bunx biome format --no-errors-on-unmatched {staged_files}
+      run: bunx oxfmt --write {staged_files}
       stage_fixed: true
 
     lint:
       glob: "*.{js,ts,tsx}"
-      run: bunx biome lint --no-errors-on-unmatched {staged_files}
+      run: bunx oxlint {staged_files}
 
     typecheck:
       glob: "*.{ts,tsx}"

--- a/templates/minimal/package.json.template
+++ b/templates/minimal/package.json.template
@@ -24,9 +24,9 @@
 		"typecheck": "tsc --noEmit",
 		"check": "ultracite check",
 		"verify:ci": "bun run typecheck && bun run check && bun run build && bun run test",
-		"lint": "biome check .",
-		"lint:fix": "biome check . --write",
-		"format": "biome format --write .",
+		"lint": "oxlint .",
+		"lint:fix": "oxlint --fix .",
+		"format": "oxfmt --write .",
 		"clean:artifacts": "rm -rf dist .turbo",
 		"clean": "rm -rf dist"
 	},


### PR DESCRIPTION
## Summary

- Delete 3 `biome.json.template` files from scaffold presets
- Update 9 `package.json.template` files: replace biome lint scripts with oxlint/oxfmt
- Update 5 `.lefthook.yml.template` files: replace `bunx biome format/lint` with `bunx oxfmt/oxlint`

## Test plan

- [x] `bun run test --filter=@outfitter/presets` (14 tests pass)

Closes OS-388

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Completes the scaffold template layer of the biome → oxlint/oxfmt migration. Deletes 6 `biome.json.template` files (3 in `packages/presets/presets/`, 3 in legacy `templates/`), updates 10 `.lefthook.yml.template` files to use `bunx oxfmt --write` and `bunx oxlint`, and updates 18 `package.json.template` files to replace biome lint/format scripts with oxlint/oxfmt equivalents. Also adds `.oxlintrc.json` and `.oxfmtrc.jsonc` to the tooling preset skip filter in `executor.ts` (with backward-compat retention of `biome.json`), and strengthens the linter block test to assert `.oxfmtrc.jsonc` creation.

- All canonical (`packages/presets/presets/`) and legacy (`templates/`) template locations are kept in sync
- `executor.ts` correctly retains `biome.json` in `TOOLING_PRESET_PATHS` for older preset snapshots
- Note: `shared-deps.ts` still references `@biomejs/biome` in `SHARED_DEV_DEPS` and biome scripts in `SHARED_SCRIPTS` — template scripts override at merge time, but scaffolded projects will still receive biome as an unused devDependency until that file is updated

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — template changes are consistent and well-tested, with one minor leftover dependency concern in a file outside the changeset.
- Score of 4 reflects that all template changes are mechanically correct and consistent across all preset types and both directory locations, with passing tests. Deducted one point because `shared-deps.ts` (not in this PR) still injects `@biomejs/biome` as a devDependency into scaffolded projects, which is a minor inconsistency that should be resolved in a follow-up.
- No files in this PR require special attention. However, `apps/outfitter/src/commands/shared-deps.ts` (outside this changeset) still has biome references that should be updated in a follow-up.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/outfitter/src/__tests__/init.test.ts | Adds `.oxfmtrc.jsonc` assertion and file existence check to the linter block test, complementing the existing `.oxlintrc.json` check. |
| apps/outfitter/src/engine/executor.ts | Adds `.oxlintrc.json` and `.oxfmtrc.jsonc` to `TOOLING_PRESET_PATHS` set and retains `biome.json` for legacy support with a clear comment. |
| packages/presets/presets/basic/.lefthook.yml.template | Replaces `bunx biome format/lint` commands with `bunx oxfmt --write` and `bunx oxlint`. |
| packages/presets/presets/basic/package.json.template | Replaces biome lint/format scripts with `oxlint`/`oxfmt` equivalents. |
| packages/presets/presets/cli/biome.json.template | Deleted — biome config template no longer needed after migration to oxlint/oxfmt. |
| packages/presets/presets/cli/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |
| packages/presets/presets/daemon/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |
| packages/presets/presets/full-stack/apps/cli/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |
| packages/presets/presets/library/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |
| packages/presets/presets/mcp/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |
| packages/presets/presets/minimal/package.json.template | Replaces biome lint/format scripts with oxlint/oxfmt equivalents. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["outfitter init --preset X"] --> B["Copy preset templates"]
    B --> C["package.json.template"]
    B --> D[".lefthook.yml.template"]
    B --> E["biome.json.template ❌ DELETED"]
    
    C --> F["Scripts: oxlint / oxfmt ✅"]
    D --> G["Hooks: bunx oxlint / oxfmt ✅"]
    
    A --> H["inject-shared-config"]
    H --> I["SHARED_SCRIPTS\n(biome fallbacks)"]
    H --> J["SHARED_DEV_DEPS\n(@biomejs/biome ⚠️)"]
    
    F -->|"overrides"| I
    
    A --> K["add-blocks: linter"]
    K --> L[".oxlintrc.json ✅"]
    K --> M[".oxfmtrc.jsonc ✅"]
    
    style E fill:#ff6b6b,color:#fff
    style J fill:#ffd93d,color:#333
    style F fill:#6bcb77,color:#fff
    style G fill:#6bcb77,color:#fff
    style L fill:#6bcb77,color:#fff
    style M fill:#6bcb77,color:#fff
```
</details>


[![Fix All in Claude Code](https://img.shields.io/badge/Fix_All_in_claude-black?logo=claude&logoColor=%23D97706)](https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Foutfitter%2Fsrc%2Fengine%2Fexecutor.ts%3A19-20%0A**Stale%20biome%20refs%20in%20%60shared-deps.ts%60**%0A%0AThe%20legacy%20%60biome.json%60%20entry%20here%20is%20fine%20%28and%20well-commented%29%2C%20but%20%60apps%2Foutfitter%2Fsrc%2Fcommands%2Fshared-deps.ts%60%20still%20injects%20%60%22%40biomejs%2Fbiome%22%60%20into%20%60SHARED_DEV_DEPS%60%20%28line%2045%29%20and%20defines%20biome-based%20%60lint%60%2F%60lint%3Afix%60%2F%60format%60%20scripts%20in%20%60SHARED_SCRIPTS%60%20%28lines%2062-64%29.%20The%20template%20scripts%20override%20%60SHARED_SCRIPTS%60%20%28template%20values%20win%20via%20spread%20order%20in%20%60config.ts%3A103%60%29%2C%20so%20lint%2Fformat%20commands%20are%20correct.%20However%2C%20%60%40biomejs%2Fbiome%60%20will%20still%20be%20added%20as%20a%20devDependency%20to%20every%20scaffolded%20project%20since%20no%20template%20overrides%20it%20in%20%60devDependencies%60.%20If%20this%20is%20planned%20for%20a%20follow-up%20PR%2C%20no%20action%20needed%20%E2%80%94%20just%20flagging%20the%20gap.%0A%0A&repo=outfitter-dev%2Foutfitter) [![Fix All in Codex](https://img.shields.io/badge/Fix_All_in_codex-black?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzZsNS44MTUgMy4zNTUtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1bC01LjgzMy0zLjM4N0wxNS4xMTkgNy4yYS4wNzYuMDc2IDAgMCAxIC4wNzEgMGw0LjgzIDIuNzkxYTQuNDk0IDQuNDk0IDAgMCAxLS42NzYgOC4xMDV2LTUuNjc4YS43OS43OSAwIDAgMC0uNDA3LS42Njd6bTIuMDEtMy4wMjNsLS4xNDEtLjA4NS00Ljc3NC0yLjc4MmEuNzc2Ljc3NiAwIDAgMC0uNzg1IDBMOS40MDkgOS4yM1Y2Ljg5N2EuMDY2LjA2NiAwIDAgMSAuMDI4LS4wNjFsNC44My0yLjc4N2E0LjUgNC41IDAgMCAxIDYuNjggNC42NnptLTEyLjY0IDQuMTM1bC0yLjAyLTEuMTY0YS4wOC4wOCAwIDAgMS0uMDM4LS4wNTdWNi4wNzVhNC41IDQuNSAwIDAgMSA3LjM3NS0zLjQ1M2wtLjE0Mi4wOEw4LjcwNCA1LjQ2YS43OTUuNzk1IDAgMCAwLS4zOTMuNjgxem0xLjA5Ny0yLjM2NWwyLjYwMi0xLjUgMi42MDcgMS41djIuOTk5bC0yLjU5NyAxLjUtMi42MDctMS41eiIvPjwvc3ZnPg==&logoColor=white)](https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Foutfitter%2Fsrc%2Fengine%2Fexecutor.ts%3A19-20%0A**Stale%20biome%20refs%20in%20%60shared-deps.ts%60**%0A%0AThe%20legacy%20%60biome.json%60%20entry%20here%20is%20fine%20%28and%20well-commented%29%2C%20but%20%60apps%2Foutfitter%2Fsrc%2Fcommands%2Fshared-deps.ts%60%20still%20injects%20%60%22%40biomejs%2Fbiome%22%60%20into%20%60SHARED_DEV_DEPS%60%20%28line%2045%29%20and%20defines%20biome-based%20%60lint%60%2F%60lint%3Afix%60%2F%60format%60%20scripts%20in%20%60SHARED_SCRIPTS%60%20%28lines%2062-64%29.%20The%20template%20scripts%20override%20%60SHARED_SCRIPTS%60%20%28template%20values%20win%20via%20spread%20order%20in%20%60config.ts%3A103%60%29%2C%20so%20lint%2Fformat%20commands%20are%20correct.%20However%2C%20%60%40biomejs%2Fbiome%60%20will%20still%20be%20added%20as%20a%20devDependency%20to%20every%20scaffolded%20project%20since%20no%20template%20overrides%20it%20in%20%60devDependencies%60.%20If%20this%20is%20planned%20for%20a%20follow-up%20PR%2C%20no%20action%20needed%20%E2%80%94%20just%20flagging%20the%20gap.%0A%0A&repo=outfitter-dev%2Foutfitter)

<sub>Last reviewed commit: cbeb8eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->