### PR TITLE
chore(deps): remove @biomejs/biome from catalog and all dependencies

### DIFF
--- a/apps/outfitter/src/commands/shared-deps.ts
+++ b/apps/outfitter/src/commands/shared-deps.ts
@@ -42,10 +42,11 @@ function requireInternalVersion(name: string): string {
  * Internal @outfitter/* versions come from workspace scanning.
  */
 export const SHARED_DEV_DEPS: Readonly<Record<string, string>> = {
-  "@biomejs/biome": requireVersion("@biomejs/biome"),
   "@outfitter/tooling": requireInternalVersion("@outfitter/tooling"),
   "@types/bun": requireVersion("@types/bun"),
   lefthook: requireVersion("lefthook"),
+  oxfmt: requireVersion("oxfmt"),
+  oxlint: requireVersion("oxlint"),
   typescript: requireVersion("typescript"),
   ultracite: requireVersion("ultracite"),
 };
@@ -59,8 +60,8 @@ export const SHARED_SCRIPTS = {
   "clean:artifacts": "rm -rf dist .turbo",
   "verify:ci":
     "bun run typecheck && bun run check && bun run build && bun run test",
-  lint: "biome check .",
-  "lint:fix": "biome check . --write",
-  format: "biome format --write .",
+  lint: "oxlint .",
+  "lint:fix": "oxlint --fix .",
+  format: "oxfmt --write .",
   typecheck: "tsc --noEmit",
 } as const;

--- a/bun.lock
+++ b/bun.lock
@@ -232,7 +232,6 @@
       "name": "@outfitter/presets",
       "version": "0.2.0",
       "dependencies": {
-        "@biomejs/biome": "catalog:",
         "@clack/prompts": "catalog:",
         "@logtape/logtape": "catalog:",
         "@modelcontextprotocol/sdk": "catalog:",
@@ -241,6 +240,8 @@
         "bunup": "catalog:",
         "commander": "catalog:",
         "lefthook": "catalog:",
+        "oxfmt": "catalog:",
+        "oxlint": "catalog:",
         "smol-toml": "catalog:",
         "ultracite": "catalog:",
         "yaml": "catalog:",
@@ -370,7 +371,6 @@
     "oxlint",
   ],
   "catalog": {
-    "@biomejs/biome": "2.4.4",
     "@clack/prompts": "^1.0.1",
     "@logtape/logtape": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
@@ -398,24 +398,6 @@
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@biomejs/biome": ["@biomejs/biome@2.4.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
-
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A=="],
-
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg=="],
-
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg=="],
-
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ=="],
-
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg=="],
-
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g=="],
-
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q=="],
-
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
 
     "@bunup/dts": ["@bunup/dts@0.14.53", "", { "dependencies": { "@babel/parser": "^7.28.6", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.16.2", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.10.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-qyHgYEYxcghoChICEhuFKfA/EqqRA9WHOHLXcIkR9c70DgLAEXcOlkYhfBPmGxfMKJYL0X4VtQwst0/AMk9D3g=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   },
   "packageManager": "bun@1.3.9",
   "catalog": {
-    "@biomejs/biome": "2.4.4",
     "@clack/prompts": "^1.0.1",
     "@logtape/logtape": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -39,7 +39,6 @@
     "prepublishOnly": "bun ../../scripts/check-publish-manifest.ts"
   },
   "dependencies": {
-    "@biomejs/biome": "catalog:",
     "@clack/prompts": "catalog:",
     "@logtape/logtape": "catalog:",
     "@modelcontextprotocol/sdk": "catalog:",


### PR DESCRIPTION
## Summary

- Remove `@biomejs/biome` from root `package.json` catalog
- Remove `@biomejs/biome` from `@outfitter/presets` dependencies
- Replace biome references in `shared-deps.ts` with oxlint and oxfmt
- Update `bun.lock`

## Test plan

- [x] `grep -r "@biomejs" bun.lock` returns nothing
- [x] `bun run test --filter=@outfitter/presets`
- [x] `bun run verify:ci`

Closes OS-382

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully removes `@biomejs/biome` from the project in favor of oxlint/oxfmt. The changes are comprehensive and correctly implemented:

- Removed `@biomejs/biome` from root catalog and `@outfitter/presets` dependencies
- Updated `shared-deps.ts` to replace biome with oxlint/oxfmt in both dependencies and scripts
- Cleaned up validation logic in `check-preset-dependency-versions.ts` by removing biome-specific checks
- `bun.lock` properly updated with no remaining biome references

Minor documentation updates needed: Three code comments and CLI descriptions still reference the removed "biome" block, which should be updated to reflect current tooling options.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - all biome dependencies and references cleanly removed with proper oxlint/oxfmt replacements
- All dependency changes are correct and complete. Scripts properly updated. Only minor documentation strings need cleanup, which doesn't affect functionality. Tests confirm clean removal.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/outfitter/src/commands/shared-deps.ts | Correctly replaced `@biomejs/biome` with `oxfmt` and `oxlint` in SHARED_DEV_DEPS and updated all script commands appropriately |
| package.json | Removed `@biomejs/biome` from catalog as expected |
| packages/presets/package.json | Removed `@biomejs/biome` dependency; `oxfmt` and `oxlint` already present from previous PR |
| scripts/check-preset-dependency-versions.ts | Removed biome-specific validation logic (`validateBiomeSchemaUrls`) and updated check numbering accordingly |

</details>


</details>


[![Fix All in Claude Code](https://img.shields.io/badge/Fix_All_in_claude-black?logo=claude&logoColor=%23D97706)](https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Foutfitter%2Fsrc%2Factions%2Fadd.ts%3A48%0AUpdate%20description%20-%20%60biome%60%20block%20no%20longer%20exists%20%28replaced%20by%20oxlint%2Foxfmt%29%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22Add%20a%20block%20from%20the%20registry%20%28claude%2C%20lefthook%2C%20bootstrap%2C%20scaffolding%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Foutfitter%2Fsrc%2Factions%2Finit.ts%3A124%0AUpdate%20description%20-%20%60biome%60%20is%20no%20longer%20a%20valid%20tooling%20option%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22Tooling%20to%20add%20%28comma-separated%3A%20scaffolding%2C%20claude%2C%20lefthook%2C%20bootstrap%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Foutfitter%2Fsrc%2Fmanifest.ts%3A198%0AUpdate%20example%20-%20%60biome%60%20block%20no%20longer%20exists%0A%0A%60%60%60suggestion%0A%20*%20await%20stampBlock%28process.cwd%28%29%2C%20%22linter%22%2C%20%220.2.1%22%29%3B%0A%60%60%60%0A%0A&repo=outfitter-dev%2Foutfitter) [![Fix All in Codex](https://img.shields.io/badge/Fix_All_in_codex-black?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzZsNS44MTUgMy4zNTUtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1bC01LjgzMy0zLjM4N0wxNS4xMTkgNy4yYS4wNzYuMDc2IDAgMCAxIC4wNzEgMGw0LjgzIDIuNzkxYTQuNDk0IDQuNDk0IDAgMCAxLS42NzYgOC4xMDV2LTUuNjc4YS43OS43OSAwIDAgMC0uNDA3LS42Njd6bTIuMDEtMy4wMjNsLS4xNDEtLjA4NS00Ljc3NC0yLjc4MmEuNzc2Ljc3NiAwIDAgMC0uNzg1IDBMOS40MDkgOS4yM1Y2Ljg5N2EuMDY2LjA2NiAwIDAgMSAuMDI4LS4wNjFsNC44My0yLjc4N2E0LjUgNC41IDAgMCAxIDYuNjggNC42NnptLTEyLjY0IDQuMTM1bC0yLjAyLTEuMTY0YS4wOC4wOCAwIDAgMS0uMDM4LS4wNTdWNi4wNzVhNC41IDQuNSAwIDAgMSA3LjM3NS0zLjQ1M2wtLjE0Mi4wOEw4LjcwNCA1LjQ2YS43OTUuNzk1IDAgMCAwLS4zOTMuNjgxem0xLjA5Ny0yLjM2NWwyLjYwMi0xLjUgMi42MDcgMS41djIuOTk5bC0yLjU5NyAxLjUtMi42MDctMS41eiIvPjwvc3ZnPg==&logoColor=white)](https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Foutfitter%2Fsrc%2Factions%2Fadd.ts%3A48%0AUpdate%20description%20-%20%60biome%60%20block%20no%20longer%20exists%20%28replaced%20by%20oxlint%2Foxfmt%29%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22Add%20a%20block%20from%20the%20registry%20%28claude%2C%20lefthook%2C%20bootstrap%2C%20scaffolding%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Foutfitter%2Fsrc%2Factions%2Finit.ts%3A124%0AUpdate%20description%20-%20%60biome%60%20is%20no%20longer%20a%20valid%20tooling%20option%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%22Tooling%20to%20add%20%28comma-separated%3A%20scaffolding%2C%20claude%2C%20lefthook%2C%20bootstrap%29%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Foutfitter%2Fsrc%2Fmanifest.ts%3A198%0AUpdate%20example%20-%20%60biome%60%20block%20no%20longer%20exists%0A%0A%60%60%60suggestion%0A%20*%20await%20stampBlock%28process.cwd%28%29%2C%20%22linter%22%2C%20%220.2.1%22%29%3B%0A%60%60%60%0A%0A&repo=outfitter-dev%2Foutfitter)

<sub>Last reviewed commit: a6eab55</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->