### PR TITLE
chore(build): remove dead DTS splitting version guard

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -1,14 +1,6 @@
 import type { BunupPlugin } from "bunup";
 import { defineWorkspace } from "bunup";
 
-// DTS splitting requires Bun >= 1.3.7 (fix: oven-sh/bun#26089)
-// TODO: Remove version check once 1.3.7 is widely adopted
-const bunVersion = Bun.version.split(".").map(Number);
-const supportsDtsSplitting =
-  bunVersion[0] > 1 ||
-  (bunVersion[0] === 1 && bunVersion[1] > 3) ||
-  (bunVersion[0] === 1 && bunVersion[1] === 3 && bunVersion[2] >= 7);
-
 /**
  * Work around Bun duplicate export bug with re-exported entrypoints.
  * Removes duplicate export statements that appear consecutively.
@@ -258,8 +250,8 @@ export default defineWorkspace(
     format: ["esm"],
     // Work around Bun duplicate export bug with re-exported entrypoints
     plugins: [stripDuplicateExports()],
-    // TypeScript declarations (splitting enabled when Bun >= 1.3.7)
-    dts: supportsDtsSplitting ? { splitting: true } : true,
+    // TypeScript declarations with splitting
+    dts: { splitting: true },
     // Auto-generate package.json exports field
     exports: true,
     // Code splitting for optimal tree-shaking


### PR DESCRIPTION
## Summary

- Remove dead Bun version check for DTS splitting in `bunup.config.ts`
- The guard required Bun >= 1.3.7 but we're pinned to >= 1.3.9
- Inline `{ splitting: true }` directly

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run verify:ci`

Closes OS-366

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed obsolete Bun version check for DTS splitting feature in `bunup.config.ts`. The guard required Bun >= 1.3.7, but the project is pinned to >= 1.3.9 in `package.json:79`, making the conditional logic unnecessary. The `{ splitting: true }` configuration is now inlined directly.

- Removed 8 lines of dead code (version parsing and conditional logic)
- Updated comment from conditional phrasing to definitive statement
- No functional change since the condition was always true

<h3>Confidence Score: 5/5</h3>

- Safe to merge — simple dead code removal with no functional impact
- The change correctly removes unnecessary conditional logic since the Bun version requirement (>= 1.3.9) exceeds the guard threshold (>= 1.3.7). Test plan confirms build succeeds and CI passes.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| bunup.config.ts | Removed dead Bun version check for DTS splitting (>= 1.3.7) since project is pinned to >= 1.3.9 |

</details>


</details>


<sub>Last reviewed commit: 17e641d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->