### PR TITLE
fix(build): key turbo cache on Bun version

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "remoteCache": {
     "signature": true
   },
+  "globalDependencies": [".bun-version"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Add `.bun-version` to `globalDependencies` in `turbo.json`
- Cache now invalidates when the pinned Bun version changes
- Prevents cross-version cache poisoning when switching between Bun versions

## Test plan

- [x] `turbo build --dry-run=json` shows `.bun-version` in `globalCacheInputs`
- [x] `bun run verify:ci`

Closes OS-370

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `.bun-version` to Turbo's `globalDependencies` to prevent cache poisoning when switching Bun versions. This ensures the cache invalidates whenever the pinned Bun version changes, which is critical for a Bun-first monorepo where runtime version affects build outputs.

- Correctly targets the root `.bun-version` file used by CI workflows
- Aligns with existing version consistency checks in `scripts/check-preset-dependency-versions.ts`
- Minimal, focused change with clear benefit

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line configuration change with clear purpose and no side effects. The change correctly references an existing file (`.bun-version`) that is already used throughout the project. Test plan confirms the expected behavior.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| turbo.json | Added `.bun-version` to `globalDependencies` to invalidate cache when Bun version changes |

</details>


</details>


<sub>Last reviewed commit: 2bbde5c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->