### PR TITLE
fix: move root dependencies to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,26 +4,24 @@
   "workspaces": {
     "": {
       "name": "outfitter",
-      "dependencies": {
-        "@clack/prompts": "^1.0.1",
-        "@types/node": "^25.3.0",
-        "smol-toml": "^1.6.0",
-        "yaml": "^2.8.2",
-        "zod": "^4.3.5",
-      },
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
+        "@clack/prompts": "^1.0.1",
         "@outfitter/presets": "workspace:*",
+        "@types/node": "^25.3.0",
         "bunup": "^0.16.29",
         "lefthook": "^2.1.1",
         "oxfmt": "0.35.0",
         "oxlint": "1.50.0",
+        "smol-toml": "^1.6.0",
         "turbo": "^2.8.10",
         "typedoc": "^0.28.17",
         "typedoc-plugin-coverage": "^4.0.2",
         "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^5.9.3",
         "ultracite": "7.2.3",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.5",
       },
     },
     "apps/cli-demo": {

--- a/package.json
+++ b/package.json
@@ -54,26 +54,24 @@
     "publish:rc": "bun run scripts/publish-rc.ts",
     "prepare": "lefthook install"
   },
-  "dependencies": {
-    "@clack/prompts": "^1.0.1",
-    "@types/node": "^25.3.0",
-    "smol-toml": "^1.6.0",
-    "yaml": "^2.8.2",
-    "zod": "^4.3.5"
-  },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
+    "@clack/prompts": "^1.0.1",
     "@outfitter/presets": "workspace:*",
+    "@types/node": "^25.3.0",
     "bunup": "^0.16.29",
     "lefthook": "^2.1.1",
     "oxfmt": "0.35.0",
     "oxlint": "1.50.0",
+    "smol-toml": "^1.6.0",
     "turbo": "^2.8.10",
     "typedoc": "^0.28.17",
     "typedoc-plugin-coverage": "^4.0.2",
     "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^5.9.3",
-    "ultracite": "7.2.3"
+    "ultracite": "7.2.3",
+    "yaml": "^2.8.2",
+    "zod": "^4.3.5"
   },
   "engines": {
     "bun": ">=1.3.9",


### PR DESCRIPTION
## Summary

Move 5 packages from `dependencies` to `devDependencies` in root `package.json`:
- `@clack/prompts`, `@types/node`, `smol-toml`, `yaml`, `zod`

Root is `private: true` — this is purely semantic. Clarifies these are build/dev tools, not runtime exports.

Closes OS-404.

## Test plan

- [x] `bun install` — lockfile updated cleanly
- [x] `bun run check` — 0 lint errors
- [x] `bun run test` — 40/40 tasks pass

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)