### PR TITLE
feat(tooling): add Bun version guard to pre-push hook

### DIFF
--- a/packages/tooling/src/cli/pre-push.ts
+++ b/packages/tooling/src/cli/pre-push.ts
@@ -418,6 +418,36 @@ function runScript(scriptName: string): boolean {
   return result.exitCode === 0;
 }
 
+export interface BunVersionCheckResult {
+  readonly matches: boolean;
+  readonly expected?: string;
+  readonly actual?: string;
+}
+
+/**
+ * Check that the local Bun version matches the pinned version in ".bun-version".
+ *
+ * @param projectRoot - Directory containing ".bun-version" (defaults to cwd)
+ * @returns Result indicating whether versions match
+ */
+export function checkBunVersion(
+  projectRoot: string = process.cwd()
+): BunVersionCheckResult {
+  const versionFile = join(projectRoot, ".bun-version");
+  if (!existsSync(versionFile)) {
+    return { matches: true };
+  }
+
+  const expected = readFileSync(versionFile, "utf-8").trim();
+  const actual = Bun.version;
+
+  if (expected === actual) {
+    return { matches: true };
+  }
+
+  return { matches: false, expected, actual };
+}
+
 export interface PrePushOptions {
   force?: boolean;
 }
@@ -428,6 +458,14 @@ export interface PrePushOptions {
 export async function runPrePush(options: PrePushOptions = {}): Promise<void> {
   log(`${COLORS.blue}Pre-push verify${COLORS.reset} (TDD-aware)`);
   log("");
+
+  const versionCheck = checkBunVersion();
+  if (!versionCheck.matches) {
+    log(
+      `${COLORS.yellow}Bun version mismatch${COLORS.reset}: expected ${versionCheck.expected} (from .bun-version), running ${versionCheck.actual}`
+    );
+    log("");
+  }
 
   const branch = getCurrentBranch();
 


### PR DESCRIPTION
## Summary

Add a Bun version guard to the pre-push hook. Reads `.bun-version` and compares against `Bun.version`. On mismatch, prints a yellow warning but does not block the push.

- New `checkBunVersion()` function in `packages/tooling/src/cli/pre-push.ts`
- 4 new tests: match, mismatch, missing file, whitespace trimming
- Gracefully skips if `.bun-version` is missing

Closes OS-371.

## Test plan

- [x] `cd packages/tooling && bun test` — 259 tests pass (4 new)
- [x] `bun run check` — 0 lint errors
- [x] `bun run typecheck` — clean

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)