### PR TITLE
feat: add --check flag to normalize-exports.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "check-boundary-invocations": "bun run apps/outfitter/src/commands/repo.ts check boundary-invocations --cwd .",
     "check-canonical-surface-map": "if git ls-files --error-unmatch 'apps/outfitter/.outfitter/surface.json' >/dev/null 2>&1; then echo \"apps/outfitter/.outfitter/surface.json must not be tracked. Canonical surface map is .outfitter/surface.json.\" && exit 1; fi",
     "check-surface-map-format": "bun run scripts/check-surface-map-format.ts",
+    "exports:check": "bun scripts/normalize-exports.ts --check",
     "schema:diff": "bun run apps/outfitter/src/cli.ts schema diff",
     "docs:check:links": "bun run apps/outfitter/src/commands/repo.ts check markdown-links --cwd .",
     "build": "bunup && bun scripts/normalize-exports.ts",

--- a/scripts/normalize-exports.ts
+++ b/scripts/normalize-exports.ts
@@ -139,7 +139,24 @@ export async function normalizeWorkspaceExports(
 }
 
 async function main(): Promise<void> {
-  const result = await normalizeWorkspaceExports();
+  const check = Bun.argv.includes("--check");
+  const result = await normalizeWorkspaceExports({ write: !check });
+
+  if (check) {
+    if (result.changedPackages.length > 0) {
+      console.error(
+        `[normalize-exports] Export ordering drift in ${result.changedPackages.length} package(s):`
+      );
+      for (const pkg of result.changedPackages) {
+        console.error(`  - ${pkg}`);
+      }
+      console.error("\nRun `bun scripts/normalize-exports.ts` to fix.");
+      process.exit(1);
+    }
+    console.log("[normalize-exports] All exports are normalized.");
+    return;
+  }
+
   if (result.changedPackages.length > 0) {
     console.log(
       `[normalize-exports] Sorted exports in ${result.changedPackages.length} package(s)`


### PR DESCRIPTION
## Summary

Add `--check` flag to `scripts/normalize-exports.ts`. When passed, runs in dry-run mode (`write: false`) and exits non-zero if any packages have export ordering drift.

- Parses `--check` from CLI args
- Lists affected packages to stderr on drift
- Adds `exports:check` convenience script in root `package.json`

Closes OS-403.

## Test plan

- [x] `bun scripts/normalize-exports.ts --check` — exits 0 (exports in sync)
- [x] `bun run exports:check` — convenience alias works
- [x] `bun run check` — lint clean
- [x] `bun run test` — all passing

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)