### PR TITLE
fix: narrow pre-commit typecheck to affected packages

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -11,9 +11,9 @@ pre-commit:
 
     typecheck:
       glob: "*.{ts,tsx}"
-      # Avoid turbo dependency fan-out (^build) in commit hooks, which can
-      # trigger bunup export rewrites and leave unstaged package.json drift.
-      run: bun run typecheck -- --only
+      # Only typecheck packages that have staged .ts/.tsx files, rather than
+      # running turbo typecheck across all 20+ packages on every commit.
+      run: ./scripts/pre-commit-typecheck.sh {staged_files}
 
     check-exports:
       glob: "*.{ts,tsx}"

--- a/scripts/pre-commit-typecheck.sh
+++ b/scripts/pre-commit-typecheck.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# pre-commit-typecheck.sh
+# Runs turbo typecheck only on packages that contain staged .ts/.tsx files.
+# Called by lefthook with staged file paths as arguments.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Collect unique workspace directories from staged file paths.
+# Workspace roots: packages/*, apps/*, plugins/*
+# Uses a string-based dedup approach (Bash 3-compatible, no associative arrays).
+seen_dirs=""
+filters=()
+
+for file in "$@"; do
+  # Match workspace patterns: packages/<name>/..., apps/<name>/..., plugins/<name>/...
+  if [[ "$file" =~ ^(packages|apps|plugins)/([^/]+)/ ]]; then
+    ws_dir="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+
+    # Skip already-seen directories
+    case "$seen_dirs" in
+      *"|$ws_dir|"*) continue ;;
+    esac
+    seen_dirs="${seen_dirs}|${ws_dir}|"
+
+    # Read the package name from package.json
+    pkg_json="$ROOT_DIR/$ws_dir/package.json"
+    if [[ -f "$pkg_json" ]]; then
+      pkg_name=$(bun -e "console.log(JSON.parse(await Bun.file('$pkg_json').text()).name)")
+      if [[ -n "$pkg_name" ]]; then
+        filters+=("--filter=$pkg_name")
+      fi
+    fi
+  fi
+done
+
+if [[ ${#filters[@]} -eq 0 ]]; then
+  # No workspace files staged (root-level .ts files, etc.) — fall back to full typecheck
+  echo "[typecheck] No workspace packages detected, running full typecheck"
+  exec bun run typecheck -- --only
+fi
+
+echo "[typecheck] Checking: ${filters[*]}"
+exec turbo run typecheck --no-daemon --only "${filters[@]}"


### PR DESCRIPTION
## Summary

Narrow the pre-commit typecheck hook to only check affected packages instead of all 20+ packages.

- New `scripts/pre-commit-typecheck.sh` extracts workspace package names from staged file paths
- Runs `turbo run typecheck --no-daemon --only --filter=<pkg>` for only affected packages
- Falls back to full typecheck for root-level `.ts` files
- Supports all workspace patterns: `packages/*`, `apps/*`, `plugins/*`

Closes OS-402.

## Test plan

- [x] Single package file → scoped to that package only
- [x] Multiple package files → scoped to affected packages
- [x] Root-level file → falls back to full typecheck
- [x] `bun run check` — lint clean

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)