### PR TITLE
fix: move root dependencies to devDependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,26 +4,24 @@
   "workspaces": {
     "": {
       "name": "outfitter",
-      "dependencies": {
-        "@clack/prompts": "^1.0.1",
-        "@types/node": "^25.3.0",
-        "smol-toml": "^1.6.0",
-        "yaml": "^2.8.2",
-        "zod": "^4.3.5",
-      },
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
+        "@clack/prompts": "^1.0.1",
         "@outfitter/presets": "workspace:*",
+        "@types/node": "^25.3.0",
         "bunup": "^0.16.29",
         "lefthook": "^2.1.1",
         "oxfmt": "0.35.0",
         "oxlint": "1.50.0",
+        "smol-toml": "^1.6.0",
         "turbo": "^2.8.10",
         "typedoc": "^0.28.17",
         "typedoc-plugin-coverage": "^4.0.2",
         "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^5.9.3",
         "ultracite": "7.2.3",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.5",
       },
     },
     "apps/cli-demo": {

--- a/package.json
+++ b/package.json
@@ -56,26 +56,24 @@
     "publish:rc": "bun run scripts/publish-rc.ts",
     "prepare": "lefthook install"
   },
-  "dependencies": {
-    "@clack/prompts": "^1.0.1",
-    "@types/node": "^25.3.0",
-    "smol-toml": "^1.6.0",
-    "yaml": "^2.8.2",
-    "zod": "^4.3.5"
-  },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
+    "@clack/prompts": "^1.0.1",
     "@outfitter/presets": "workspace:*",
+    "@types/node": "^25.3.0",
     "bunup": "^0.16.29",
     "lefthook": "^2.1.1",
     "oxfmt": "0.35.0",
     "oxlint": "1.50.0",
+    "smol-toml": "^1.6.0",
     "turbo": "^2.8.10",
     "typedoc": "^0.28.17",
     "typedoc-plugin-coverage": "^4.0.2",
     "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "^5.9.3",
-    "ultracite": "7.2.3"
+    "ultracite": "7.2.3",
+    "yaml": "^2.8.2",
+    "zod": "^4.3.5"
   },
   "engines": {
     "bun": ">=1.3.9",


### PR DESCRIPTION
## Context
Linear: OS-404

The repository root package is private and primarily a workspace/tooling orchestrator. Dependencies listed at root should reflect development/build usage, not published runtime surface.

## What Changed
- Moved the following packages from root `dependencies` to root `devDependencies` in `package.json`:
  - `@clack/prompts`
  - `@types/node`
  - `smol-toml`
  - `yaml`
  - `zod`
- Updated `bun.lock` accordingly.

## Why
- Clarifies dependency intent and aligns with root package semantics.
- No change to application/runtime behavior for published artifacts.

## Validation
- Included in stack submit verification (`verify:ci`) and passing checks.

## Risk / Rollout
- Low risk: dependency metadata classification only.
