### PR TITLE
chore(tooling): remove lingering biome references

### DIFF
--- a/packages/tooling/scripts/__tests__/sync-exports.test.ts
+++ b/packages/tooling/scripts/__tests__/sync-exports.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "bun:test";
 import { buildSyncedExports, shortAlias, sortExports } from "../sync-exports";
 
 describe("shortAlias", () => {
-  test("biome.json returns biome", () => {
-    expect(shortAlias("biome.json")).toBe("biome");
+  test(".oxlintrc.json returns .oxlintrc", () => {
+    expect(shortAlias(".oxlintrc.json")).toBe(".oxlintrc");
   });
 
   test("tsconfig.preset.json returns tsconfig", () => {
@@ -45,7 +45,7 @@ describe("buildSyncedExports", () => {
     const synced = buildSyncedExports({
       files: [
         "dist",
-        "biome.json",
+        ".oxlintrc.json",
         "tsconfig.preset.json",
         "tsconfig.preset.bun.json",
         "lefthook.yml",
@@ -58,8 +58,8 @@ describe("buildSyncedExports", () => {
             default: "./dist/cli/check.js",
           },
         },
-        "./biome": "./stale.json",
-        "./biome.json": "./stale.json",
+        "./.oxlintrc": "./stale.json",
+        "./.oxlintrc.json": "./stale.json",
         "./tsconfig": "./stale.json",
         "./tsconfig.preset.json": "./stale.json",
         "./package.json": "./package.json",
@@ -72,8 +72,8 @@ describe("buildSyncedExports", () => {
       },
     });
 
-    expect(synced["./biome"]).toBe("./biome.json");
-    expect(synced["./biome.json"]).toBe("./biome.json");
+    expect(synced["./.oxlintrc"]).toBe("./.oxlintrc.json");
+    expect(synced["./.oxlintrc.json"]).toBe("./.oxlintrc.json");
     expect(synced["./tsconfig"]).toBe("./tsconfig.preset.json");
     expect(synced["./tsconfig.preset.json"]).toBe("./tsconfig.preset.json");
     expect(synced["./tsconfig-bun"]).toBe("./tsconfig.preset.bun.json");
@@ -83,8 +83,8 @@ describe("buildSyncedExports", () => {
       ".",
       "./.markdownlint-cli2",
       "./.markdownlint-cli2.jsonc",
-      "./biome",
-      "./biome.json",
+      "./.oxlintrc",
+      "./.oxlintrc.json",
       "./cli/check",
       "./lefthook",
       "./lefthook.yml",

--- a/packages/tooling/scripts/sync-exports.ts
+++ b/packages/tooling/scripts/sync-exports.ts
@@ -6,7 +6,7 @@
  * gets two exports: the full filename and an extensionless short alias.
  *
  * Short alias rules:
- *   biome.json               → ./biome
+ *   .oxlintrc.json           → ./.oxlintrc
  *   tsconfig.preset.json     → ./tsconfig
  *   tsconfig.preset.bun.json → ./tsconfig-bun
  *   lefthook.yml             → ./lefthook

--- a/packages/tooling/src/__tests__/check-exports.test.ts
+++ b/packages/tooling/src/__tests__/check-exports.test.ts
@@ -181,11 +181,11 @@ describe("compareExports", () => {
   test("treats string export values correctly", () => {
     const actual: ExportMap = {
       "./package.json": "./package.json",
-      "./biome": "./biome.json",
+      "./lefthook": "./lefthook.yml",
     };
     const expected: ExportMap = {
       "./package.json": "./package.json",
-      "./biome": "./biome.json",
+      "./lefthook": "./lefthook.yml",
     };
 
     const result = compareExports({

--- a/packages/tooling/src/__tests__/pre-push.test.ts
+++ b/packages/tooling/src/__tests__/pre-push.test.ts
@@ -76,7 +76,7 @@ describe("createVerificationPlan", () => {
   test("uses lint in fallback when check is missing", () => {
     const plan = createVerificationPlan({
       typecheck: "tsc --noEmit",
-      lint: "biome check .",
+      lint: "oxlint .",
       build: "bun build src/index.ts",
       test: "bun test",
     });

--- a/packages/tooling/src/__tests__/registry.test.ts
+++ b/packages/tooling/src/__tests__/registry.test.ts
@@ -58,9 +58,9 @@ describe("BlockSchema", () => {
 
   test("validates block with dependencies", () => {
     const block = {
-      name: "biome",
-      description: "Biome configuration",
-      files: [{ path: "biome.json", content: "{}" }],
+      name: "linter",
+      description: "Linter configuration",
+      files: [{ path: ".oxlintrc.json", content: "{}" }],
       devDependencies: {
         ultracite: "^7.0.0",
       },
@@ -73,7 +73,7 @@ describe("BlockSchema", () => {
     const block = {
       name: "scaffolding",
       description: "Full starter kit",
-      extends: ["claude", "biome", "lefthook", "bootstrap"],
+      extends: ["claude", "linter", "lefthook", "bootstrap"],
     };
     const result = BlockSchema.parse(block);
     expect(result.extends).toHaveLength(4);
@@ -91,16 +91,16 @@ describe("RegistrySchema", () => {
           description: "Claude Code settings",
           files: [{ path: ".claude/settings.json", content: "{}" }],
         },
-        biome: {
-          name: "biome",
-          description: "Biome configuration",
-          files: [{ path: "biome.json", content: "{}" }],
+        linter: {
+          name: "linter",
+          description: "Linter configuration",
+          files: [{ path: ".oxlintrc.json", content: "{}" }],
           devDependencies: { ultracite: "^7.0.0" },
         },
         scaffolding: {
           name: "scaffolding",
           description: "Full starter kit",
-          extends: ["claude", "biome"],
+          extends: ["claude", "linter"],
         },
       },
     };


### PR DESCRIPTION
## Summary

Remove lingering biome references from `@outfitter/tooling` after the oxlint migration. The linter was swapped from biome to oxlint in an earlier phase, but test fixtures, code comments, and export-sync examples still referenced biome.

- Update `sync-exports` test fixtures: `biome.json` → `.oxlintrc.json` in alias and export map tests
- Update `sync-exports.ts` doc comment examples to reflect oxlint config filenames
- Update `check-exports` test to use `lefthook` instead of `biome` as a string export example
- Update `pre-push` and `registry` tests to reference oxlint instead of biome

## Test plan

- [x] `bun test --filter=@outfitter/tooling` — all updated fixtures pass
- [x] No remaining biome references in tooling package source or tests

Closes: OS-414