### PR TITLE
feat(tooling): wire oxlint plugin into linter scaffolding

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,11 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": [
+    {
+      "name": "outfitter",
+      "specifier": "@outfitter/oxlint-plugin"
+    }
+  ],
   "globals": { "Bun": "readonly" },
   "categories": {
     "correctness": "error",
@@ -26,6 +32,20 @@
     "no-unused-vars": "off",
     "no-unsafe-optional-chaining": "off",
     "no-void": "off",
+    "outfitter/action-must-register": "warn",
+    "outfitter/handler-must-return-result": "error",
+    "outfitter/max-file-lines": ["warn", { "warn": 200, "error": 400 }],
+    "outfitter/no-console-in-packages": "error",
+    "outfitter/no-cross-tier-import": "error",
+    "outfitter/no-deep-relative-import": "warn",
+    "outfitter/no-nested-barrel": "warn",
+    "outfitter/no-process-env-in-packages": "warn",
+    "outfitter/no-process-exit-in-packages": "error",
+    "outfitter/no-throw-in-handler": "warn",
+    "outfitter/prefer-bun-api": "warn",
+    "outfitter/snapshot-location": "warn",
+    "outfitter/test-file-naming": "warn",
+    "outfitter/use-error-taxonomy": "warn",
     "preserve-caught-error": "off",
     "require-await": "off",
     "typescript/require-await": "off"

--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -316,6 +316,7 @@
     "@outfitter/docs": "workspace:*",
     "@outfitter/logging": "workspace:*",
     "@outfitter/mcp": "workspace:*",
+    "@outfitter/oxlint-plugin": "workspace:*",
     "@outfitter/presets": "workspace:*",
     "@outfitter/tooling": "workspace:*",
     "@outfitter/tui": "workspace:*",

--- a/apps/outfitter/src/__tests__/add.test.ts
+++ b/apps/outfitter/src/__tests__/add.test.ts
@@ -71,6 +71,9 @@ describe("runAdd", () => {
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.created).toContain(".oxlintrc.json");
+      expect(result.value.devDependencies["@outfitter/oxlint-plugin"]).toMatch(
+        /^\^\d+\.\d+\.\d+$/
+      );
       expect(result.value.devDependencies.ultracite).toBe(
         resolvedVersions["ultracite"]
       );
@@ -79,6 +82,9 @@ describe("runAdd", () => {
     // Verify package.json was updated
     const pkgContent = readFileSync(join(testDir, "package.json"), "utf-8");
     const pkg = JSON.parse(pkgContent);
+    expect(pkg.devDependencies?.["@outfitter/oxlint-plugin"]).toMatch(
+      /^\^\d+\.\d+\.\d+$/
+    );
     expect(pkg.devDependencies?.ultracite).toBe(resolvedVersions["ultracite"]);
   });
 
@@ -96,6 +102,9 @@ describe("runAdd", () => {
       expect(result.value.created.length).toBeGreaterThanOrEqual(4);
       expect(result.value.devDependencies.ultracite).toBe(
         resolvedVersions["ultracite"]
+      );
+      expect(result.value.devDependencies["@outfitter/oxlint-plugin"]).toMatch(
+        /^\^\d+\.\d+\.\d+$/
       );
       expect(result.value.devDependencies.lefthook).toBe(
         resolvedVersions["lefthook"]

--- a/apps/outfitter/src/__tests__/init.test.ts
+++ b/apps/outfitter/src/__tests__/init.test.ts
@@ -175,6 +175,9 @@ describe("init command file creation", () => {
 
     const packageJsonPath = join(tempDir, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+    expect(packageJson.devDependencies["@outfitter/oxlint-plugin"]).toBe(
+      workspaceVersion("@outfitter/oxlint-plugin")
+    );
     expect(packageJson.devDependencies["@outfitter/tooling"]).toBe(
       workspaceVersion("@outfitter/tooling")
     );

--- a/apps/outfitter/src/__tests__/scaffold.test.ts
+++ b/apps/outfitter/src/__tests__/scaffold.test.ts
@@ -272,6 +272,9 @@ describe("scaffold command", () => {
       workspaceVersion("@outfitter/logging")
     );
     expect(packageJson.dependencies.commander).toBe("^14.0.2");
+    expect(packageJson.devDependencies["@outfitter/oxlint-plugin"]).toBe(
+      workspaceVersion("@outfitter/oxlint-plugin")
+    );
     expect(packageJson.devDependencies["@outfitter/tooling"]).toBe(
       workspaceVersion("@outfitter/tooling")
     );

--- a/apps/outfitter/src/commands/shared-deps.ts
+++ b/apps/outfitter/src/commands/shared-deps.ts
@@ -42,6 +42,9 @@ function requireInternalVersion(name: string): string {
  * Internal @outfitter/* versions come from workspace scanning.
  */
 export const SHARED_DEV_DEPS: Readonly<Record<string, string>> = {
+  "@outfitter/oxlint-plugin": requireInternalVersion(
+    "@outfitter/oxlint-plugin"
+  ),
   "@outfitter/tooling": requireInternalVersion("@outfitter/tooling"),
   "@types/bun": requireVersion("@types/bun"),
   lefthook: requireVersion("lefthook"),

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
         "@clack/prompts": "^1.0.1",
+        "@outfitter/oxlint-plugin": "workspace:*",
         "@outfitter/presets": "workspace:*",
         "@types/node": "^25.3.0",
         "bunup": "^0.16.29",
@@ -48,8 +49,8 @@
       "name": "outfitter",
       "version": "0.3.2",
       "bin": {
-        "outfitter": "./dist/cli.js",
         "out": "./dist/cli.js",
+        "outfitter": "./dist/cli.js",
       },
       "dependencies": {
         "@clack/prompts": "catalog:",
@@ -60,6 +61,7 @@
         "@outfitter/docs": "workspace:*",
         "@outfitter/logging": "workspace:*",
         "@outfitter/mcp": "workspace:*",
+        "@outfitter/oxlint-plugin": "workspace:*",
         "@outfitter/presets": "workspace:*",
         "@outfitter/tooling": "workspace:*",
         "@outfitter/tui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "@clack/prompts": "^1.0.1",
+    "@outfitter/oxlint-plugin": "workspace:*",
     "@outfitter/presets": "workspace:*",
     "@types/node": "^25.3.0",
     "bunup": "^0.16.29",

--- a/packages/tooling/configs/.oxlintrc.json
+++ b/packages/tooling/configs/.oxlintrc.json
@@ -1,6 +1,12 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["eslint"],
+  "jsPlugins": [
+    {
+      "name": "outfitter",
+      "specifier": "@outfitter/oxlint-plugin"
+    }
+  ],
   "globals": { "Bun": "readonly" },
   "categories": {
     "correctness": "error",
@@ -17,6 +23,20 @@
     "**/*.gen.ts"
   ],
   "rules": {
-    "no-void": "off"
+    "no-void": "off",
+    "outfitter/action-must-register": "warn",
+    "outfitter/handler-must-return-result": "error",
+    "outfitter/max-file-lines": ["error", { "warn": 200, "error": 400 }],
+    "outfitter/no-console-in-packages": "error",
+    "outfitter/no-cross-tier-import": "error",
+    "outfitter/no-deep-relative-import": "warn",
+    "outfitter/no-nested-barrel": "warn",
+    "outfitter/no-process-env-in-packages": "warn",
+    "outfitter/no-process-exit-in-packages": "error",
+    "outfitter/no-throw-in-handler": "error",
+    "outfitter/prefer-bun-api": "warn",
+    "outfitter/snapshot-location": "warn",
+    "outfitter/test-file-naming": "warn",
+    "outfitter/use-error-taxonomy": "warn"
   }
 }

--- a/packages/tooling/src/__tests__/oxlint-plugin-integration.test.ts
+++ b/packages/tooling/src/__tests__/oxlint-plugin-integration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const decoder = new TextDecoder();
+
+describe("oxlint plugin integration", () => {
+  test("loads @outfitter/oxlint-plugin from tooling config", () => {
+    const repoRoot = join(import.meta.dirname, "../../../..");
+    const fixtureDir = join(
+      repoRoot,
+      "packages",
+      `.tmp-oxlint-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    const fixtureSource = join(fixtureDir, "src", "index.ts");
+    const configPath = join(
+      repoRoot,
+      "packages/tooling/configs/.oxlintrc.json"
+    );
+
+    mkdirSync(join(fixtureDir, "src"), { recursive: true });
+    writeFileSync(fixtureSource, "console.log('lint me');\n");
+
+    try {
+      const result = Bun.spawnSync(
+        ["bun", "x", "oxlint", "--config", configPath, fixtureSource],
+        {
+          cwd: repoRoot,
+          stderr: "pipe",
+          stdout: "pipe",
+        }
+      );
+
+      const output = [
+        decoder.decode(result.stdout).trim(),
+        decoder.decode(result.stderr).trim(),
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      expect(result.exitCode).not.toBe(0);
+      expect(output).toMatch(
+        /outfitter\(no-console-in-packages\)|outfitter\/no-console-in-packages/
+      );
+      expect(output).not.toContain("Failed to load JS plugin");
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/tooling/src/__tests__/registry-build.test.ts
+++ b/packages/tooling/src/__tests__/registry-build.test.ts
@@ -132,4 +132,13 @@ describe("Registry Build Output", () => {
     expect(version).toBeDefined();
     expect(version).toMatch(/^\^\d+\.\d+\.\d+$/);
   });
+
+  test("linter block includes the oxlint plugin dependency", () => {
+    const version =
+      REGISTRY_CONFIG.blocks.linter?.devDependencies?.[
+        "@outfitter/oxlint-plugin"
+      ];
+    expect(version).toBeDefined();
+    expect(version).toMatch(/^\^\d+\.\d+\.\d+$/);
+  });
 });


### PR DESCRIPTION
## Summary

Wire the custom `@outfitter/oxlint-plugin` (JS plugin API rules for architecture, safety, and hygiene) into the `@outfitter/tooling` linter scaffolding pipeline so it activates automatically in scaffolded projects.

- Add `@outfitter/oxlint-plugin` as a workspace dependency for `apps/outfitter`
- Update root `.oxlintrc.json` and `packages/tooling/configs/.oxlintrc.json` to load the plugin
- Add integration test in `@outfitter/tooling` validating the plugin loads and rules fire
- Update registry build test to include plugin in expected output
- Fix test fixtures in `apps/outfitter` that were affected by new lint rules

## Test plan

- [x] `bun test --filter=@outfitter/tooling` — integration test validates plugin wiring and rule activation
- [x] `bun run lint` passes workspace-wide with plugin active (0 errors)
- [x] Scaffold output includes oxlint plugin reference

Closes: OS-400