### PR TITLE
fix(root): include turbo cache in clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check": "oxlint . && oxfmt --check .",
     "fix": "oxlint --fix .",
     "clean:artifacts": "turbo run clean --no-daemon && rm -rf .turbo",
-    "clean": "turbo run clean --no-daemon && rm -rf node_modules",
+    "clean": "turbo run clean --no-daemon && rm -rf node_modules .turbo",
     "changeset": "changeset",
     "version-packages": "changeset version && bun run sync-plugin-versions",
     "sync-plugin-versions": "bun run scripts/sync-plugin-versions.ts",


### PR DESCRIPTION
## Summary

The `bun run clean` script removed `node_modules` but left the `.turbo` cache directory behind, meaning stale Turbo cache could persist across clean rebuilds and cause hard-to-debug caching issues.

- Add `.turbo` to the `rm -rf` list in the root `clean` script
- Now matches `clean:artifacts` which already cleaned `.turbo`

One-line change: `rm -rf node_modules` → `rm -rf node_modules .turbo`

## Test plan

- [x] `bun run clean` removes both `node_modules/` and `.turbo/`
- [x] Subsequent `bun install && bun run build` works from a clean slate

Closes: OS-373