### PR TITLE
ci: switch pipeline to build then verify:ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build & Test
+    name: Build & Verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,18 +26,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Verify CI Gate (checks)
-        run: bun run verify:ci:checks
+      - name: Build
+        run: bun run build
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
-          NO_CHANGESET: ${{ contains(github.event.pull_request.labels.*.name, 'release:none') && '1' || '0' }}
 
-      - name: Run Tests
-        run: bun run test || (rc=$?; echo "::warning::Tests exited $rc, retrying..." && bun run test)
+      - name: Verify CI Gate
+        run: bun run verify:ci
         env:
+          NO_CHANGESET: ${{ contains(github.event.pull_request.labels.*.name, 'release:none') && '1' || '0' }}
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}


### PR DESCRIPTION
## Summary

Update the CI workflow to use the new check orchestrator instead of separate verification and test steps. Previously CI ran `verify:ci:checks` (checks only) then `bun run test` with a retry fallback — now it runs `build` first, then `verify:ci` which delegates to `outfitter check --ci` (includes all checks + tests in a single coordinated run with fail-fast and tree-mutation traceability).

### What changed in `ci.yml`

- Rename job from "Build & Test" to "Build & Verify"
- Replace `verify:ci:checks` + separate `test` steps with `build` → `verify:ci`
- Remove test retry hack (`bun run test || ... && bun run test`) — the orchestrator handles failure reporting
- Clean up env var placement (`NO_CHANGESET` moves to the verify step)

## Test plan

- [x] CI workflow YAML is valid and references correct script names
- [x] `bun run build && bun run verify:ci` passes end-to-end locally
- [x] `NO_CHANGESET` label detection still works for PRs with `release:none` label

Closes: OS-410
