### PR TITLE
chore(hooks): migrate lefthook to check orchestrator modes

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -2,33 +2,14 @@
 # https://github.com/evilmartians/lefthook
 
 pre-commit:
-  parallel: true
+  parallel: false
   commands:
-    ultracite:
-      glob: "*.{js,jsx,ts,tsx,json,jsonc,css}"
-      run: bun x ultracite fix {staged_files}
-      stage_fixed: true
-
-    typecheck:
-      glob: "*.{ts,tsx}"
-      # Only typecheck packages that have staged .ts/.tsx files, rather than
-      # running turbo typecheck across all 20+ packages on every commit.
-      run: ./scripts/pre-commit-typecheck.sh {staged_files}
-
-    check-exports:
-      glob: "*.{ts,tsx}"
-      # Keep export drift detection explicit and non-mutating in pre-commit.
-      run: bun run check-exports
-
-    sync-agent-scaffolding:
-      glob: ".claude/{settings.json,hooks/*}"
-      run: ./scripts/sync-agent-scaffolding.sh
+    verify:
+      run: bun run apps/outfitter/src/cli.ts check --pre-commit {staged_files}
       stage_fixed: true
 
 pre-push:
   parallel: false
   commands:
     verify:
-      run: bun run packages/tooling/src/cli/index.ts pre-push
-    schema-drift:
-      run: bun run apps/outfitter/src/cli.ts schema diff
+      run: bun run apps/outfitter/src/cli.ts check --pre-push

--- a/apps/outfitter/src/actions/check.ts
+++ b/apps/outfitter/src/actions/check.ts
@@ -96,8 +96,10 @@ const _checkAction: ActionSpec<CheckActionInput, unknown> = defineAction({
   input: checkInputSchema,
   cli: {
     group: "check",
-    // No `command` — this IS the base "check" command. Omitting `command`
-    // prevents schema from rendering "check check".
+    // Accept optional staged-file args for hook-driven `--pre-commit` mode.
+    // Using an argument-only command spec keeps this as the base `check`
+    // command (without rendering `check check` in schema output).
+    command: "[staged-files...]",
     description:
       "Compare local config blocks against the registry for drift detection",
     options: [


### PR DESCRIPTION
## Summary

Replace individual lefthook hook commands with check orchestrator modes. Previously each hook had its own inline command or script reference — now they delegate to `outfitter check` with the appropriate mode flag, giving hooks the same fail-fast, tree-mutation traceability, and structured output as CI.

### What changed

- **pre-commit**: `bun run apps/outfitter/src/cli.ts check --pre-commit {staged_files}` replaces inline ultracite/typecheck/exports commands
- **pre-push**: `bun run apps/outfitter/src/cli.ts check --pre-push` replaces separate hook-verify and schema-drift commands
- Wire `--pre-commit` and `--pre-push` flags into the `check` action's `mapInput`

### Why this matters

Hooks now share the same check definitions as CI — adding a new check to `all`/`ci` mode automatically includes it in the right hook when appropriate. No more maintaining parallel check lists across `.lefthook.yml` and scripts.

## Test plan

- [x] Pre-commit hook runs orchestrator with staged files (ultracite fix → typecheck for TS files → exports)
- [x] Pre-push hook runs orchestrator (hook verify → schema drift)
- [x] `bun test --filter=outfitter` passes

Closes: OS-411
