### PR TITLE
fix(outfitter): restore check output env fallback semantics

### DIFF
--- a/apps/outfitter/src/__tests__/action-mapinput.test.ts
+++ b/apps/outfitter/src/__tests__/action-mapinput.test.ts
@@ -9,6 +9,19 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { outfitterActions } from "../actions.js";
 
+async function withArgv(
+  argv: readonly string[],
+  run: () => void | Promise<void>
+): Promise<void> {
+  const originalArgv = process.argv;
+  process.argv = [...argv];
+  try {
+    await run();
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // check mapInput
 // ---------------------------------------------------------------------------
@@ -136,26 +149,36 @@ describe("check mapInput", () => {
 
     test("explicit --output human overrides OUTFITTER_JSON=1", () => {
       process.env["OUTFITTER_JSON"] = "1";
-      const action = outfitterActions.get("check");
-      const mapped = action?.cli?.mapInput?.({
-        args: [],
-        flags: { output: "human" },
-      }) as { outputMode: string };
+      return withArgv(
+        ["bun", "outfitter", "check", "--output", "human"],
+        () => {
+          const action = outfitterActions.get("check");
+          const mapped = action?.cli?.mapInput?.({
+            args: [],
+            flags: { output: "human" },
+          }) as { outputMode: string };
 
-      expect(mapped.outputMode).toBe("human");
+          expect(mapped.outputMode).toBe("human");
+        }
+      );
     });
 
     test("explicit --output human overrides OUTFITTER_JSONL=1", () => {
       const previousJsonl = process.env["OUTFITTER_JSONL"];
       process.env["OUTFITTER_JSONL"] = "1";
       try {
-        const action = outfitterActions.get("check");
-        const mapped = action?.cli?.mapInput?.({
-          args: [],
-          flags: { output: "human" },
-        }) as { outputMode: string };
+        return withArgv(
+          ["bun", "outfitter", "check", "--output", "human"],
+          () => {
+            const action = outfitterActions.get("check");
+            const mapped = action?.cli?.mapInput?.({
+              args: [],
+              flags: { output: "human" },
+            }) as { outputMode: string };
 
-        expect(mapped.outputMode).toBe("human");
+            expect(mapped.outputMode).toBe("human");
+          }
+        );
       } finally {
         if (previousJsonl === undefined) {
           delete process.env["OUTFITTER_JSONL"];
@@ -252,13 +275,18 @@ describe("check.tsdoc mapInput", () => {
     process.env["OUTFITTER_JSON"] = "1";
 
     try {
-      const action = outfitterActions.get("check.tsdoc");
-      const mapped = action?.cli?.mapInput?.({
-        args: [],
-        flags: { output: "human" },
-      }) as { outputMode: string };
+      return withArgv(
+        ["bun", "outfitter", "check", "tsdoc", "--output", "human"],
+        () => {
+          const action = outfitterActions.get("check.tsdoc");
+          const mapped = action?.cli?.mapInput?.({
+            args: [],
+            flags: { output: "human" },
+          }) as { outputMode: string };
 
-      expect(mapped.outputMode).toBe("human");
+          expect(mapped.outputMode).toBe("human");
+        }
+      );
     } finally {
       if (previousJson === undefined) {
         delete process.env["OUTFITTER_JSON"];
@@ -273,13 +301,18 @@ describe("check.tsdoc mapInput", () => {
     process.env["OUTFITTER_JSONL"] = "1";
 
     try {
-      const action = outfitterActions.get("check.tsdoc");
-      const mapped = action?.cli?.mapInput?.({
-        args: [],
-        flags: { output: "human" },
-      }) as { outputMode: string };
+      return withArgv(
+        ["bun", "outfitter", "check", "tsdoc", "--output", "human"],
+        () => {
+          const action = outfitterActions.get("check.tsdoc");
+          const mapped = action?.cli?.mapInput?.({
+            args: [],
+            flags: { output: "human" },
+          }) as { outputMode: string };
 
-      expect(mapped.outputMode).toBe("human");
+          expect(mapped.outputMode).toBe("human");
+        }
+      );
     } finally {
       if (previousJsonl === undefined) {
         delete process.env["OUTFITTER_JSONL"];

--- a/apps/outfitter/src/actions/check-automation.ts
+++ b/apps/outfitter/src/actions/check-automation.ts
@@ -40,7 +40,7 @@ import {
   type CliOutputMode,
   resolveStructuredOutputMode,
 } from "../output-mode.js";
-import { outputModeSchema } from "./shared.js";
+import { hasExplicitOutputFlag, outputModeSchema } from "./shared.js";
 
 interface CheckAutomationInput {
   cwd: string;
@@ -61,7 +61,7 @@ function mapCheckAutomationInput(context: {
   const { outputMode: presetOutputMode } = checkAutomationOutput.resolve(
     context.flags
   );
-  const explicitOutput = typeof context.flags["output"] === "string";
+  const explicitOutput = hasExplicitOutputFlag(context.flags);
 
   let outputMode: CliOutputMode;
   if (explicitOutput) {

--- a/apps/outfitter/src/actions/check.ts
+++ b/apps/outfitter/src/actions/check.ts
@@ -30,7 +30,11 @@ import {
   type CliOutputMode,
   resolveStructuredOutputMode,
 } from "../output-mode.js";
-import { outputModeSchema, resolveStringFlag } from "./shared.js";
+import {
+  hasExplicitOutputFlag,
+  outputModeSchema,
+  resolveStringFlag,
+} from "./shared.js";
 
 interface CheckActionInput {
   block?: string;
@@ -136,7 +140,7 @@ const _checkAction: ActionSpec<CheckActionInput, unknown> = defineAction({
       const { outputMode: presetOutputMode } = checkOutputMode.resolve(
         context.flags
       );
-      const explicitOutput = typeof context.flags["output"] === "string";
+      const explicitOutput = hasExplicitOutputFlag(context.flags);
       const block = resolveStringFlag(context.flags["block"]);
       if (mode !== undefined && block !== undefined) {
         throw ValidationError.fromMessage(
@@ -341,7 +345,7 @@ const _checkTsdocAction: ActionSpec<
         context.flags
       );
       const { jq } = checkTsdocJq.resolve(context.flags);
-      const explicitOutput = typeof context.flags["output"] === "string";
+      const explicitOutput = hasExplicitOutputFlag(context.flags);
       let outputMode: CliOutputMode;
       if (explicitOutput) {
         // Explicit --output should always win over env fallbacks.

--- a/apps/outfitter/src/actions/shared.ts
+++ b/apps/outfitter/src/actions/shared.ts
@@ -11,6 +11,45 @@ const _outputModeSchema: z.ZodType<"human" | "json" | "jsonl"> = z
   .default("human");
 export const outputModeSchema: typeof _outputModeSchema = _outputModeSchema;
 
+function argvContainsOutputFlag(argv: readonly string[]): boolean {
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "-o" || arg === "--output") {
+      return true;
+    }
+
+    if (arg.startsWith("--output=") || arg.startsWith("-o=")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function hasExplicitOutputFlag(
+  flags: Record<string, unknown>,
+  options: {
+    readonly argv?: readonly string[];
+    readonly defaultMode?: "human" | "json" | "jsonl";
+  } = {}
+): boolean {
+  const mode = flags["output"];
+  if (typeof mode !== "string") {
+    return false;
+  }
+
+  const defaultMode = options.defaultMode ?? "human";
+  if (mode !== defaultMode) {
+    return true;
+  }
+
+  return argvContainsOutputFlag(options.argv ?? process.argv.slice(2));
+}
+
 export function resolveStringFlag(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Summary

Fix a bug where `OUTFITTER_JSON=1` and `OUTFITTER_JSONL=1` environment variables were silently ignored by all check actions. The env var fallback path was dead code — it never executed because Commander's default value mechanism made the condition unreachable.

### Root cause

Commander sets `flags.output` to the default value `"human"` even when the user doesn't pass `--output` on the command line. The old check was:

```typescript
const explicitOutput = typeof context.flags["output"] === "string";
```

This was always `true` (Commander fills in the default), so the env var fallback branch (`OUTFITTER_JSON` / `OUTFITTER_JSONL`) was unreachable.

### Fix

Add `hasExplicitOutputFlag()` that distinguishes between:
1. **User explicitly passed `--output human`** → honor the explicit flag, skip env fallback
2. **Commander filled in the default `"human"`** → check env vars for fallback

When the flag value matches the default mode, the function checks `process.argv` to determine whether `--output` / `-o` was actually present on the command line. The `options.argv` parameter allows callers to provide custom argv for embedded/test scenarios.

### Affected actions

- `check` (root orchestrator)
- `check.tsdoc`
- All check automation actions (`check.publish-guardrails`, `check.preset-versions`, `check.surface-map`, `check.surface-map-format`, `check.docs-sentinel`)

## Test plan

- [x] `mapInput` tests updated to set `process.argv` via `withArgv()` for env-override scenarios
- [x] Tests verify: explicit `--output human` overrides `OUTFITTER_JSON=1`, and absence of `--output` allows env fallback
- [x] `bun test --filter=outfitter` passes

Closes: OS-417
