### PR TITLE
feat(ci): add explicit Turbo/Bun CI concurrency guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         run: bun run verify:ci
         env:
           NO_CHANGESET: ${{ contains(github.event.pull_request.labels.*.name, 'release:none') && '1' || '0' }}
+          OUTFITTER_CI_TURBO_CONCURRENCY: "2"
+          OUTFITTER_CI_BUN_MAX_CONCURRENCY: "4"
+          OUTFITTER_CI_TURBO_LOG_ORDER: "stream"
+          OUTFITTER_CI_TURBO_OUTPUT_LOGS: "full"
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,10 @@ jobs:
         run: bun run verify:ci
         env:
           NO_CHANGESET: "1"
+          OUTFITTER_CI_TURBO_CONCURRENCY: "2"
+          OUTFITTER_CI_BUN_MAX_CONCURRENCY: "4"
+          OUTFITTER_CI_TURBO_LOG_ORDER: "stream"
+          OUTFITTER_CI_TURBO_OUTPUT_LOGS: "full"
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -118,8 +122,12 @@ jobs:
         run: bun run verify:docs:release:llms
 
       - name: Run Tests
-        run: bun run test || bun run test
+        run: bun run test:ci || bun run test:ci
         env:
+          OUTFITTER_CI_TURBO_CONCURRENCY: "2"
+          OUTFITTER_CI_BUN_MAX_CONCURRENCY: "4"
+          OUTFITTER_CI_TURBO_LOG_ORDER: "stream"
+          OUTFITTER_CI_TURBO_OUTPUT_LOGS: "full"
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ yarn-error.log*
 .scratch/
 tmp/
 temp/
+.outfitter/ci/
 .outfitter/reports/
 apps/outfitter/.outfitter/surface.json
 

--- a/apps/outfitter/src/__tests__/check-orchestrator.test.ts
+++ b/apps/outfitter/src/__tests__/check-orchestrator.test.ts
@@ -81,6 +81,9 @@ describe("buildCheckOrchestratorPlan", () => {
 
     expect(stepIds).toContain("tests");
     expect(stepIds.at(-1)).toBe("tests");
+    expect(plan.find((step) => step.id === "tests")).toMatchObject({
+      command: ["bun", "run", "test:ci"],
+    });
   });
 
   test("pre-push mode runs hook verify and schema drift", () => {

--- a/apps/outfitter/src/commands/check-orchestrator.ts
+++ b/apps/outfitter/src/commands/check-orchestrator.ts
@@ -271,7 +271,7 @@ export function buildCheckOrchestratorPlan(
       steps.push({
         id: "tests",
         label: "Tests",
-        command: ["bun", "run", "test", "--", "--only"],
+        command: ["bun", "run", "test:ci"],
       });
     }
 

--- a/docs/reference/export-contracts.md
+++ b/docs/reference/export-contracts.md
@@ -49,6 +49,12 @@ build -> verify:ci (outfitter check --ci)
 
 `outfitter check --ci` orchestrates typecheck, lint/format checks, docs sentinel/link checks, export/readme/boundary checks, working-tree cleanliness, schema drift, and tests.
 
+The CI test phase uses `bun run test:ci` (via `check --ci`) with explicit concurrency guardrails and diagnostics:
+
+- `OUTFITTER_CI_TURBO_CONCURRENCY` (default `2`) controls Turbo task parallelism.
+- `OUTFITTER_CI_BUN_MAX_CONCURRENCY` (default `4`) is passed to each package test command as Bun `--max-concurrency`.
+- `OUTFITTER_CI_TURBO_LOG_ORDER` (default `stream`) and `OUTFITTER_CI_TURBO_OUTPUT_LOGS` (default `full`) keep active-task logs visible for crash forensics.
+
 This same pipeline runs locally via pre-push hook (`outfitter check --pre-push`) and in CI. Local and CI are always in parity for day-to-day PR verification.
 
 Tracked llms artifacts (`docs/llms.txt`, `docs/llms-full.txt`) are refreshed and validated in the stable release workflow rather than in every PR CI run.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "sync:all": "./scripts/workspace-sync.sh",
     "build": "turbo run build && bun scripts/normalize-exports.ts",
     "test": "turbo run test --no-daemon",
+    "test:ci": "bun run scripts/ci-test-runner.ts",
     "lint": "turbo run lint --no-daemon",
     "format:check": "bun x ultracite check .",
     "format:fix": "bun x ultracite fix .",

--- a/scripts/ci-test-runner.test.ts
+++ b/scripts/ci-test-runner.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildTurboCiTestCommand,
+  resolveCiTestRunnerConfig,
+} from "./ci-test-runner";
+
+describe("resolveCiTestRunnerConfig", () => {
+  test("uses deterministic defaults when no env overrides are set", () => {
+    const config = resolveCiTestRunnerConfig({
+      cwd: "/repo",
+      env: {},
+      now: new Date("2026-02-25T12:00:00.000Z"),
+    });
+
+    expect(config.rootDir).toBe("/repo");
+    expect(config.diagnosticsDir).toBe("/repo/.outfitter/ci");
+    expect(config.turboConcurrency).toBe(2);
+    expect(config.bunMaxConcurrency).toBe(4);
+    expect(config.logOrder).toBe("stream");
+    expect(config.outputLogs).toBe("full");
+    expect(config.runId).toBe("local-20260225T120000000Z");
+  });
+
+  test("accepts CI env overrides and GitHub run metadata", () => {
+    const config = resolveCiTestRunnerConfig({
+      cwd: "/repo",
+      env: {
+        OUTFITTER_CI_TURBO_CONCURRENCY: "1",
+        OUTFITTER_CI_BUN_MAX_CONCURRENCY: "3",
+        OUTFITTER_CI_TURBO_LOG_ORDER: "grouped",
+        OUTFITTER_CI_TURBO_OUTPUT_LOGS: "errors-only",
+        GITHUB_RUN_ID: "42",
+        GITHUB_RUN_ATTEMPT: "3",
+      },
+      now: new Date("2026-02-25T12:00:00.000Z"),
+    });
+
+    expect(config.turboConcurrency).toBe(1);
+    expect(config.bunMaxConcurrency).toBe(3);
+    expect(config.logOrder).toBe("grouped");
+    expect(config.outputLogs).toBe("errors-only");
+    expect(config.runId).toBe("gha-42-3-20260225T120000000Z");
+  });
+});
+
+describe("buildTurboCiTestCommand", () => {
+  test("builds an explicit turbo + bun-concurrency command", () => {
+    const command = buildTurboCiTestCommand({
+      bunMaxConcurrency: 3,
+      logOrder: "grouped",
+      outputLogs: "errors-only",
+      turboConcurrency: 1,
+    });
+
+    expect(command).toEqual([
+      "bun",
+      "x",
+      "turbo",
+      "run",
+      "test",
+      "--no-daemon",
+      "--only",
+      "--concurrency",
+      "1",
+      "--output-logs",
+      "errors-only",
+      "--log-order",
+      "grouped",
+      "--log-prefix",
+      "task",
+      "--summarize",
+      "--",
+      "--max-concurrency",
+      "3",
+    ]);
+  });
+});

--- a/scripts/ci-test-runner.ts
+++ b/scripts/ci-test-runner.ts
@@ -1,0 +1,364 @@
+/**
+ * CI-focused test runner with explicit Turbo/Bun concurrency and diagnostics.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  copyFileSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+type TurboLogOrder = "auto" | "stream" | "grouped";
+type TurboOutputLogs =
+  | "full"
+  | "none"
+  | "hash-only"
+  | "new-only"
+  | "errors-only";
+
+interface ResolveCiTestRunnerConfigOptions {
+  readonly cwd: string;
+  readonly env?: Record<string, string | undefined>;
+  readonly now?: Date;
+}
+
+export interface CiTestRunnerConfig {
+  readonly bunMaxConcurrency: number;
+  readonly diagnosticsDir: string;
+  readonly logOrder: TurboLogOrder;
+  readonly outputLogs: TurboOutputLogs;
+  readonly rootDir: string;
+  readonly runId: string;
+  readonly turboConcurrency: number;
+}
+
+interface TurboCommandOptions {
+  readonly bunMaxConcurrency: number;
+  readonly logOrder: TurboLogOrder;
+  readonly outputLogs: TurboOutputLogs;
+  readonly turboConcurrency: number;
+}
+
+interface CiRunMetadata {
+  readonly $schema: "https://outfitter.dev/reports/ci-tests/v1";
+  readonly artifacts: {
+    readonly log: string;
+    readonly turboSummary: string | null;
+  };
+  readonly command: readonly string[];
+  readonly durationMs: number;
+  readonly environment: {
+    readonly bunMaxConcurrency: number;
+    readonly logOrder: TurboLogOrder;
+    readonly outputLogs: TurboOutputLogs;
+    readonly turboConcurrency: number;
+  };
+  readonly exitCode: number;
+  readonly finishedAt: string;
+  readonly github: {
+    readonly attempt: string | null;
+    readonly runId: string | null;
+    readonly sha: string | null;
+  };
+  readonly runId: string;
+  readonly startedAt: string;
+  readonly status: "failed" | "passed";
+}
+
+const DEFAULT_TURBO_CONCURRENCY = 2;
+const DEFAULT_BUN_MAX_CONCURRENCY = 4;
+const DEFAULT_LOG_ORDER: TurboLogOrder = "stream";
+const DEFAULT_OUTPUT_LOGS: TurboOutputLogs = "full";
+
+function isTurboLogOrder(value: string): value is TurboLogOrder {
+  return value === "auto" || value === "stream" || value === "grouped";
+}
+
+function isTurboOutputLogs(value: string): value is TurboOutputLogs {
+  return (
+    value === "full" ||
+    value === "none" ||
+    value === "hash-only" ||
+    value === "new-only" ||
+    value === "errors-only"
+  );
+}
+
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  minimum = 1
+): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= minimum ? parsed : fallback;
+}
+
+function isoRunStamp(now: Date): string {
+  return now.toISOString().replace(/[-:]/g, "").replace(/\./g, "");
+}
+
+function resolveRunId(
+  env: Record<string, string | undefined>,
+  now: Date
+): string {
+  const explicitRunId = env["OUTFITTER_CI_RUN_ID"];
+  if (explicitRunId && explicitRunId.trim().length > 0) {
+    return explicitRunId.trim();
+  }
+
+  const run = env["GITHUB_RUN_ID"];
+  const attempt = env["GITHUB_RUN_ATTEMPT"];
+  const stamp = isoRunStamp(now);
+  if (run && attempt) {
+    return `gha-${run}-${attempt}-${stamp}`;
+  }
+  return `local-${stamp}`;
+}
+
+export function resolveCiTestRunnerConfig(
+  options: ResolveCiTestRunnerConfigOptions
+): CiTestRunnerConfig {
+  const env = options.env ?? process.env;
+  const now = options.now ?? new Date();
+  const rootDir = resolve(options.cwd);
+  const diagnosticsDir = join(rootDir, ".outfitter", "ci");
+
+  const logOrderRaw = env["OUTFITTER_CI_TURBO_LOG_ORDER"];
+  const outputLogsRaw = env["OUTFITTER_CI_TURBO_OUTPUT_LOGS"];
+
+  return {
+    rootDir,
+    diagnosticsDir,
+    runId: resolveRunId(env, now),
+    turboConcurrency: parsePositiveInt(
+      env["OUTFITTER_CI_TURBO_CONCURRENCY"],
+      DEFAULT_TURBO_CONCURRENCY
+    ),
+    bunMaxConcurrency: parsePositiveInt(
+      env["OUTFITTER_CI_BUN_MAX_CONCURRENCY"],
+      DEFAULT_BUN_MAX_CONCURRENCY
+    ),
+    logOrder:
+      logOrderRaw && isTurboLogOrder(logOrderRaw)
+        ? logOrderRaw
+        : DEFAULT_LOG_ORDER,
+    outputLogs:
+      outputLogsRaw && isTurboOutputLogs(outputLogsRaw)
+        ? outputLogsRaw
+        : DEFAULT_OUTPUT_LOGS,
+  };
+}
+
+export function buildTurboCiTestCommand(
+  options: TurboCommandOptions
+): readonly string[] {
+  return [
+    "bun",
+    "x",
+    "turbo",
+    "run",
+    "test",
+    "--no-daemon",
+    "--only",
+    "--concurrency",
+    String(options.turboConcurrency),
+    "--output-logs",
+    options.outputLogs,
+    "--log-order",
+    options.logOrder,
+    "--log-prefix",
+    "task",
+    "--summarize",
+    "--",
+    "--max-concurrency",
+    String(options.bunMaxConcurrency),
+  ];
+}
+
+function listTurboRunSummaries(rootDir: string): string[] {
+  const runsDir = join(rootDir, ".turbo", "runs");
+  if (!existsSync(runsDir)) {
+    return [];
+  }
+  return readdirSync(runsDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => join(runsDir, file));
+}
+
+function findNewestPath(paths: readonly string[]): string | undefined {
+  if (paths.length === 0) return undefined;
+  return [...paths].toSorted(
+    (a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs
+  )[0];
+}
+
+function findNewTurboSummary(
+  rootDir: string,
+  beforeRun: ReadonlySet<string>
+): string | undefined {
+  const afterRun = listTurboRunSummaries(rootDir);
+  const fresh = afterRun.filter((path) => !beforeRun.has(path));
+  if (fresh.length > 0) {
+    return findNewestPath(fresh);
+  }
+  return findNewestPath(afterRun);
+}
+
+function writeMetadata(path: string, metadata: CiRunMetadata): void {
+  writeFileSync(path, `${JSON.stringify(metadata, null, 2)}\n`, "utf-8");
+}
+
+async function mirrorStreamToOutputs(
+  stream: ReadableStream<Uint8Array> | null,
+  destination: NodeJS.WriteStream,
+  logSink: ReturnType<typeof createWriteStream>
+): Promise<void> {
+  if (!stream) return;
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      destination.write(value);
+      logSink.write(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function logStart(
+  config: CiTestRunnerConfig,
+  command: readonly string[]
+): void {
+  process.stdout.write(
+    [
+      "[ci-test-runner] Starting CI test run",
+      `[ci-test-runner] runId=${config.runId}`,
+      `[ci-test-runner] turboConcurrency=${config.turboConcurrency}`,
+      `[ci-test-runner] bunMaxConcurrency=${config.bunMaxConcurrency}`,
+      `[ci-test-runner] turboLogOrder=${config.logOrder}`,
+      `[ci-test-runner] turboOutputLogs=${config.outputLogs}`,
+      `[ci-test-runner] command=${command.join(" ")}`,
+    ].join("\n") + "\n"
+  );
+}
+
+export async function runCiTests(config: CiTestRunnerConfig): Promise<{
+  readonly exitCode: number;
+  readonly logPath: string;
+  readonly metadataPath: string;
+  readonly summaryArtifactPath: string | null;
+}> {
+  mkdirSync(config.diagnosticsDir, { recursive: true });
+
+  const command = buildTurboCiTestCommand(config);
+  const startedAt = new Date();
+  const startedAtMs = Date.now();
+  const beforeRun = new Set(listTurboRunSummaries(config.rootDir));
+
+  const logPath = join(config.diagnosticsDir, `test-run-${config.runId}.log`);
+  const metadataPath = join(
+    config.diagnosticsDir,
+    `test-run-${config.runId}.json`
+  );
+  const summaryArtifactPath = join(
+    config.diagnosticsDir,
+    `turbo-summary-${config.runId}.json`
+  );
+  const logSink = createWriteStream(logPath, { flags: "a" });
+
+  logStart(config, command);
+  logSink.write(
+    [
+      `runId=${config.runId}`,
+      `startedAt=${startedAt.toISOString()}`,
+      `command=${command.join(" ")}`,
+      "",
+    ].join("\n")
+  );
+
+  const handle = Bun.spawn([...command], {
+    cwd: config.rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode] = await Promise.all([
+    handle.exited,
+    mirrorStreamToOutputs(handle.stdout, process.stdout, logSink),
+    mirrorStreamToOutputs(handle.stderr, process.stderr, logSink),
+  ]);
+
+  const finishedAt = new Date();
+  const durationMs = Date.now() - startedAtMs;
+
+  const turboSummary = findNewTurboSummary(config.rootDir, beforeRun);
+  let copiedTurboSummaryPath: string | null = null;
+  if (turboSummary) {
+    copyFileSync(turboSummary, summaryArtifactPath);
+    copiedTurboSummaryPath = summaryArtifactPath;
+  }
+
+  const metadata: CiRunMetadata = {
+    $schema: "https://outfitter.dev/reports/ci-tests/v1",
+    runId: config.runId,
+    status: exitCode === 0 ? "passed" : "failed",
+    exitCode,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs,
+    command,
+    environment: {
+      turboConcurrency: config.turboConcurrency,
+      bunMaxConcurrency: config.bunMaxConcurrency,
+      logOrder: config.logOrder,
+      outputLogs: config.outputLogs,
+    },
+    artifacts: {
+      log: logPath,
+      turboSummary: copiedTurboSummaryPath,
+    },
+    github: {
+      runId: process.env["GITHUB_RUN_ID"] ?? null,
+      attempt: process.env["GITHUB_RUN_ATTEMPT"] ?? null,
+      sha: process.env["GITHUB_SHA"] ?? null,
+    },
+  };
+
+  writeMetadata(metadataPath, metadata);
+  logSink.end();
+
+  process.stdout.write(
+    [
+      `[ci-test-runner] exitCode=${exitCode}`,
+      `[ci-test-runner] diagnostics=${config.diagnosticsDir}`,
+      `[ci-test-runner] metadata=${metadataPath}`,
+      `[ci-test-runner] turboSummary=${copiedTurboSummaryPath ?? "none"}`,
+    ].join("\n") + "\n"
+  );
+
+  return {
+    exitCode,
+    logPath,
+    metadataPath,
+    summaryArtifactPath: copiedTurboSummaryPath,
+  };
+}
+
+if (import.meta.main) {
+  const config = resolveCiTestRunnerConfig({
+    cwd: process.cwd(),
+  });
+  const result = await runCiTests(config);
+  process.exit(result.exitCode);
+}


### PR DESCRIPTION
## Summary
- Add explicit CI test concurrency guardrails for both orchestration layers:
  - Turbo task concurrency via `OUTFITTER_CI_TURBO_CONCURRENCY`
  - Bun per-task file concurrency via `OUTFITTER_CI_BUN_MAX_CONCURRENCY`
- Route CI verification through the orchestrator (`outfitter check --ci`) and keep diagnostics emitted by `scripts/ci-test-runner.ts`.
- Pin routine CI/release workflow logging to `OUTFITTER_CI_TURBO_OUTPUT_LOGS=errors-only` while preserving structured diagnostics artifacts.
- Document the guardrail/runtime contract in `docs/reference/export-contracts.md`.

## How To Test
- `bun test scripts/ci-test-runner.test.ts apps/outfitter/src/__tests__/check-orchestrator.test.ts`
- `OUTFITTER_CI_TURBO_OUTPUT_LOGS=errors-only bun run apps/outfitter/src/cli.ts check --ci --output json`

Closes: OS-312
