### PR TITLE
feat(ci): add Bun crash diagnostics and trial workflow

### DIFF
--- a/.github/workflows/bun-stability-trial.yml
+++ b/.github/workflows/bun-stability-trial.yml
@@ -1,0 +1,143 @@
+name: Bun Stability Trial
+
+on:
+  workflow_dispatch:
+    inputs:
+      bun_versions:
+        description: "Comma-separated Bun versions (example: 1.3.9,1.3.10)"
+        required: false
+        default: "1.3.9,1.3.10"
+      iterations:
+        description: "Repeated test:ci runs per Bun version"
+        required: false
+        default: "10"
+      turbo_concurrency:
+        description: "Turbo task concurrency for CI tests"
+        required: false
+        default: "2"
+      bun_max_concurrency:
+        description: "Bun test-file max concurrency"
+        required: false
+        default: "4"
+
+jobs:
+  resolve-versions:
+    name: Resolve Bun Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      versions_json: ${{ steps.parse.outputs.versions_json }}
+    steps:
+      - name: Parse versions input
+        id: parse
+        shell: bash
+        env:
+          RAW_VERSIONS: ${{ github.event.inputs.bun_versions }}
+        run: |
+          set -euo pipefail
+          raw="${RAW_VERSIONS}"
+          if [ -z "$raw" ]; then
+            raw='1.3.9,1.3.10'
+          fi
+          versions_json=$(printf '%s' "$raw" | awk -F',' '
+            BEGIN { printf "["; count=0 }
+            {
+              for (i = 1; i <= NF; i++) {
+                gsub(/^[ \t]+|[ \t]+$/, "", $i)
+                if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$/) {
+                  if (count > 0) printf ","
+                  printf "\"%s\"", $i
+                  count++
+                }
+              }
+            }
+            END { printf "]" }
+          ')
+          echo "versions_json=$versions_json" >> "$GITHUB_OUTPUT"
+
+  trial:
+    name: Trial (Bun ${{ matrix.bun_version }})
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun_version: ${{ fromJson(needs.resolve-versions.outputs.versions_json) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun_version }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run repeated CI test passes
+        shell: bash
+        env:
+          ITERATIONS: ${{ github.event.inputs.iterations || '10' }}
+          OUTFITTER_CI_TURBO_CONCURRENCY: ${{ github.event.inputs.turbo_concurrency || '2' }}
+          OUTFITTER_CI_BUN_MAX_CONCURRENCY: ${{ github.event.inputs.bun_max_concurrency || '4' }}
+          OUTFITTER_CI_TURBO_LOG_ORDER: stream
+          OUTFITTER_CI_TURBO_OUTPUT_LOGS: full
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ secrets.TURBO_API }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p .outfitter/ci-trial
+
+          passes=0
+          failures=0
+          for i in $(seq 1 "$ITERATIONS"); do
+            echo "::group::Bun ${{ matrix.bun_version }} iteration $i/$ITERATIONS"
+            run_id="trial-${{ matrix.bun_version }}-${i}-$(date +%s)"
+            if OUTFITTER_CI_RUN_ID="$run_id" bun run test:ci; then
+              status="pass"
+              passes=$((passes + 1))
+            else
+              status="fail"
+              failures=$((failures + 1))
+            fi
+            echo "iteration=$i status=$status run_id=$run_id" >> ".outfitter/ci-trial/results-${{ matrix.bun_version }}.log"
+            echo "::endgroup::"
+          done
+
+          cat > ".outfitter/ci-trial/summary-${{ matrix.bun_version }}.json" <<JSON
+          {
+            "schema": "https://outfitter.dev/reports/bun-stability-trial/v1",
+            "bunVersion": "${{ matrix.bun_version }}",
+            "iterations": ${ITERATIONS},
+            "passed": ${passes},
+            "failed": ${failures},
+            "turboConcurrency": ${OUTFITTER_CI_TURBO_CONCURRENCY},
+            "bunMaxConcurrency": ${OUTFITTER_CI_BUN_MAX_CONCURRENCY}
+          }
+          JSON
+
+          {
+            echo "## Bun Stability Trial"
+            echo ""
+            echo "- Bun version: \`${{ matrix.bun_version }}\`"
+            echo "- Iterations: \`${ITERATIONS}\`"
+            echo "- Passed: \`${passes}\`"
+            echo "- Failed: \`${failures}\`"
+            echo "- Turbo concurrency: \`${OUTFITTER_CI_TURBO_CONCURRENCY}\`"
+            echo "- Bun max concurrency: \`${OUTFITTER_CI_BUN_MAX_CONCURRENCY}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload stability diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-stability-trial-${{ matrix.bun_version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          path: |
+            .outfitter/ci/**
+            .outfitter/ci-trial/**
+            .turbo/runs/*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,13 @@ jobs:
           TURBO_API: ${{ secrets.TURBO_API }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
+      - name: Upload test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-test-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          path: |
+            .outfitter/ci/**
+            .turbo/runs/*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,16 @@ jobs:
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
+      - name: Upload test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-test-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          path: |
+            .outfitter/ci/**
+            .turbo/runs/*.json
+
       - name: Setup Node (for npm OIDC publish)
         uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ yarn-error.log*
 tmp/
 temp/
 .outfitter/ci/
+.outfitter/ci-trial/
 .outfitter/reports/
 apps/outfitter/.outfitter/surface.json
 

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -25,12 +25,13 @@ Add the `release:none` label to PRs that don't need a release (docs, CI, tests).
 
 ### Workflows Overview
 
-| Workflow               | Trigger                            | Purpose                                               |
-| ---------------------- | ---------------------------------- | ----------------------------------------------------- |
-| `auto-label.yml`       | PR open/update                     | Label PRs by file changes                             |
-| `canary.yml`           | Push to main (changeset files)     | Publish `@canary` dist-tag                            |
-| `changeset-labels.yml` | PR with manual changeset           | Apply release label                                   |
-| `release.yml`          | Manual dispatch / release PR merge | Two-phase: prepare release PR, then publish `@latest` |
-| `stack-labels.yml`     | PR open/update                     | Graphite stack labels                                 |
-| `label-sync.yml`       | Push to main                       | Sync label definitions                                |
-| `ci.yml`               | PR/push                            | Build and test                                        |
+| Workflow                  | Trigger                            | Purpose                                                    |
+| ------------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| `auto-label.yml`          | PR open/update                     | Label PRs by file changes                                  |
+| `canary.yml`              | Push to main (changeset files)     | Publish `@canary` dist-tag                                 |
+| `changeset-labels.yml`    | PR with manual changeset           | Apply release label                                        |
+| `release.yml`             | Manual dispatch / release PR merge | Two-phase: prepare release PR, then publish `@latest`      |
+| `stack-labels.yml`        | PR open/update                     | Graphite stack labels                                      |
+| `label-sync.yml`          | Push to main                       | Sync label definitions                                     |
+| `ci.yml`                  | PR/push                            | Build and test                                             |
+| `bun-stability-trial.yml` | Manual dispatch                    | Repeated `test:ci` runs across Bun versions with artifacts |

--- a/docs/reference/export-contracts.md
+++ b/docs/reference/export-contracts.md
@@ -54,6 +54,7 @@ The CI test phase uses `bun run test:ci` (via `check --ci`) with explicit concur
 - `OUTFITTER_CI_TURBO_CONCURRENCY` (default `2`) controls Turbo task parallelism.
 - `OUTFITTER_CI_BUN_MAX_CONCURRENCY` (default `4`) is passed to each package test command as Bun `--max-concurrency`.
 - `OUTFITTER_CI_TURBO_LOG_ORDER` (default `stream`) and `OUTFITTER_CI_TURBO_OUTPUT_LOGS` (default `full`) keep active-task logs visible for crash forensics.
+- CI diagnostics are written to `.outfitter/ci/`, and failure runs upload both those files and `.turbo/runs/*.json` as workflow artifacts.
 
 This same pipeline runs locally via pre-push hook (`outfitter check --pre-push`) and in CI. Local and CI are always in parity for day-to-day PR verification.
 


### PR DESCRIPTION
## Summary
- Add Bun crash diagnostics and trial tooling for CI stability analysis.
- Introduce manual `bun-stability-trial.yml` workflow to run repeated `test:ci` passes across Bun versions with controlled concurrency inputs.
- Upload CI/release diagnostics artifacts (`.outfitter/reports/ci/**`, `.turbo/runs/*.json`) on failure.
- Keep trial workflow log verbosity at `OUTFITTER_CI_TURBO_OUTPUT_LOGS=full` for forensic runs.
- Document reliability process and rollout details in CI/CD docs.

## How To Test
- `bun run test:ci`
- Trigger **Actions > Bun Stability Trial** with sample inputs (for example `bun_versions=1.3.9,1.3.10`, `iterations=3`).

Closes: OS-314
