### PR TITLE
ci(release): remove redundant test step from publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build
+        run: bun run build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ secrets.TURBO_API }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
       - name: Verify CI Gate
         run: bun run verify:ci
         env:


### PR DESCRIPTION
## Summary

Two fixes to the release publish workflow:

1. **Remove redundant test step**: The `verify:ci` step already runs tests through the check orchestrator (`outfitter check --ci`), so the separate `bun run test:ci || bun run test:ci` with retry was doubling test execution on every release.

2. **Add explicit build step**: The release workflow was missing `bun run build` before `verify:ci`. Since the CI test runner uses Turbo's `--only` flag (skipping task dependencies), tests need build artifacts to already exist. The regular CI workflow already had this step; the release workflow was missing it.

## Test plan

- [x] `verify:ci` still includes tests via the check orchestrator's CI mode
- [x] Release workflow matches CI workflow structure: build → verify → publish
- [x] Release workflow YAML is valid

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)