### PR TITLE
fix(outfitter): add explicit type params to defineAction() for isolatedDeclarations

### DIFF
--- a/apps/outfitter/src/actions/add.ts
+++ b/apps/outfitter/src/actions/add.ts
@@ -44,7 +44,7 @@ const addCwd = cwdPreset();
 const _addAction: ActionSpec<
   AddInput & { outputMode: CliOutputMode },
   unknown
-> = defineAction({
+> = defineAction<AddInput & { outputMode: CliOutputMode }, unknown>({
   id: "add",
   description: "Add a block from the registry to your project",
   surfaces: ["cli"],
@@ -89,7 +89,7 @@ const _addAction: ActionSpec<
 export const addAction: typeof _addAction = _addAction;
 
 const _listBlocksAction: ActionSpec<{ outputMode: CliOutputMode }, unknown> =
-  defineAction({
+  defineAction<{ outputMode: CliOutputMode }, unknown>({
     id: "add.list",
     description: "List available blocks",
     surfaces: ["cli"],

--- a/apps/outfitter/src/actions/check-automation.ts
+++ b/apps/outfitter/src/actions/check-automation.ts
@@ -83,7 +83,7 @@ function mapCheckAutomationInput(context: {
 }
 
 const _checkPublishGuardrailsAction: ActionSpec<CheckAutomationInput, unknown> =
-  defineAction({
+  defineAction<CheckAutomationInput, unknown>({
     id: "check.publish-guardrails",
     description:
       "Validate publishable package manifests enforce prepublishOnly guardrails",
@@ -126,7 +126,7 @@ export const checkPublishGuardrailsAction: typeof _checkPublishGuardrailsAction 
   _checkPublishGuardrailsAction;
 
 const _checkPresetVersionsAction: ActionSpec<CheckAutomationInput, unknown> =
-  defineAction({
+  defineAction<CheckAutomationInput, unknown>({
     id: "check.preset-versions",
     description:
       "Validate preset dependency versions, registry versions, and Bun version consistency",
@@ -169,7 +169,7 @@ export const checkPresetVersionsAction: typeof _checkPresetVersionsAction =
   _checkPresetVersionsAction;
 
 const _checkSurfaceMapAction: ActionSpec<CheckAutomationInput, unknown> =
-  defineAction({
+  defineAction<CheckAutomationInput, unknown>({
     id: "check.surface-map",
     description:
       "Validate canonical surface map path usage (.outfitter/surface.json only)",
@@ -212,7 +212,7 @@ export const checkSurfaceMapAction: typeof _checkSurfaceMapAction =
   _checkSurfaceMapAction;
 
 const _checkSurfaceMapFormatAction: ActionSpec<CheckAutomationInput, unknown> =
-  defineAction({
+  defineAction<CheckAutomationInput, unknown>({
     id: "check.surface-map-format",
     description: "Validate canonical formatting for .outfitter/surface.json",
     surfaces: ["cli"],
@@ -253,7 +253,7 @@ export const checkSurfaceMapFormatAction: typeof _checkSurfaceMapFormatAction =
   _checkSurfaceMapFormatAction;
 
 const _checkDocsSentinelAction: ActionSpec<CheckAutomationInput, unknown> =
-  defineAction({
+  defineAction<CheckAutomationInput, unknown>({
     id: "check.docs-sentinel",
     description: "Validate docs/README.md PACKAGE_LIST sentinel freshness",
     surfaces: ["cli"],

--- a/apps/outfitter/src/actions/check.ts
+++ b/apps/outfitter/src/actions/check.ts
@@ -105,7 +105,10 @@ function resolveCheckMode(
   return requestedModes[0];
 }
 
-const _checkAction: ActionSpec<CheckActionInput, unknown> = defineAction({
+const _checkAction: ActionSpec<CheckActionInput, unknown> = defineAction<
+  CheckActionInput,
+  unknown
+>({
   id: "check",
   description:
     "Compare local config blocks against the registry for drift detection",

--- a/apps/outfitter/src/actions/demo.ts
+++ b/apps/outfitter/src/actions/demo.ts
@@ -33,7 +33,10 @@ const demoInputSchema = z.object({
   outputMode: outputModeSchema,
 }) as z.ZodType<DemoActionInput>;
 
-const _demoAction: ActionSpec<DemoActionInput, unknown> = defineAction({
+const _demoAction: ActionSpec<DemoActionInput, unknown> = defineAction<
+  DemoActionInput,
+  unknown
+>({
   id: "demo",
   description: "Run the CLI demo app",
   surfaces: ["cli"],

--- a/apps/outfitter/src/actions/docs.ts
+++ b/apps/outfitter/src/actions/docs.ts
@@ -53,7 +53,10 @@ const docsListCwd = cwdPreset();
 const docsListOutputMode = outputModePreset({ includeJsonl: true });
 const docsListJq = jqPreset();
 
-const _docsListAction: ActionSpec<DocsListInput, unknown> = defineAction({
+const _docsListAction: ActionSpec<DocsListInput, unknown> = defineAction<
+  DocsListInput,
+  unknown
+>({
   id: "docs.list",
   description: "List documentation entries from the docs map",
   surfaces: ["cli"],
@@ -121,7 +124,10 @@ const docsShowCwd = cwdPreset();
 const docsShowOutputMode = outputModePreset({ includeJsonl: true });
 const docsShowJq = jqPreset();
 
-const _docsShowAction: ActionSpec<DocsShowInput, unknown> = defineAction({
+const _docsShowAction: ActionSpec<DocsShowInput, unknown> = defineAction<
+  DocsShowInput,
+  unknown
+>({
   id: "docs.show",
   description: "Show a specific documentation entry and its content",
   surfaces: ["cli"],
@@ -179,7 +185,10 @@ const docsSearchCwd = cwdPreset();
 const docsSearchOutputMode = outputModePreset({ includeJsonl: true });
 const docsSearchJq = jqPreset();
 
-const _docsSearchAction: ActionSpec<DocsSearchInput, unknown> = defineAction({
+const _docsSearchAction: ActionSpec<DocsSearchInput, unknown> = defineAction<
+  DocsSearchInput,
+  unknown
+>({
   id: "docs.search",
   description: "Search documentation content for a query string",
   surfaces: ["cli"],
@@ -249,7 +258,10 @@ const docsApiCwd = cwdPreset();
 const docsApiOutputMode = outputModePreset({ includeJsonl: true });
 const docsApiJq = jqPreset();
 
-const _docsApiAction: ActionSpec<DocsApiInput, unknown> = defineAction({
+const _docsApiAction: ActionSpec<DocsApiInput, unknown> = defineAction<
+  DocsApiInput,
+  unknown
+>({
   id: "docs.api",
   description: "Extract API reference from TSDoc coverage data",
   surfaces: ["cli"],
@@ -338,7 +350,10 @@ const docsExportInputSchema = z.object({
 const docsExportCwd = cwdPreset();
 const docsExportOutputMode = outputModePreset({ includeJsonl: true });
 
-const _docsExportAction: ActionSpec<DocsExportInput, unknown> = defineAction({
+const _docsExportAction: ActionSpec<DocsExportInput, unknown> = defineAction<
+  DocsExportInput,
+  unknown
+>({
   id: "docs.export",
   description: "Export documentation to packages, llms.txt, or both",
   surfaces: ["cli"],

--- a/apps/outfitter/src/actions/doctor.ts
+++ b/apps/outfitter/src/actions/doctor.ts
@@ -29,7 +29,10 @@ const doctorInputSchema = z.object({
 
 const doctorCwd = cwdPreset();
 
-const _doctorAction: ActionSpec<DoctorActionInput, unknown> = defineAction({
+const _doctorAction: ActionSpec<DoctorActionInput, unknown> = defineAction<
+  DoctorActionInput,
+  unknown
+>({
   id: "doctor",
   description: "Validate environment and dependencies",
   surfaces: ["cli"],

--- a/apps/outfitter/src/actions/init.ts
+++ b/apps/outfitter/src/actions/init.ts
@@ -238,7 +238,7 @@ function createInitAction(options: {
     initOptions.push(presetOption);
   }
 
-  return defineAction({
+  return defineAction<InitActionInput, unknown>({
     id: options.id,
     description: options.description,
     surfaces: ["cli"],
@@ -270,7 +270,11 @@ function createInitAction(options: {
   });
 }
 
-const _createAction: ActionSpec<{}, unknown, InternalError> = defineAction({
+const _createAction: ActionSpec<{}, unknown, InternalError> = defineAction<
+  {},
+  unknown,
+  InternalError
+>({
   id: "create",
   description: "Removed - use 'outfitter init' instead",
   surfaces: ["cli"],
@@ -302,7 +306,7 @@ const _createAction: ActionSpec<{}, unknown, InternalError> = defineAction({
 });
 export const createAction: typeof _createAction = _createAction;
 
-const _initAction: ReturnType<typeof createInitAction> = createInitAction({
+const _initAction: ActionSpec<InitActionInput, unknown> = createInitAction({
   id: "init",
   description: "Create a new Outfitter project",
   command: "[directory]",
@@ -310,7 +314,7 @@ const _initAction: ReturnType<typeof createInitAction> = createInitAction({
 });
 export const initAction: typeof _initAction = _initAction;
 
-const _initCliAction: ReturnType<typeof createInitAction> = createInitAction({
+const _initCliAction: ActionSpec<InitActionInput, unknown> = createInitAction({
   id: "init.cli",
   description: "Create a new CLI project",
   command: "cli [directory]",
@@ -318,7 +322,7 @@ const _initCliAction: ReturnType<typeof createInitAction> = createInitAction({
 });
 export const initCliAction: typeof _initCliAction = _initCliAction;
 
-const _initMcpAction: ReturnType<typeof createInitAction> = createInitAction({
+const _initMcpAction: ActionSpec<InitActionInput, unknown> = createInitAction({
   id: "init.mcp",
   description: "Create a new MCP server",
   command: "mcp [directory]",
@@ -326,17 +330,16 @@ const _initMcpAction: ReturnType<typeof createInitAction> = createInitAction({
 });
 export const initMcpAction: typeof _initMcpAction = _initMcpAction;
 
-const _initDaemonAction: ReturnType<typeof createInitAction> = createInitAction(
-  {
+const _initDaemonAction: ActionSpec<InitActionInput, unknown> =
+  createInitAction({
     id: "init.daemon",
     description: "Create a new daemon project",
     command: "daemon [directory]",
     presetOverride: "daemon",
-  }
-);
+  });
 export const initDaemonAction: typeof _initDaemonAction = _initDaemonAction;
 
-const _initLibraryAction: ReturnType<typeof createInitAction> =
+const _initLibraryAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.library",
     description: "Create a new library project",
@@ -345,7 +348,7 @@ const _initLibraryAction: ReturnType<typeof createInitAction> =
   });
 export const initLibraryAction: typeof _initLibraryAction = _initLibraryAction;
 
-const _initFullStackAction: ReturnType<typeof createInitAction> =
+const _initFullStackAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.full-stack",
     description: "Create a full-stack workspace",

--- a/apps/outfitter/src/actions/scaffold.ts
+++ b/apps/outfitter/src/actions/scaffold.ts
@@ -95,7 +95,10 @@ function resolveScaffoldOptions(context: {
   };
 }
 
-const _scaffoldAction: ActionSpec<ScaffoldActionInput, unknown> = defineAction({
+const _scaffoldAction: ActionSpec<ScaffoldActionInput, unknown> = defineAction<
+  ScaffoldActionInput,
+  unknown
+>({
   id: "scaffold",
   description: "Add a capability to an existing project",
   surfaces: ["cli"],

--- a/apps/outfitter/src/actions/upgrade.ts
+++ b/apps/outfitter/src/actions/upgrade.ts
@@ -85,7 +85,10 @@ const upgradeFlags = actionCliPresets(
   upgradeGuide
 );
 
-const _upgradeAction: ActionSpec<UpgradeActionInput, unknown> = defineAction({
+const _upgradeAction: ActionSpec<UpgradeActionInput, unknown> = defineAction<
+  UpgradeActionInput,
+  unknown
+>({
   id: "upgrade",
   description: "Check for @outfitter/* package updates and migration guidance",
   surfaces: ["cli"],


### PR DESCRIPTION
## Summary

Adds explicit generic type parameters to all `defineAction()` calls in `apps/outfitter/src/actions/` so bunup can emit correct `.d.ts` files under `isolatedDeclarations` on Linux CI.

- Annotated 19 `defineAction()` call sites across 9 action files
- Replaced `ReturnType<typeof createInitAction>` with explicit `ActionSpec<InitActionInput, unknown>` on init variant declarations
- Also fixed `check-automation.ts`, `add.ts`, and `upgrade.ts` which had the same latent issue

Closes OS-392

## Test plan

- [x] `bun run build` — 20/20 tasks pass
- [x] `bun run typecheck` — 34/34 tasks pass
- [x] `bun run test --filter=outfitter` — 545 tests pass, 0 failures
- [ ] Linux CI build confirms TS9010 errors are resolved