### PR TITLE
fix(types): enable `isolatedDeclarations` and fix remaining TS9010 violations

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,5 +6,5 @@
     "strictNullChecks": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/__tests__"]
 }

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -115,7 +115,13 @@ export interface ToolAnnotations {
  * mark the whole tool as destructive. Per-action annotations are an MCP spec
  * limitation; presets + spread cover most edge cases.
  */
-export const TOOL_ANNOTATIONS = {
+export const TOOL_ANNOTATIONS: {
+  readonly destructive: ToolAnnotations;
+  readonly openWorld: ToolAnnotations;
+  readonly readOnly: ToolAnnotations;
+  readonly write: ToolAnnotations;
+  readonly writeIdempotent: ToolAnnotations;
+} = {
   /** Read-only, safe to call repeatedly. */
   readOnly: {
     readOnlyHint: true,
@@ -151,7 +157,7 @@ export const TOOL_ANNOTATIONS = {
     idempotentHint: false,
     openWorldHint: true,
   },
-} as const satisfies Record<string, ToolAnnotations>;
+};
 
 // ============================================================================
 // Tool Definition

--- a/packages/tui/src/render/stack.ts
+++ b/packages/tui/src/render/stack.ts
@@ -31,7 +31,14 @@ export interface DelimiterSet {
 /**
  * Available delimiter names.
  */
-export type DelimiterName = keyof typeof DELIMITERS;
+export type DelimiterName =
+  | "arrow"
+  | "bullet"
+  | "colon"
+  | "dot"
+  | "pipe"
+  | "slash"
+  | "space";
 
 /**
  * Registry of delimiter characters with unicode and fallback support.
@@ -47,7 +54,7 @@ export type DelimiterName = keyof typeof DELIMITERS;
  * console.log(getDelimiter("bullet")); // "•" or "*"
  * ```
  */
-export const DELIMITERS = {
+export const DELIMITERS: Readonly<Record<DelimiterName, DelimiterSet>> = {
   space: { unicode: " ", fallback: " " },
   bullet: { unicode: "•", fallback: "*" },
   dot: { unicode: "·", fallback: "." },
@@ -55,7 +62,7 @@ export const DELIMITERS = {
   arrow: { unicode: "→", fallback: "->" },
   slash: { unicode: "/", fallback: "/" },
   colon: { unicode: ":", fallback: ":" },
-} as const satisfies Record<string, DelimiterSet>;
+};
 
 /**
  * Gets a delimiter character with automatic unicode/fallback selection.

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -6,5 +6,5 @@
     "strictNullChecks": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/__tests__"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
+    "isolatedDeclarations": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
 


### PR DESCRIPTION
## Summary

Enables `isolatedDeclarations` in `tsconfig.base.json` so `tsc --noEmit` catches TS9010 errors locally — preventing the class of CI-only failures from OS-392.

- Added `isolatedDeclarations: true` to `tsconfig.base.json`
- Fixed `TOOL_ANNOTATIONS` in `@outfitter/mcp` — added explicit type annotation preserving literal keys
- Fixed `DELIMITERS` in `@outfitter/tui` — defined `DelimiterName` as explicit union, replaced `keyof typeof` circular dependency
- Excluded `src/__tests__/` from `cli` and `tui` tsconfigs (test helpers don't need DTS compliance)

Closes OS-423

## Test plan

- [x] `bun run typecheck` — 34/34 pass with `isolatedDeclarations` enabled
- [x] `bun run build` — 20/20 pass
- [x] `bun run test --filter=@outfitter/mcp --filter=@outfitter/tui` — 152 tests pass