### PR TITLE
refactor(outfitter): add shared action boundary error adapter

### DIFF
--- a/apps/outfitter/src/actions/add.ts
+++ b/apps/outfitter/src/actions/add.ts
@@ -9,7 +9,7 @@ import { resolve } from "node:path";
 import { output } from "@outfitter/cli";
 import { actionCliPresets } from "@outfitter/cli/actions";
 import { cwdPreset, dryRunPreset, forcePreset } from "@outfitter/cli/flags";
-import { defineAction, InternalError, Result } from "@outfitter/contracts";
+import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 import { listBlocks, printAddResults, runAdd } from "../commands/add.js";
@@ -18,7 +18,7 @@ import {
   resolveOutputModeFromContext,
   resolveStructuredOutputMode,
 } from "../output-mode.js";
-import { outputModeSchema } from "./shared.js";
+import { actionInternalErr, outputModeSchema } from "./shared.js";
 
 interface AddActionInput {
   readonly block: string;
@@ -74,12 +74,7 @@ export const addAction: AddAction = defineAction({
     });
 
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "add" },
-        })
-      );
+      return actionInternalErr("add", result.error);
     }
 
     await printAddResults(result.value, addInput.dryRun, { mode: outputMode });
@@ -113,12 +108,7 @@ export const listBlocksAction: ListBlocksAction = defineAction({
     const result = listBlocks();
 
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "add.list" },
-        })
-      );
+      return actionInternalErr("add.list", result.error);
     }
 
     const structuredMode = resolveStructuredOutputMode(input.outputMode);

--- a/apps/outfitter/src/actions/check-automation.ts
+++ b/apps/outfitter/src/actions/check-automation.ts
@@ -8,7 +8,7 @@ import { resolve } from "node:path";
 
 import { cwdPreset } from "@outfitter/cli/flags";
 import { outputModePreset } from "@outfitter/cli/query";
-import { defineAction, InternalError, Result } from "@outfitter/contracts";
+import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 import {
@@ -35,7 +35,11 @@ import {
   type CliOutputMode,
   resolveStructuredOutputMode,
 } from "../output-mode.js";
-import { hasExplicitOutputFlag, outputModeSchema } from "./shared.js";
+import {
+  actionInternalErr,
+  hasExplicitOutputFlag,
+  outputModeSchema,
+} from "./shared.js";
 
 interface CheckAutomationInput {
   cwd: string;
@@ -102,12 +106,7 @@ export const checkPublishGuardrailsAction: CheckAutomationAction = defineAction(
     handler: async (input) => {
       const result = await runCheckPublishGuardrails({ cwd: input.cwd });
       if (result.isErr()) {
-        return Result.err(
-          new InternalError({
-            message: result.error.message,
-            context: { action: "check.publish-guardrails" },
-          })
-        );
+        return actionInternalErr("check.publish-guardrails", result.error);
       }
 
       await printCheckPublishGuardrailsResult(result.value, {
@@ -140,12 +139,7 @@ export const checkPresetVersionsAction: CheckAutomationAction = defineAction({
   handler: async (input) => {
     const result = await runCheckPresetVersions({ cwd: input.cwd });
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check.preset-versions" },
-        })
-      );
+      return actionInternalErr("check.preset-versions", result.error);
     }
 
     await printCheckPresetVersionsResult(result.value, {
@@ -177,12 +171,7 @@ export const checkSurfaceMapAction: CheckAutomationAction = defineAction({
   handler: async (input) => {
     const result = await runCheckSurfaceMap({ cwd: input.cwd });
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check.surface-map" },
-        })
-      );
+      return actionInternalErr("check.surface-map", result.error);
     }
 
     await printCheckSurfaceMapResult(result.value, {
@@ -212,12 +201,7 @@ export const checkSurfaceMapFormatAction: CheckAutomationAction = defineAction({
   handler: async (input) => {
     const result = await runCheckSurfaceMapFormat({ cwd: input.cwd });
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check.surface-map-format" },
-        })
-      );
+      return actionInternalErr("check.surface-map-format", result.error);
     }
 
     await printCheckSurfaceMapFormatResult(result.value, {
@@ -247,12 +231,7 @@ export const checkDocsSentinelAction: CheckAutomationAction = defineAction({
   handler: async (input) => {
     const result = await runCheckDocsSentinel({ cwd: input.cwd });
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check.docs-sentinel" },
-        })
-      );
+      return actionInternalErr("check.docs-sentinel", result.error);
     }
 
     await printCheckDocsSentinelResult(result.value, {

--- a/apps/outfitter/src/actions/check.ts
+++ b/apps/outfitter/src/actions/check.ts
@@ -34,6 +34,7 @@ import {
   resolveStructuredOutputMode,
 } from "../output-mode.js";
 import {
+  actionInternalErr,
   hasExplicitOutputFlag,
   outputModeSchema,
   resolveStringFlag,
@@ -228,12 +229,7 @@ export const checkAction: CheckAction = defineAction({
       });
 
       if (orchestratorResult.isErr()) {
-        return Result.err(
-          new InternalError({
-            message: orchestratorResult.error.message,
-            context: { action: "check" },
-          })
-        );
+        return actionInternalErr("check", orchestratorResult.error);
       }
 
       await printCheckOrchestratorResults(orchestratorResult.value, {
@@ -255,12 +251,7 @@ export const checkAction: CheckAction = defineAction({
     });
 
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check" },
-        })
-      );
+      return actionInternalErr("check", result.error);
     }
 
     await printCheckResults(result.value, {
@@ -426,12 +417,7 @@ export const checkTsdocAction: CheckTsdocAction = defineAction({
         return Result.err(result.error);
       }
 
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "check.tsdoc" },
-        })
-      );
+      return actionInternalErr("check.tsdoc", result.error);
     }
 
     if (!result.value.ok) {

--- a/apps/outfitter/src/actions/demo.ts
+++ b/apps/outfitter/src/actions/demo.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { defineAction, InternalError, Result } from "@outfitter/contracts";
+import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 import { runDemo } from "../commands/demo.js";
@@ -12,7 +12,10 @@ import {
   type CliOutputMode,
   resolveOutputModeFromContext,
 } from "../output-mode.js";
-import { outputModeSchema } from "./shared.js";
+import {
+  outputModeSchema,
+  toActionInternalErrorFromUnknown,
+} from "./shared.js";
 
 interface DemoActionInput {
   readonly animate?: boolean | undefined;
@@ -72,11 +75,7 @@ export const demoAction: DemoAction = defineAction({
       return Result.ok(result);
     } catch (error) {
       return Result.err(
-        new InternalError({
-          message:
-            error instanceof Error ? error.message : "Failed to run demo",
-          context: { action: "demo" },
-        })
+        toActionInternalErrorFromUnknown("demo", error, "Failed to run demo")
       );
     }
   },

--- a/apps/outfitter/src/actions/init.ts
+++ b/apps/outfitter/src/actions/init.ts
@@ -27,6 +27,7 @@ import {
   resolveOutputModeFromContext,
 } from "../output-mode.js";
 import {
+  actionInternalErr,
   outputModeSchema,
   resolveInstallTimeoutFlag,
   resolveLocalFlag,
@@ -255,12 +256,7 @@ function createInitAction(options: {
       const { outputMode, ...initInput } = input;
       const result = await runInit(initInput);
       if (result.isErr()) {
-        return Result.err(
-          new InternalError({
-            message: result.error.message,
-            context: { action: options.id },
-          })
-        );
+        return actionInternalErr(options.id, result.error);
       }
 
       await printInitResults(result.value, { mode: outputMode });

--- a/apps/outfitter/src/actions/scaffold.ts
+++ b/apps/outfitter/src/actions/scaffold.ts
@@ -6,7 +6,7 @@
 
 import { actionCliPresets } from "@outfitter/cli/actions";
 import { dryRunPreset, forcePreset } from "@outfitter/cli/flags";
-import { defineAction, InternalError, Result } from "@outfitter/contracts";
+import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 import { printScaffoldResults, runScaffold } from "../commands/scaffold.js";
@@ -15,6 +15,7 @@ import {
   resolveOutputModeFromContext,
 } from "../output-mode.js";
 import {
+  actionInternalErr,
   outputModeSchema,
   resolveInstallTimeoutFlag,
   resolveLocalFlag,
@@ -134,12 +135,7 @@ export const scaffoldAction: ScaffoldAction = defineAction({
     const result = await runScaffold(scaffoldInput);
 
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "scaffold" },
-        })
-      );
+      return actionInternalErr("scaffold", result.error);
     }
 
     await printScaffoldResults(result.value, { mode: outputMode });

--- a/apps/outfitter/src/actions/shared.ts
+++ b/apps/outfitter/src/actions/shared.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import { InternalError, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 export const outputModeSchema: z.ZodType<"human" | "json" | "jsonl"> = z
@@ -93,4 +94,36 @@ export function resolveInstallTimeoutFlag(value: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+interface ActionBoundaryErrorLike {
+  readonly message: string;
+}
+
+export function toActionInternalError(
+  action: string,
+  error: ActionBoundaryErrorLike
+): InternalError {
+  return new InternalError({
+    message: error.message,
+    context: { action },
+  });
+}
+
+export function actionInternalErr<T = never>(
+  action: string,
+  error: ActionBoundaryErrorLike
+): Result<T, InternalError> {
+  return Result.err<T, InternalError>(toActionInternalError(action, error));
+}
+
+export function toActionInternalErrorFromUnknown(
+  action: string,
+  error: unknown,
+  fallbackMessage: string
+): InternalError {
+  return new InternalError({
+    message: error instanceof Error ? error.message : fallbackMessage,
+    context: { action },
+  });
 }

--- a/apps/outfitter/src/actions/upgrade.ts
+++ b/apps/outfitter/src/actions/upgrade.ts
@@ -13,7 +13,7 @@ import {
   dryRunPreset,
   interactionPreset,
 } from "@outfitter/cli/flags";
-import { defineAction, InternalError, Result } from "@outfitter/contracts";
+import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
 
 import { printUpgradeResults, runUpgrade } from "../commands/upgrade.js";
@@ -21,7 +21,7 @@ import {
   type CliOutputMode,
   resolveOutputModeFromContext,
 } from "../output-mode.js";
-import { outputModeSchema } from "./shared.js";
+import { actionInternalErr, outputModeSchema } from "./shared.js";
 
 interface UpgradeActionInput {
   readonly all: boolean;
@@ -130,12 +130,7 @@ export const upgradeAction: UpgradeAction = defineAction({
     });
 
     if (result.isErr()) {
-      return Result.err(
-        new InternalError({
-          message: result.error.message,
-          context: { action: "upgrade" },
-        })
-      );
+      return actionInternalErr("upgrade", result.error);
     }
 
     await printUpgradeResults(result.value, {


### PR DESCRIPTION
## Summary
- Introduce shared action-boundary internal error adapters and migrate repeated handler error wrapping to the shared helpers.

## Testing
- bun run typecheck -- --only
- cd apps/outfitter && bun test src/__tests__/actions.test.ts src/__tests__/check-automation-actions.test.ts

Closes: OS-426
