### PR TITLE
refactor(outfitter): consolidate action mapInput plumbing

### DIFF
--- a/apps/outfitter/src/actions/add.ts
+++ b/apps/outfitter/src/actions/add.ts
@@ -4,8 +4,6 @@
  * @packageDocumentation
  */
 
-import { resolve } from "node:path";
-
 import { output } from "@outfitter/cli";
 import { actionCliPresets } from "@outfitter/cli/actions";
 import { cwdPreset, dryRunPreset, forcePreset } from "@outfitter/cli/flags";
@@ -18,7 +16,11 @@ import {
   resolveOutputModeFromContext,
   resolveStructuredOutputMode,
 } from "../output-mode.js";
-import { actionInternalErr, outputModeSchema } from "./shared.js";
+import {
+  actionInternalErr,
+  outputModeSchema,
+  resolveCwdFromPreset,
+} from "./shared.js";
 
 interface AddActionInput {
   readonly block: string;
@@ -55,13 +57,11 @@ export const addAction: AddAction = defineAction({
     mapInput: (context) => {
       const outputMode = resolveOutputModeFromContext(context.flags);
       const { force, dryRun } = addSharedFlags.resolve(context);
-      const { cwd: rawCwd } = addCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
       return {
         block: context.args[0] as string,
         force,
         dryRun,
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, addCwd),
         outputMode,
       };
     },

--- a/apps/outfitter/src/actions/docs.ts
+++ b/apps/outfitter/src/actions/docs.ts
@@ -4,8 +4,6 @@
  * @packageDocumentation
  */
 
-import { resolve } from "node:path";
-
 import { cwdPreset } from "@outfitter/cli/flags";
 import { jqPreset, outputModePreset } from "@outfitter/cli/query";
 import { defineAction, Result } from "@outfitter/contracts";
@@ -39,7 +37,11 @@ import {
 } from "../commands/docs-show.js";
 import { checkTsdocOutputSchema } from "./check.js";
 import { resolveDocsOutputMode } from "./docs-output-mode.js";
-import { outputModeSchema, resolveStringFlag } from "./shared.js";
+import {
+  outputModeSchema,
+  resolveCwdFromPreset,
+  resolveStringFlag,
+} from "./shared.js";
 
 const docsListInputSchema = z.object({
   cwd: z.string(),
@@ -84,13 +86,11 @@ export const docsListAction: DocsListAction = defineAction({
       );
       const { jq } = docsListJq.resolve(context.flags);
       const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
-      const { cwd: rawCwd } = docsListCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
       const kind = resolveStringFlag(context.flags["kind"]);
       const pkg = resolveStringFlag(context.flags["package"]);
 
       return {
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, docsListCwd),
         outputMode,
         jq,
         ...(kind !== undefined ? { kind } : {}),
@@ -144,12 +144,10 @@ export const docsShowAction: DocsShowAction = defineAction({
       );
       const { jq } = docsShowJq.resolve(context.flags);
       const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
-      const { cwd: rawCwd } = docsShowCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
 
       return {
         id: context.args[0] as string,
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, docsShowCwd),
         jq,
         outputMode,
       };
@@ -214,14 +212,12 @@ export const docsSearchAction: DocsSearchAction = defineAction({
       );
       const { jq } = docsSearchJq.resolve(context.flags);
       const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
-      const { cwd: rawCwd } = docsSearchCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
       const kind = resolveStringFlag(context.flags["kind"]);
       const pkg = resolveStringFlag(context.flags["package"]);
 
       return {
         query: context.args[0] as string,
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, docsSearchCwd),
         outputMode,
         jq,
         ...(kind !== undefined ? { kind } : {}),
@@ -286,8 +282,6 @@ export const docsApiAction: DocsApiAction = defineAction({
       );
       const { jq } = docsApiJq.resolve(context.flags);
       const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
-      const { cwd: rawCwd } = docsApiCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
 
       // Resolve --level flag
       const levelRaw = context.flags["level"];
@@ -307,7 +301,7 @@ export const docsApiAction: DocsApiAction = defineAction({
       }
 
       return {
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, docsApiCwd),
         outputMode,
         jq,
         level,
@@ -377,13 +371,11 @@ export const docsExportAction: DocsExportAction = defineAction({
         context.flags
       );
       const outputMode = resolveDocsOutputMode(context.flags, presetOutputMode);
-      const { cwd: rawCwd } = docsExportCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
       const targetRaw = resolveStringFlag(context.flags["target"]);
       const target = (targetRaw ?? "all") as DocsExportTarget;
 
       return {
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, docsExportCwd),
         target,
         outputMode,
       };

--- a/apps/outfitter/src/actions/doctor.ts
+++ b/apps/outfitter/src/actions/doctor.ts
@@ -4,8 +4,6 @@
  * @packageDocumentation
  */
 
-import { resolve } from "node:path";
-
 import { cwdPreset } from "@outfitter/cli/flags";
 import { defineAction, Result } from "@outfitter/contracts";
 import { z } from "zod";
@@ -15,7 +13,7 @@ import {
   type CliOutputMode,
   resolveOutputModeFromContext,
 } from "../output-mode.js";
-import { outputModeSchema } from "./shared.js";
+import { outputModeSchema, resolveCwdFromPreset } from "./shared.js";
 
 interface DoctorActionInput {
   readonly cwd: string;
@@ -42,10 +40,8 @@ export const doctorAction: DoctorAction = defineAction({
     options: [...doctorCwd.options],
     mapInput: (context) => {
       const outputMode = resolveOutputModeFromContext(context.flags);
-      const { cwd: rawCwd } = doctorCwd.resolve(context.flags);
-      const cwd = resolve(process.cwd(), rawCwd);
       return {
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, doctorCwd),
         outputMode,
       };
     },

--- a/apps/outfitter/src/actions/init.ts
+++ b/apps/outfitter/src/actions/init.ts
@@ -29,6 +29,7 @@ import {
 import {
   actionInternalErr,
   outputModeSchema,
+  resolveBooleanFlagAlias,
   resolveInstallTimeoutFlag,
   resolveLocalFlag,
   resolveNoToolingFlag,
@@ -163,11 +164,17 @@ function resolveInitOptions(
   const local = resolveLocalFlag(flags);
   const withBlocks = resolveStringFlag(flags.with);
   const noTooling = resolveNoToolingFlag(flags);
-  const skipInstall = Boolean(
-    flags.skipInstall ?? context.flags["skip-install"]
+  const skipInstall = resolveBooleanFlagAlias(
+    context.flags,
+    "skipInstall",
+    "skip-install"
   );
-  const skipGit = Boolean(flags.skipGit ?? context.flags["skip-git"]);
-  const skipCommit = Boolean(flags.skipCommit ?? context.flags["skip-commit"]);
+  const skipGit = resolveBooleanFlagAlias(context.flags, "skipGit", "skip-git");
+  const skipCommit = resolveBooleanFlagAlias(
+    context.flags,
+    "skipCommit",
+    "skip-commit"
+  );
   const installTimeout = resolveInstallTimeoutFlag(flags.installTimeout);
   const outputMode = resolveOutputModeFromContext(context.flags);
 

--- a/apps/outfitter/src/actions/scaffold.ts
+++ b/apps/outfitter/src/actions/scaffold.ts
@@ -17,6 +17,7 @@ import {
 import {
   actionInternalErr,
   outputModeSchema,
+  resolveBooleanFlagAlias,
   resolveInstallTimeoutFlag,
   resolveLocalFlag,
   resolveNoToolingFlag,
@@ -84,7 +85,11 @@ function resolveScaffoldOptions(context: {
     target: String(context.args[0] ?? ""),
     name: resolveStringFlag(context.args[1]),
     force,
-    skipInstall: Boolean(flags.skipInstall ?? context.flags["skip-install"]),
+    skipInstall: resolveBooleanFlagAlias(
+      context.flags,
+      "skipInstall",
+      "skip-install"
+    ),
     dryRun,
     ...(local !== undefined ? { local } : {}),
     with: resolveStringFlag(flags.with),

--- a/apps/outfitter/src/actions/upgrade.ts
+++ b/apps/outfitter/src/actions/upgrade.ts
@@ -4,8 +4,6 @@
  * @packageDocumentation
  */
 
-import { resolve } from "node:path";
-
 import { actionCliPresets } from "@outfitter/cli/actions";
 import {
   booleanFlagPreset,
@@ -21,7 +19,11 @@ import {
   type CliOutputMode,
   resolveOutputModeFromContext,
 } from "../output-mode.js";
-import { actionInternalErr, outputModeSchema } from "./shared.js";
+import {
+  actionInternalErr,
+  outputModeSchema,
+  resolveCwdFromPreset,
+} from "./shared.js";
 
 interface UpgradeActionInput {
   readonly all: boolean;
@@ -96,20 +98,12 @@ export const upgradeAction: UpgradeAction = defineAction({
     options: [...upgradeFlags.options],
     mapInput: (context) => {
       const outputMode = resolveOutputModeFromContext(context.flags);
-      const {
-        cwd: rawCwd,
-        dryRun,
-        interactive,
-        yes,
-        all,
-        noCodemods,
-        guide,
-      } = upgradeFlags.resolve(context);
-      const cwd = resolve(process.cwd(), rawCwd);
+      const { dryRun, interactive, yes, all, noCodemods, guide } =
+        upgradeFlags.resolve(context);
       const guidePackages =
         context.args.length > 0 ? (context.args as string[]) : undefined;
       return {
-        cwd,
+        cwd: resolveCwdFromPreset(context.flags, upgradeCwd),
         guide,
         ...(guidePackages !== undefined ? { guidePackages } : {}),
         dryRun,


### PR DESCRIPTION
## Summary
- Extract shared mapInput helpers for cwd/output/flag resolution and apply them across action modules.

## Testing
- bun run typecheck -- --only
- cd apps/outfitter && bun test src/__tests__/actions.test.ts src/__tests__/check-automation-actions.test.ts

Closes: OS-427
