### PR TITLE
refactor(outfitter): slim upgrade command orchestration

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -189,10 +189,22 @@
         "default": "./dist/commands/upgrade.js"
       }
     },
+    "./commands/upgrade-apply": {
+      "import": {
+        "types": "./dist/commands/upgrade-apply.d.ts",
+        "default": "./dist/commands/upgrade-apply.js"
+      }
+    },
     "./commands/upgrade-codemods": {
       "import": {
         "types": "./dist/commands/upgrade-codemods.d.ts",
         "default": "./dist/commands/upgrade-codemods.js"
+      }
+    },
+    "./commands/upgrade-latest-version": {
+      "import": {
+        "types": "./dist/commands/upgrade-latest-version.d.ts",
+        "default": "./dist/commands/upgrade-latest-version.js"
       }
     },
     "./commands/upgrade-migration-docs": {

--- a/apps/outfitter/src/commands/upgrade-apply.ts
+++ b/apps/outfitter/src/commands/upgrade-apply.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { OutfitterError } from "@outfitter/contracts";
+import { InternalError, Result } from "@outfitter/contracts";
+
+interface PackageJsonContent {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface UpgradeApplyInput {
+  readonly latestVersion: string;
+  readonly name: string;
+}
+
+/**
+ * Determine the version range prefix used for a dependency specifier.
+ *
+ * Returns the prefix (e.g. "^", "~", ">=") or "" if the version has no prefix.
+ * Workspace protocol versions are preserved as-is.
+ */
+function getVersionPrefix(specifier: string): string {
+  if (specifier.startsWith("workspace:")) {
+    const inner = specifier.slice("workspace:".length);
+    return `workspace:${getVersionPrefix(inner)}`;
+  }
+  const match = specifier.match(/^([\^~>=<]+)/);
+  return match?.[1] ?? "";
+}
+
+/**
+ * Apply non-breaking updates to package.json and run `bun install`.
+ *
+ * Reads the package.json, updates version ranges for the specified packages
+ * (preserving the existing range prefix), writes it back, and runs install.
+ */
+export async function applyUpdates(
+  cwd: string,
+  updates: readonly UpgradeApplyInput[]
+): Promise<Result<void, OutfitterError>> {
+  const pkgPath = join(cwd, "package.json");
+
+  let raw: string;
+  try {
+    raw = readFileSync(pkgPath, "utf-8");
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to read package.json for apply", { cwd })
+    );
+  }
+
+  let pkg: PackageJsonContent;
+  try {
+    pkg = JSON.parse(raw);
+  } catch {
+    return Result.err(
+      InternalError.create("Invalid JSON in package.json", { cwd })
+    );
+  }
+
+  // Build a lookup for quick access
+  const updateMap = new Map<string, string>();
+  for (const update of updates) {
+    updateMap.set(update.name, update.latestVersion);
+  }
+
+  // Update dependencies and devDependencies in-place
+  for (const section of ["dependencies", "devDependencies"] as const) {
+    const deps = pkg[section];
+    if (!deps) continue;
+
+    for (const name of Object.keys(deps)) {
+      const newVersion = updateMap.get(name);
+      if (newVersion === undefined) continue;
+
+      const currentSpecifier = deps[name];
+      if (currentSpecifier === undefined) continue;
+
+      const prefix = getVersionPrefix(currentSpecifier);
+      deps[name] = `${prefix}${newVersion}`;
+    }
+  }
+
+  // Write the updated package.json, preserving 2-space indentation
+  try {
+    const updated = `${JSON.stringify(pkg, null, 2)}\n`;
+    await Bun.write(pkgPath, updated);
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to write updated package.json", { cwd })
+    );
+  }
+
+  // Run bun install to update the lockfile
+  try {
+    const proc = Bun.spawn(["bun", "install"], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return Result.err(
+        InternalError.create("bun install failed", {
+          cwd,
+          exitCode,
+          stderr: stderr.trim(),
+        })
+      );
+    }
+  } catch {
+    return Result.err(
+      InternalError.create("Failed to run bun install", { cwd })
+    );
+  }
+
+  return Result.ok(undefined);
+}

--- a/apps/outfitter/src/commands/upgrade-latest-version.ts
+++ b/apps/outfitter/src/commands/upgrade-latest-version.ts
@@ -1,0 +1,19 @@
+/**
+ * Query npm registry for the latest version of a package.
+ */
+export async function getLatestVersion(name: string): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["npm", "view", name, "version"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) return null;
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/outfitter/src/commands/upgrade.ts
+++ b/apps/outfitter/src/commands/upgrade.ts
@@ -7,18 +7,19 @@
  * @packageDocumentation
  */
 
-import { readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 import type { OutputMode } from "@outfitter/cli/types";
 import type { OutfitterError } from "@outfitter/contracts";
 import { InternalError, Result } from "@outfitter/contracts";
 
+import { applyUpdates } from "./upgrade-apply.js";
 import {
   discoverCodemods,
   findCodemodsDir,
   runCodemod,
 } from "./upgrade-codemods.js";
+import { getLatestVersion } from "./upgrade-latest-version.js";
 import {
   findMigrationDocsDir,
   readMigrationBreakingFlag,
@@ -134,145 +135,6 @@ export interface UpgradeResult {
   readonly unknownPackages?: readonly string[];
   /** Number of packages with updates available */
   readonly updatesAvailable: number;
-}
-
-// =============================================================================
-// Version Detection
-// =============================================================================
-
-/**
- * Query npm registry for the latest version of a package.
- */
-async function getLatestVersion(name: string): Promise<string | null> {
-  try {
-    const proc = Bun.spawn(["npm", "view", name, "version"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const stdout = await new Response(proc.stdout).text();
-    const exitCode = await proc.exited;
-
-    if (exitCode !== 0) return null;
-    return stdout.trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-// =============================================================================
-// Apply Updates
-// =============================================================================
-
-/**
- * Determine the version range prefix used for a dependency specifier.
- *
- * Returns the prefix (e.g. "^", "~", ">=") or "" if the version has no prefix.
- * Workspace protocol versions are preserved as-is.
- */
-function getVersionPrefix(specifier: string): string {
-  if (specifier.startsWith("workspace:")) {
-    const inner = specifier.slice("workspace:".length);
-    return `workspace:${getVersionPrefix(inner)}`;
-  }
-  const match = specifier.match(/^([\^~>=<]+)/);
-  return match?.[1] ?? "";
-}
-
-interface PackageJsonContent {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  [key: string]: unknown;
-}
-
-/**
- * Apply non-breaking updates to package.json and run `bun install`.
- *
- * Reads the package.json, updates version ranges for the specified packages
- * (preserving the existing range prefix), writes it back, and runs install.
- */
-async function applyUpdates(
-  cwd: string,
-  updates: readonly { name: string; latestVersion: string }[]
-): Promise<Result<void, OutfitterError>> {
-  const pkgPath = join(cwd, "package.json");
-
-  let raw: string;
-  try {
-    raw = readFileSync(pkgPath, "utf-8");
-  } catch {
-    return Result.err(
-      InternalError.create("Failed to read package.json for apply", { cwd })
-    );
-  }
-
-  let pkg: PackageJsonContent;
-  try {
-    pkg = JSON.parse(raw);
-  } catch {
-    return Result.err(
-      InternalError.create("Invalid JSON in package.json", { cwd })
-    );
-  }
-
-  // Build a lookup for quick access
-  const updateMap = new Map<string, string>();
-  for (const u of updates) {
-    updateMap.set(u.name, u.latestVersion);
-  }
-
-  // Update dependencies and devDependencies in-place
-  for (const section of ["dependencies", "devDependencies"] as const) {
-    const deps = pkg[section];
-    if (!deps) continue;
-
-    for (const name of Object.keys(deps)) {
-      const newVersion = updateMap.get(name);
-      if (newVersion === undefined) continue;
-
-      const currentSpecifier = deps[name];
-      if (currentSpecifier === undefined) continue;
-
-      const prefix = getVersionPrefix(currentSpecifier);
-      deps[name] = `${prefix}${newVersion}`;
-    }
-  }
-
-  // Write the updated package.json, preserving 2-space indentation
-  try {
-    const updated = `${JSON.stringify(pkg, null, 2)}\n`;
-    await Bun.write(pkgPath, updated);
-  } catch {
-    return Result.err(
-      InternalError.create("Failed to write updated package.json", { cwd })
-    );
-  }
-
-  // Run bun install to update the lockfile
-  try {
-    const proc = Bun.spawn(["bun", "install"], {
-      cwd,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      return Result.err(
-        InternalError.create("bun install failed", {
-          cwd,
-          exitCode,
-          stderr: stderr.trim(),
-        })
-      );
-    }
-  } catch {
-    return Result.err(
-      InternalError.create("Failed to run bun install", { cwd })
-    );
-  }
-
-  return Result.ok(undefined);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Extract upgrade npm lookup and single-package apply internals so upgrade.ts remains orchestration-focused with stable exports.

## Testing
- bun run typecheck -- --only
- cd apps/outfitter && bun test src/__tests__/upgrade.test.ts src/__tests__/upgrade-apply.test.ts src/__tests__/upgrade-integration-report-artifact.test.ts

Closes: OS-434
