### PR TITLE
refactor(outfitter): extract init output rendering helpers

### DIFF
--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -171,6 +171,12 @@
         "default": "./dist/commands/init-option-resolution.js"
       }
     },
+    "./commands/init-output": {
+      "import": {
+        "types": "./dist/commands/init-output.d.ts",
+        "default": "./dist/commands/init-output.js"
+      }
+    },
     "./commands/jq-utils": {
       "import": {
         "types": "./dist/commands/jq-utils.d.ts",

--- a/apps/outfitter/src/commands/init-output.ts
+++ b/apps/outfitter/src/commands/init-output.ts
@@ -1,0 +1,132 @@
+import { realpath } from "node:fs/promises";
+
+import { output } from "@outfitter/cli";
+import type { OutputMode } from "@outfitter/cli/types";
+
+import { OperationCollector } from "../engine/collector.js";
+import { renderOperationPlan } from "../engine/render-plan.js";
+import { resolveStructuredOutputMode } from "../output-mode.js";
+import type { InitResult } from "./init.js";
+
+export interface PrintInitResultsOptions {
+  readonly mode?: OutputMode;
+}
+
+export async function printInitResults(
+  result: InitResult,
+  options?: PrintInitResultsOptions
+): Promise<void> {
+  // Normalize paths for display (resolves symlinks like /tmp -> /private/tmp on macOS)
+  let rootDir = result.rootDir;
+  let projectDir = result.projectDir;
+  try {
+    rootDir = await realpath(rootDir);
+    projectDir = await realpath(projectDir);
+  } catch {
+    // Fall back to raw paths if realpath fails (e.g., path doesn't exist yet in dry-run)
+  }
+
+  const structuredMode = resolveStructuredOutputMode(options?.mode);
+
+  if (result.dryRunPlan) {
+    if (structuredMode) {
+      await output(
+        {
+          rootDir,
+          projectDir,
+          structure: result.structure,
+          preset: result.preset,
+          packageName: result.packageName,
+          ...result.dryRunPlan,
+        },
+        { mode: structuredMode }
+      );
+      return;
+    }
+
+    const collector = new OperationCollector();
+    for (const op of result.dryRunPlan.operations) {
+      collector.add(op as never);
+    }
+    await renderOperationPlan(collector, { rootDir });
+    return;
+  }
+
+  if (structuredMode) {
+    await output(
+      {
+        structure: result.structure,
+        rootDir,
+        projectDir,
+        preset: result.preset,
+        packageName: result.packageName,
+        blocksAdded: result.blocksAdded ?? null,
+        postScaffold: result.postScaffold,
+        nextSteps: result.postScaffold.nextSteps,
+      },
+      { mode: structuredMode }
+    );
+    return;
+  }
+
+  const lines: string[] = [
+    `Project initialized successfully in ${rootDir}`,
+    `Structure: ${result.structure}`,
+    `Preset: ${result.preset}`,
+  ];
+
+  if (result.structure === "workspace") {
+    lines.push(`Workspace project path: ${projectDir}`);
+  }
+
+  if (result.blocksAdded) {
+    const { created, skipped, dependencies, devDependencies } =
+      result.blocksAdded;
+
+    if (created.length > 0) {
+      lines.push("", `Added ${created.length} tooling file(s):`);
+      for (const file of created) {
+        lines.push(`  \u2713 ${file}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      lines.push("", `Skipped ${skipped.length} existing file(s):`);
+      for (const file of skipped) {
+        lines.push(`  - ${file}`);
+      }
+    }
+
+    const depCount =
+      Object.keys(dependencies).length + Object.keys(devDependencies).length;
+    if (depCount > 0) {
+      lines.push("", `Added ${depCount} package(s) to package.json:`);
+      for (const [name, version] of Object.entries(dependencies)) {
+        lines.push(`  + ${name}@${version}`);
+      }
+      for (const [name, version] of Object.entries(devDependencies)) {
+        lines.push(`  + ${name}@${version} (dev)`);
+      }
+    }
+  }
+
+  if (result.postScaffold.installResult === "failed") {
+    lines.push(
+      "",
+      `Warning: bun install failed: ${result.postScaffold.installError ?? "unknown"}`
+    );
+  }
+  if (result.postScaffold.gitInitResult === "failed") {
+    lines.push(
+      "",
+      `Warning: git setup failed: ${result.postScaffold.gitError ?? "unknown"}`
+    );
+  }
+
+  lines.push("", "Next steps:");
+  for (const step of result.postScaffold.nextSteps) {
+    lines.push(`  ${step}`);
+  }
+
+  await output(lines, { mode: "human" });
+}

--- a/apps/outfitter/src/commands/init.ts
+++ b/apps/outfitter/src/commands/init.ts
@@ -7,7 +7,6 @@
  * @packageDocumentation
  */
 
-import { realpath } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 
 import {
@@ -19,13 +18,12 @@ import {
   select,
   text,
 } from "@clack/prompts";
-import { exitWithError, output } from "@outfitter/cli";
+import { exitWithError } from "@outfitter/cli";
 import type { OutputMode } from "@outfitter/cli/types";
 import { Result } from "@outfitter/contracts";
 import type { AddBlockResult } from "@outfitter/tooling";
 import type { Command } from "commander";
 
-import { OperationCollector } from "../engine/collector.js";
 import {
   deriveBinName,
   deriveProjectName,
@@ -34,8 +32,6 @@ import {
   validatePackageName,
 } from "../engine/index.js";
 import type { PostScaffoldResult } from "../engine/post-scaffold.js";
-import { renderOperationPlan } from "../engine/render-plan.js";
-import { resolveStructuredOutputMode } from "../output-mode.js";
 import {
   getInitTarget,
   INIT_TARGET_IDS,
@@ -52,6 +48,7 @@ import {
   resolvePresetFromFlags,
   type InitPresetId,
 } from "./init-option-resolution.js";
+import { printInitResults } from "./init-output.js";
 
 // =============================================================================
 // Types
@@ -59,6 +56,7 @@ import {
 
 export type { InitStructure } from "./init-execution.js";
 export type { InitPresetId } from "./init-option-resolution.js";
+export { printInitResults };
 
 /**
  * Options for the init command.
@@ -410,125 +408,6 @@ export async function runInit(
   }
 
   return Result.ok(executeResult.value);
-}
-
-export async function printInitResults(
-  result: InitResult,
-  options?: { mode?: OutputMode }
-): Promise<void> {
-  // Normalize paths for display (resolves symlinks like /tmp → /private/tmp on macOS)
-  let rootDir = result.rootDir;
-  let projectDir = result.projectDir;
-  try {
-    rootDir = await realpath(rootDir);
-    projectDir = await realpath(projectDir);
-  } catch {
-    // Fall back to raw paths if realpath fails (e.g., path doesn't exist yet in dry-run)
-  }
-
-  const structuredMode = resolveStructuredOutputMode(options?.mode);
-
-  if (result.dryRunPlan) {
-    if (structuredMode) {
-      await output(
-        {
-          rootDir,
-          projectDir,
-          structure: result.structure,
-          preset: result.preset,
-          packageName: result.packageName,
-          ...result.dryRunPlan,
-        },
-        { mode: structuredMode }
-      );
-      return;
-    }
-
-    const collector = new OperationCollector();
-    for (const op of result.dryRunPlan.operations) {
-      collector.add(op as never);
-    }
-    await renderOperationPlan(collector, { rootDir });
-    return;
-  }
-
-  if (structuredMode) {
-    await output(
-      {
-        structure: result.structure,
-        rootDir,
-        projectDir,
-        preset: result.preset,
-        packageName: result.packageName,
-        blocksAdded: result.blocksAdded ?? null,
-        postScaffold: result.postScaffold,
-        nextSteps: result.postScaffold.nextSteps,
-      },
-      { mode: structuredMode }
-    );
-    return;
-  }
-
-  const lines: string[] = [
-    `Project initialized successfully in ${rootDir}`,
-    `Structure: ${result.structure}`,
-    `Preset: ${result.preset}`,
-  ];
-
-  if (result.structure === "workspace") {
-    lines.push(`Workspace project path: ${projectDir}`);
-  }
-
-  if (result.blocksAdded) {
-    const { created, skipped, dependencies, devDependencies } =
-      result.blocksAdded;
-
-    if (created.length > 0) {
-      lines.push("", `Added ${created.length} tooling file(s):`);
-      for (const file of created) {
-        lines.push(`  ✓ ${file}`);
-      }
-    }
-
-    if (skipped.length > 0) {
-      lines.push("", `Skipped ${skipped.length} existing file(s):`);
-      for (const file of skipped) {
-        lines.push(`  - ${file}`);
-      }
-    }
-
-    const depCount =
-      Object.keys(dependencies).length + Object.keys(devDependencies).length;
-    if (depCount > 0) {
-      lines.push("", `Added ${depCount} package(s) to package.json:`);
-      for (const [name, version] of Object.entries(dependencies)) {
-        lines.push(`  + ${name}@${version}`);
-      }
-      for (const [name, version] of Object.entries(devDependencies)) {
-        lines.push(`  + ${name}@${version} (dev)`);
-      }
-    }
-  }
-
-  if (result.postScaffold.installResult === "failed") {
-    lines.push(
-      "",
-      `Warning: bun install failed: ${result.postScaffold.installError ?? "unknown"}`
-    );
-  }
-  if (result.postScaffold.gitInitResult === "failed") {
-    lines.push(
-      "",
-      `Warning: git setup failed: ${result.postScaffold.gitError ?? "unknown"}`
-    );
-  }
-
-  lines.push("", "Next steps:");
-  for (const step of result.postScaffold.nextSteps) {
-    lines.push(`  ${step}`);
-  }
-
-  await output(lines, { mode: "human" });
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Move printInitResults into init-output.ts and keep init command wiring and output behavior unchanged.

## Testing
- bun run typecheck -- --only
- cd apps/outfitter && bun test src/__tests__/init-output-and-force.test.ts src/__tests__/actions.test.ts

Closes: OS-437
