### PR TITLE
test(outfitter): add init and scaffold modularity guardrails

### DIFF
--- a/apps/outfitter/src/__tests__/init-scaffold-modularity.test.ts
+++ b/apps/outfitter/src/__tests__/init-scaffold-modularity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { executeInitPipeline } from "../commands/init-execution.js";
+import { parseBlocks } from "../commands/init-option-resolution.js";
+import { printInitResults as printInitResultsFromOutput } from "../commands/init-output.js";
+import { printInitResults, runInit } from "../commands/init.js";
+import { printScaffoldResults as printScaffoldResultsFromOutput } from "../commands/scaffold-output.js";
+import { buildScaffoldPlan } from "../commands/scaffold-planning.js";
+import { printScaffoldResults, runScaffold } from "../commands/scaffold.js";
+
+describe("init/scaffold modularity boundaries", () => {
+  test("keeps init output helper re-exported through init entrypoint", () => {
+    expect(printInitResults).toBe(printInitResultsFromOutput);
+  });
+
+  test("keeps scaffold output helper re-exported through scaffold entrypoint", () => {
+    expect(printScaffoldResults).toBe(printScaffoldResultsFromOutput);
+  });
+
+  test("keeps extracted init/scaffold modules importable", () => {
+    expect(typeof runInit).toBe("function");
+    expect(typeof printInitResults).toBe("function");
+    expect(typeof executeInitPipeline).toBe("function");
+    expect(typeof parseBlocks).toBe("function");
+    expect(typeof runScaffold).toBe("function");
+    expect(typeof printScaffoldResults).toBe("function");
+    expect(typeof buildScaffoldPlan).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Add parent-level modularity guards that verify init/scaffold extracted modules remain importable and re-exported through entrypoints.

## Testing
- bun run typecheck -- --only
- cd apps/outfitter && bun test src/__tests__/init-scaffold-modularity.test.ts src/__tests__/scaffold.test.ts src/__tests__/actions.test.ts

Closes: OS-429
