### PR TITLE
docs(outfitter): add TSDoc to stack-introduced exports

### DIFF
--- a/apps/outfitter/src/actions.ts
+++ b/apps/outfitter/src/actions.ts
@@ -40,6 +40,7 @@ import {
 import { scaffoldAction } from "./actions/scaffold.js";
 import { upgradeAction } from "./actions/upgrade.js";
 
+/** Central action registry containing all Outfitter CLI commands. */
 export const outfitterActions: ActionRegistry = createActionRegistry()
   .add(createAction)
   .add(scaffoldAction)

--- a/apps/outfitter/src/actions/add.ts
+++ b/apps/outfitter/src/actions/add.ts
@@ -43,6 +43,7 @@ const addCwd = cwdPreset();
 
 type AddAction = ReturnType<typeof defineAction<AddActionInput, unknown>>;
 
+/** Add a block from the registry to the current project. */
 export const addAction: AddAction = defineAction({
   id: "add",
   description: "Add a block from the registry to your project",
@@ -88,6 +89,7 @@ type ListBlocksAction = ReturnType<
   typeof defineAction<{ outputMode: CliOutputMode }, unknown>
 >;
 
+/** List all blocks available in the registry. */
 export const listBlocksAction: ListBlocksAction = defineAction({
   id: "add.list",
   description: "List available blocks",

--- a/apps/outfitter/src/actions/check-automation.ts
+++ b/apps/outfitter/src/actions/check-automation.ts
@@ -78,6 +78,7 @@ function mapCheckAutomationInput(context: {
   };
 }
 
+/** Validate that publishable packages enforce prepublishOnly guardrails. */
 export const checkPublishGuardrailsAction: CheckAutomationAction = defineAction(
   {
     id: "check.publish-guardrails",
@@ -115,6 +116,7 @@ export const checkPublishGuardrailsAction: CheckAutomationAction = defineAction(
   }
 );
 
+/** Validate preset dependency versions, registry versions, and Bun version consistency. */
 export const checkPresetVersionsAction: CheckAutomationAction = defineAction({
   id: "check.preset-versions",
   description:
@@ -147,6 +149,7 @@ export const checkPresetVersionsAction: CheckAutomationAction = defineAction({
   },
 });
 
+/** Validate that surface map references use the canonical root path only. */
 export const checkSurfaceMapAction: CheckAutomationAction = defineAction({
   id: "check.surface-map",
   description:
@@ -179,6 +182,7 @@ export const checkSurfaceMapAction: CheckAutomationAction = defineAction({
   },
 });
 
+/** Validate canonical JSON formatting of `.outfitter/surface.json`. */
 export const checkSurfaceMapFormatAction: CheckAutomationAction = defineAction({
   id: "check.surface-map-format",
   description: "Validate canonical formatting for .outfitter/surface.json",
@@ -209,6 +213,7 @@ export const checkSurfaceMapFormatAction: CheckAutomationAction = defineAction({
   },
 });
 
+/** Validate that the `docs/README.md` PACKAGE_LIST sentinel is up to date. */
 export const checkDocsSentinelAction: CheckAutomationAction = defineAction({
   id: "check.docs-sentinel",
   description: "Validate docs/README.md PACKAGE_LIST sentinel freshness",
@@ -239,6 +244,7 @@ export const checkDocsSentinelAction: CheckAutomationAction = defineAction({
   },
 });
 
+/** Validate action ceremony guardrails (TSDoc, input schemas, handler patterns). */
 export const checkActionCeremonyAction: CheckAutomationAction = defineAction({
   id: "check.action-ceremony",
   description:

--- a/apps/outfitter/src/actions/check.ts
+++ b/apps/outfitter/src/actions/check.ts
@@ -124,6 +124,7 @@ function resolveCheckMode(
   return requestedModes[0];
 }
 
+/** Compare local config blocks against the registry for drift, or orchestrate a suite of checks. */
 export const checkAction: CheckAction = defineAction({
   id: "check",
   description:
@@ -266,6 +267,7 @@ const checkTsdocInputSchema = z.object({
   packages: z.array(z.string()),
 });
 
+/** Zod schema describing the output shape of a TSDoc coverage check. */
 export const checkTsdocOutputSchema: z.ZodType<TsDocCheckResult> = z.object({
   ok: z.boolean(),
   packages: z.array(
@@ -300,6 +302,7 @@ export const checkTsdocOutputSchema: z.ZodType<TsDocCheckResult> = z.object({
 const checkTsdocOutputMode = outputModePreset({ includeJsonl: true });
 const checkTsdocJq = jqPreset();
 
+/** Check TSDoc coverage on exported declarations across workspace packages. */
 export const checkTsdocAction: CheckTsdocAction = defineAction({
   id: "check.tsdoc",
   description: "Check TSDoc coverage on exported declarations",

--- a/apps/outfitter/src/actions/demo.ts
+++ b/apps/outfitter/src/actions/demo.ts
@@ -33,6 +33,7 @@ const demoInputSchema = z.object({
   outputMode: outputModeSchema,
 });
 
+/** Run the interactive CLI demo showcasing TUI components and output modes. */
 export const demoAction: DemoAction = defineAction({
   id: "demo",
   description: "Run the CLI demo app",

--- a/apps/outfitter/src/actions/docs.ts
+++ b/apps/outfitter/src/actions/docs.ts
@@ -57,6 +57,7 @@ const docsListJq = jqPreset();
 
 type DocsListAction = ReturnType<typeof defineAction<DocsListInput, unknown>>;
 
+/** List documentation entries from the workspace docs map. */
 export const docsListAction: DocsListAction = defineAction({
   id: "docs.list",
   description: "List documentation entries from the docs map",
@@ -124,6 +125,7 @@ const docsShowJq = jqPreset();
 
 type DocsShowAction = ReturnType<typeof defineAction<DocsShowInput, unknown>>;
 
+/** Show a specific documentation entry by ID, including its content. */
 export const docsShowAction: DocsShowAction = defineAction({
   id: "docs.show",
   description: "Show a specific documentation entry and its content",
@@ -183,6 +185,7 @@ type DocsSearchAction = ReturnType<
   typeof defineAction<DocsSearchInput, unknown>
 >;
 
+/** Search documentation content for a query string. */
 export const docsSearchAction: DocsSearchAction = defineAction({
   id: "docs.search",
   description: "Search documentation content for a query string",
@@ -252,6 +255,7 @@ const docsApiJq = jqPreset();
 
 type DocsApiAction = ReturnType<typeof defineAction<DocsApiInput, unknown>>;
 
+/** Extract API reference from TSDoc coverage data. */
 export const docsApiAction: DocsApiAction = defineAction({
   id: "docs.api",
   description: "Extract API reference from TSDoc coverage data",
@@ -348,6 +352,7 @@ type DocsExportAction = ReturnType<
   typeof defineAction<DocsExportInput, unknown>
 >;
 
+/** Export documentation to package READMEs, llms.txt, or both. */
 export const docsExportAction: DocsExportAction = defineAction({
   id: "docs.export",
   description: "Export documentation to packages, llms.txt, or both",

--- a/apps/outfitter/src/actions/doctor.ts
+++ b/apps/outfitter/src/actions/doctor.ts
@@ -29,6 +29,7 @@ const doctorInputSchema = z.object({
 
 const doctorCwd = cwdPreset();
 
+/** Validate the local environment, toolchain, and project dependencies. */
 export const doctorAction: DoctorAction = defineAction({
   id: "doctor",
   description: "Validate environment and dependencies",

--- a/apps/outfitter/src/actions/init.ts
+++ b/apps/outfitter/src/actions/init.ts
@@ -273,6 +273,7 @@ function createInitAction(options: {
   });
 }
 
+/** Removed stub -- directs users to `outfitter init`. */
 export const createAction: ActionSpec<{}, unknown, InternalError> =
   defineAction({
     id: "create",
@@ -305,6 +306,7 @@ export const createAction: ActionSpec<{}, unknown, InternalError> =
       ),
   });
 
+/** Create a new Outfitter project with an optional preset. */
 export const initAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init",
@@ -313,6 +315,7 @@ export const initAction: ActionSpec<InitActionInput, unknown> =
     includePresetOption: true,
   });
 
+/** Create a new CLI project using the `cli` preset. */
 export const initCliAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.cli",
@@ -321,6 +324,7 @@ export const initCliAction: ActionSpec<InitActionInput, unknown> =
     presetOverride: "cli",
   });
 
+/** Create a new MCP server project using the `mcp` preset. */
 export const initMcpAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.mcp",
@@ -329,6 +333,7 @@ export const initMcpAction: ActionSpec<InitActionInput, unknown> =
     presetOverride: "mcp",
   });
 
+/** Create a new daemon project using the `daemon` preset. */
 export const initDaemonAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.daemon",
@@ -337,6 +342,7 @@ export const initDaemonAction: ActionSpec<InitActionInput, unknown> =
     presetOverride: "daemon",
   });
 
+/** Create a new library project using the `library` preset. */
 export const initLibraryAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.library",
@@ -345,6 +351,7 @@ export const initLibraryAction: ActionSpec<InitActionInput, unknown> =
     presetOverride: "library",
   });
 
+/** Create a full-stack workspace with CLI, MCP, daemon, and library targets. */
 export const initFullStackAction: ActionSpec<InitActionInput, unknown> =
   createInitAction({
     id: "init.full-stack",

--- a/apps/outfitter/src/actions/scaffold.ts
+++ b/apps/outfitter/src/actions/scaffold.ts
@@ -100,6 +100,7 @@ function resolveScaffoldOptions(context: {
   };
 }
 
+/** Add a capability (CLI, MCP, daemon, library) to an existing project. */
 export const scaffoldAction: ScaffoldAction = defineAction({
   id: "scaffold",
   description: "Add a capability to an existing project",

--- a/apps/outfitter/src/actions/upgrade.ts
+++ b/apps/outfitter/src/actions/upgrade.ts
@@ -86,6 +86,7 @@ const upgradeFlags = actionCliPresets(
   upgradeGuide
 );
 
+/** Check for available `@outfitter/*` package updates and show migration guidance. */
 export const upgradeAction: UpgradeAction = defineAction({
   id: "upgrade",
   description: "Check for @outfitter/* package updates and migration guidance",

--- a/apps/outfitter/src/commands/check-action-ceremony.ts
+++ b/apps/outfitter/src/commands/check-action-ceremony.ts
@@ -41,24 +41,34 @@ const CEREMONY_BUDGETS: readonly CeremonyBudget[] = [
 
 type CeremonyBudgetId = (typeof CEREMONY_BUDGETS)[number]["id"];
 
+/** Options for the action-ceremony guardrail check. */
 export interface CheckActionCeremonyOptions {
+  /** Workspace root used to locate the actions directory. */
   readonly cwd: string;
 }
 
+/** Result for a single ceremony budget after scanning action sources. */
 export interface CeremonyBudgetResult {
+  /** Number of pattern occurrences found. */
   readonly count: number;
   readonly description: string;
   readonly id: string;
+  /** Maximum allowed occurrences before the budget is exceeded. */
   readonly maxCount: number;
+  /** Whether the count is within the allowed budget. */
   readonly ok: boolean;
 }
 
+/** Aggregate result of the action-ceremony check across all budgets. */
 export interface CheckActionCeremonyResult {
+  /** Resolved path to the scanned actions directory. */
   readonly actionsDir: string;
   readonly budgets: readonly CeremonyBudgetResult[];
+  /** True when every budget is within its allowed count. */
   readonly ok: boolean;
 }
 
+/** Error raised when the action-ceremony check cannot complete. */
 export class CheckActionCeremonyError extends Error {
   readonly _tag = "CheckActionCeremonyError" as const;
 
@@ -79,6 +89,13 @@ function readActionSources(actionsDir: string): readonly string[] {
     .map((entry) => resolve(actionsDir, entry));
 }
 
+/**
+ * Scan action source files and evaluate each ceremony budget.
+ *
+ * Reads all `.ts` files under the actions directory and counts pattern
+ * matches against pre-defined budgets. Returns per-budget results and
+ * an aggregate pass/fail.
+ */
 export async function runCheckActionCeremony(
   options: CheckActionCeremonyOptions
 ): Promise<Result<CheckActionCeremonyResult, CheckActionCeremonyError>> {
@@ -133,6 +150,12 @@ export async function runCheckActionCeremony(
   }
 }
 
+/**
+ * Render ceremony check results to stdout/stderr.
+ *
+ * Emits JSON/JSONL for structured modes or a human-readable summary
+ * listing any budgets that exceeded their limit.
+ */
 export async function printCheckActionCeremonyResult(
   result: CheckActionCeremonyResult,
   options?: { mode?: CliOutputMode }
@@ -205,6 +228,11 @@ function parseCliArgs(argv: readonly string[]): ParsedCliArgs {
   };
 }
 
+/**
+ * CLI entry point: parse argv, run the ceremony check, and print results.
+ *
+ * @returns Exit code (0 on success, 1 on failure or error).
+ */
 export async function runCheckActionCeremonyFromArgv(
   argv: readonly string[]
 ): Promise<number> {

--- a/apps/outfitter/src/commands/docs-api.ts
+++ b/apps/outfitter/src/commands/docs-api.ts
@@ -26,10 +26,14 @@ import { applyJq } from "./jq-utils.js";
 
 /** Validated input for the docs.api action handler. */
 export interface DocsApiInput {
+  /** Workspace root used to resolve package paths. */
   readonly cwd: string;
+  /** Optional jq expression applied to structured output. */
   readonly jq?: string | undefined;
+  /** Filter declarations by documentation coverage level. */
   readonly level?: "documented" | "partial" | "undocumented" | undefined;
   readonly outputMode: CliOutputMode;
+  /** Package names to include; empty array means all packages. */
   readonly packages: string[];
 }
 

--- a/apps/outfitter/src/commands/init-execution.ts
+++ b/apps/outfitter/src/commands/init-execution.ts
@@ -21,8 +21,10 @@ import { runPostScaffold } from "../engine/post-scaffold.js";
 import type { TargetDefinition } from "../targets/index.js";
 import type { InitPresetId } from "./init-option-resolution.js";
 
+/** Whether the project is a standalone package or a workspace with nested packages. */
 export type InitStructure = "single" | "workspace";
 
+/** Fully resolved inputs for the init execution pipeline, after interactive/non-interactive resolution. */
 export interface ResolvedInitExecutionInput {
   readonly binName?: string | undefined;
   readonly blocksOverride?: readonly string[];
@@ -35,6 +37,7 @@ export interface ResolvedInitExecutionInput {
   readonly workspaceName?: string | undefined;
 }
 
+/** Behavioral flags controlling how the init pipeline executes (dry-run, force, skip steps). */
 export interface InitExecutionOptions {
   readonly dryRun: boolean;
   readonly force: boolean;
@@ -44,6 +47,7 @@ export interface InitExecutionOptions {
   readonly skipInstall: boolean;
 }
 
+/** Output of a successful init pipeline run, including scaffold results and post-scaffold status. */
 export interface InitExecutionResult {
   readonly blocksAdded?: AddBlockResult | undefined;
   readonly dryRunPlan?:
@@ -105,6 +109,14 @@ function buildInitPlan(
   };
 }
 
+/**
+ * Runs the full init pipeline: validates inputs, scaffolds the project structure,
+ * executes the preset plan, and performs post-scaffold steps (install, git init).
+ * @param input - Resolved user inputs (preset, structure, package name, etc.)
+ * @param target - Target definition from the preset registry
+ * @param options - Execution flags (dry-run, force, skip steps)
+ * @returns The init result on success, or an error message string on failure
+ */
 export async function executeInitPipeline(
   input: ResolvedInitExecutionInput,
   target: TargetDefinition,

--- a/apps/outfitter/src/commands/init-option-resolution.ts
+++ b/apps/outfitter/src/commands/init-option-resolution.ts
@@ -2,11 +2,16 @@ import { Result } from "@outfitter/contracts";
 
 import type { TargetId } from "../targets/index.js";
 
+/** Subset of target IDs that are valid presets for `outfitter init`. */
 export type InitPresetId = Extract<
   TargetId,
   "minimal" | "cli" | "mcp" | "daemon" | "library" | "full-stack"
 >;
 
+/**
+ * Parses a comma-separated `--with` flag value into an array of block names.
+ * @returns The parsed block names, or `undefined` if the flag is empty/absent.
+ */
 export function parseBlocks(
   withFlag: string | undefined
 ): readonly string[] | undefined {
@@ -22,10 +27,12 @@ export function parseBlocks(
   return blocks.length > 0 ? blocks : undefined;
 }
 
+/** Returns `true` if the preset produces a project with a binary entry point. */
 export function isBinaryPreset(preset: InitPresetId): boolean {
   return preset === "cli" || preset === "daemon";
 }
 
+/** Type guard that narrows a string to {@link InitPresetId}. */
 export function isValidInitPreset(value: string): value is InitPresetId {
   return (
     value === "minimal" ||
@@ -37,6 +44,10 @@ export function isValidInitPreset(value: string): value is InitPresetId {
   );
 }
 
+/**
+ * Validates and resolves a `--preset` flag value against the available preset list.
+ * @returns The validated preset ID, `undefined` if no flag was provided, or an error for unknown presets.
+ */
 export function resolvePresetFromFlags(
   presetFromFlag: string | undefined,
   availablePresetIds: readonly string[]

--- a/apps/outfitter/src/commands/init-output.ts
+++ b/apps/outfitter/src/commands/init-output.ts
@@ -8,10 +8,15 @@ import { renderOperationPlan } from "../engine/render-plan.js";
 import { resolveStructuredOutputMode } from "../output-mode.js";
 import type { InitResult } from "./init.js";
 
+/** Options controlling how init results are rendered (human-readable, JSON, or JSONL). */
 export interface PrintInitResultsOptions {
   readonly mode?: OutputMode;
 }
 
+/**
+ * Renders init results to stdout. Handles dry-run plans, structured output modes,
+ * and human-readable summaries with next-step guidance.
+ */
 export async function printInitResults(
   result: InitResult,
   options?: PrintInitResultsOptions

--- a/apps/outfitter/src/commands/init.ts
+++ b/apps/outfitter/src/commands/init.ts
@@ -59,43 +59,67 @@ export type { InitPresetId } from "./init-option-resolution.js";
 export { printInitResults };
 
 /**
- * Options for the init command.
+ * Options for the init command, corresponding to CLI flags and positional arguments.
  */
 export interface InitOptions {
+  /** Custom binary name for CLI/daemon presets. */
   readonly bin?: string | undefined;
+  /** Preview changes without writing to disk. */
   readonly dryRun?: boolean | undefined;
+  /** Overwrite existing files without prompting. */
   readonly force: boolean;
+  /** Timeout in milliseconds for `bun install`. */
   readonly installTimeout?: number | undefined;
+  /** Use `workspace:*` protocol for `@outfitter` dependencies. */
   readonly local?: boolean | undefined;
+  /** Package name override (defaults to directory name). */
   readonly name: string | undefined;
+  /** Skip adding default tooling blocks. */
   readonly noTooling?: boolean | undefined;
+  /** Preset to scaffold from. */
   readonly preset?: InitPresetId | undefined;
+  /** Skip the initial git commit after scaffolding. */
   readonly skipCommit?: boolean | undefined;
+  /** Skip git init and initial commit entirely. */
   readonly skipGit?: boolean | undefined;
+  /** Skip running `bun install` after scaffolding. */
   readonly skipInstall?: boolean | undefined;
+  /** Whether to create a single package or a workspace. */
   readonly structure?: InitStructure | undefined;
+  /** Absolute or relative path to the target directory. */
   readonly targetDir: string;
+  /** Comma-separated tooling block names to include. */
   readonly with?: string | undefined;
+  /** Package name for the workspace root (workspace structure only). */
   readonly workspaceName?: string | undefined;
+  /** Skip interactive prompts and use defaults. */
   readonly yes?: boolean | undefined;
 }
 
 /**
- * Result of running init.
+ * Result of a successful `outfitter init` run.
  */
 export interface InitResult {
+  /** Tooling blocks that were added, if any. */
   readonly blocksAdded?: AddBlockResult | undefined;
+  /** Present only for dry-run invocations; contains the planned operations and summary counts. */
   readonly dryRunPlan?:
     | {
         readonly operations: readonly unknown[];
         readonly summary: Record<string, number>;
       }
     | undefined;
+  /** The resolved npm package name for the scaffolded project. */
   readonly packageName: string;
+  /** Results from post-scaffold steps (install, git init, next-step hints). */
   readonly postScaffold: PostScaffoldResult;
+  /** The preset that was used. */
   readonly preset: InitPresetId;
+  /** Absolute path to the scaffolded project directory. */
   readonly projectDir: string;
+  /** Absolute path to the workspace or project root. */
   readonly rootDir: string;
+  /** Whether a single package or workspace was created. */
   readonly structure: InitStructure;
 }
 
@@ -107,6 +131,7 @@ type ResolvedInitInput = ResolvedInitExecutionInput;
 export class InitError extends Error {
   readonly _tag = "InitError" as const;
 
+  /** @param message - Human-readable description of the init failure. */
   constructor(message: string) {
     super(message);
     this.name = "InitError";
@@ -379,6 +404,12 @@ async function resolveInitInput(
 // Public API
 // =============================================================================
 
+/**
+ * Runs the full init flow: resolves user input (interactive or non-interactive),
+ * looks up the target preset, and delegates to the execution pipeline.
+ * @param options - Init options from CLI flags or programmatic callers
+ * @param presetOverride - Forces a specific preset, bypassing flag resolution and prompts
+ */
 export async function runInit(
   options: InitOptions,
   presetOverride?: InitPresetId
@@ -472,6 +503,7 @@ const withCommonOptions = (command: Command): Command =>
     .option("--install-timeout <ms>", "bun install timeout in ms");
 
 /**
+ * Registers the `init` command and its preset subcommands on a Commander program.
  * @deprecated Use action-registry CLI wiring via `buildCliCommands(outfitterActions, ...)`.
  */
 export function initCommand(program: Command): void {

--- a/apps/outfitter/src/commands/scaffold-output.ts
+++ b/apps/outfitter/src/commands/scaffold-output.ts
@@ -6,10 +6,15 @@ import { renderOperationPlan } from "../engine/render-plan.js";
 import { resolveStructuredOutputMode } from "../output-mode.js";
 import type { ScaffoldCommandResult } from "./scaffold.js";
 
+/** Options controlling how scaffold results are rendered (human-readable, JSON, or JSONL). */
 export interface PrintScaffoldResultsOptions {
   readonly mode?: OutputMode;
 }
 
+/**
+ * Renders scaffold results to stdout. Handles dry-run plans, structured output modes,
+ * and human-readable summaries including workspace conversion details and next steps.
+ */
 export async function printScaffoldResults(
   result: ScaffoldCommandResult,
   options?: PrintScaffoldResultsOptions

--- a/apps/outfitter/src/commands/scaffold-planning.ts
+++ b/apps/outfitter/src/commands/scaffold-planning.ts
@@ -48,6 +48,7 @@ interface PresetMetadata {
   readonly surfaces?: readonly ("cli" | "mcp" | "daemon")[];
 }
 
+/** Discriminated union describing the detected project layout at a given directory. */
 export type ProjectStructure =
   | {
       readonly kind: "workspace";
@@ -120,6 +121,10 @@ function extractWorkspacePatterns(pkg: PackageJsonData): readonly string[] {
   return [];
 }
 
+/**
+ * Detects whether the given directory is a workspace root, a single package,
+ * or has no package.json at all. Walks up to find workspace roots when needed.
+ */
 export function detectProjectStructure(
   cwd: string
 ): Result<ProjectStructure, string> {
@@ -264,6 +269,10 @@ function parsePresetSurfaces(
   return surfaces.length === value.length ? surfaces : undefined;
 }
 
+/**
+ * Ensures the workspace root package.json includes the given placement pattern (e.g. "apps/*").
+ * @returns `true` if the pattern was added, `false` if it already existed.
+ */
 export function ensureWorkspacePattern(
   rootDir: string,
   placement: "apps" | "packages",
@@ -344,6 +353,11 @@ function movePath(source: string, destination: string): void {
   }
 }
 
+/**
+ * Converts a single-package directory into a workspace by moving existing files
+ * into the appropriate `apps/` or `packages/` subdirectory and creating a workspace root.
+ * Rolls back on failure.
+ */
 export function convertToWorkspace(
   rootDir: string,
   existingPkg: Record<string, unknown>,
@@ -498,6 +512,10 @@ function parseBlocks(
   return blocks.length > 0 ? blocks : undefined;
 }
 
+/**
+ * Builds a scaffold plan for a target within a workspace, including preset
+ * copying, shared config injection, and optional tooling blocks.
+ */
 export function buildScaffoldPlan(
   target: TargetDefinition,
   rootDir: string,
@@ -539,6 +557,10 @@ export function buildScaffoldPlan(
   };
 }
 
+/**
+ * Validates that a scaffold target name is safe as both a directory name and an npm package name.
+ * Suggests a sanitized alternative when the name is invalid.
+ */
 export function validateScaffoldTargetName(
   targetName: string
 ): Result<void, string> {

--- a/apps/outfitter/src/commands/scaffold.ts
+++ b/apps/outfitter/src/commands/scaffold.ts
@@ -32,28 +32,44 @@ import {
   validateScaffoldTargetName,
 } from "./scaffold-planning.js";
 
+/** Options for the scaffold command, corresponding to CLI flags and positional arguments. */
 export interface ScaffoldOptions {
+  /** Working directory to scaffold in. */
   readonly cwd: string;
+  /** Preview changes without writing to disk. */
   readonly dryRun: boolean;
+  /** Overwrite existing files without prompting. */
   readonly force: boolean;
+  /** Timeout in milliseconds for `bun install`. */
   readonly installTimeout?: number | undefined;
+  /** Use `workspace:*` protocol for `@outfitter` dependencies. */
   readonly local?: boolean | undefined;
+  /** Override the default target directory name. */
   readonly name?: string | undefined;
+  /** Skip adding default tooling blocks. */
   readonly noTooling?: boolean | undefined;
+  /** Skip running `bun install` after scaffolding. */
   readonly skipInstall: boolean;
+  /** Target preset ID to scaffold (e.g. "cli", "mcp"). */
   readonly target: string;
+  /** Comma-separated tooling block names to include. */
   readonly with?: string | undefined;
 }
 
+/** Result of a successful `outfitter scaffold` run. */
 export interface ScaffoldCommandResult {
+  /** Tooling blocks that were added, if any. */
   readonly blocksAdded?: AddBlockResult | undefined;
+  /** Whether the project was converted from single-package to workspace. */
   readonly converted: boolean;
+  /** Present only for dry-run invocations; contains the planned operations and summary counts. */
   readonly dryRunPlan?:
     | {
         readonly operations: readonly unknown[];
         readonly summary: Record<string, number>;
       }
     | undefined;
+  /** Details of the existing package that was relocated during workspace conversion. */
   readonly movedExisting?:
     | {
         readonly from: string;
@@ -61,16 +77,23 @@ export interface ScaffoldCommandResult {
         readonly name: string;
       }
     | undefined;
+  /** Results from post-scaffold steps (install, next-step hints). */
   readonly postScaffold: PostScaffoldResult;
+  /** Absolute path to the workspace root. */
   readonly rootDir: string;
+  /** The target preset ID that was scaffolded. */
   readonly target: string;
+  /** Absolute path to the scaffolded target directory. */
   readonly targetDir: string;
+  /** Whether a new workspace pattern was added to the root package.json. */
   readonly workspacePatternsUpdated: boolean;
 }
 
+/** Error returned when scaffolding fails. */
 export class ScaffoldCommandError extends Error {
   readonly _tag = "ScaffoldCommandError" as const;
 
+  /** @param message - Human-readable description of the scaffold failure. */
   constructor(message: string) {
     super(message);
     this.name = "ScaffoldCommandError";
@@ -79,6 +102,10 @@ export class ScaffoldCommandError extends Error {
 
 export { printScaffoldResults };
 
+/**
+ * Runs the full scaffold flow: detects project structure, converts to workspace
+ * if needed, executes the preset plan, and performs post-scaffold steps.
+ */
 export async function runScaffold(
   options: ScaffoldOptions
 ): Promise<Result<ScaffoldCommandResult, ScaffoldCommandError>> {
@@ -256,6 +283,7 @@ export async function runScaffold(
 }
 
 /**
+ * Registers the `scaffold` command on a Commander program.
  * @deprecated Use action-registry CLI wiring via `buildCliCommands(outfitterActions, ...)`.
  */
 export function scaffoldCommand(program: Command): void {

--- a/apps/outfitter/src/commands/upgrade-codemods.ts
+++ b/apps/outfitter/src/commands/upgrade-codemods.ts
@@ -177,6 +177,11 @@ function resolveCodemodPath(
 
 /**
  * Run a single codemod by importing and executing its `transform` function.
+ *
+ * @param codemodPath - Absolute path to the codemod module
+ * @param targetDir - Root directory the codemod should operate on
+ * @param dryRun - When `true`, the codemod previews changes without writing
+ * @returns Codemod result with changed/skipped files, or an error
  */
 export async function runCodemod(
   codemodPath: string,

--- a/apps/outfitter/src/commands/upgrade-latest-version.ts
+++ b/apps/outfitter/src/commands/upgrade-latest-version.ts
@@ -1,5 +1,8 @@
 /**
  * Query npm registry for the latest version of a package.
+ *
+ * @param name - Full npm package name (e.g. "@outfitter/cli")
+ * @returns Trimmed version string, or `null` if the lookup fails or returns empty
  */
 export async function getLatestVersion(name: string): Promise<string | null> {
   try {

--- a/apps/outfitter/src/commands/upgrade-migration-guides.ts
+++ b/apps/outfitter/src/commands/upgrade-migration-guides.ts
@@ -7,6 +7,7 @@ import type { PackageVersionInfo } from "./upgrade.js";
 
 type GuidePackageVersionInfo = PackageVersionInfo;
 
+/** Structured migration guide for a single package upgrade. */
 export interface MigrationGuide {
   /** Whether this is a breaking change */
   readonly breaking: boolean;

--- a/apps/outfitter/src/commands/upgrade-output.ts
+++ b/apps/outfitter/src/commands/upgrade-output.ts
@@ -9,6 +9,7 @@ import {
 } from "./upgrade-migration-docs.js";
 import type { UpgradeResult } from "./upgrade.js";
 
+/** Options controlling how upgrade results are rendered. */
 export interface PrintUpgradeResultsOptions {
   readonly all?: boolean;
   readonly cwd?: string;
@@ -19,6 +20,9 @@ export interface PrintUpgradeResultsOptions {
 
 /**
  * Format and output upgrade results.
+ *
+ * @param result - Upgrade scan/apply result to render
+ * @param options - Display options (output mode, guide, dry-run hints)
  */
 export async function printUpgradeResults(
   result: UpgradeResult,

--- a/apps/outfitter/src/commands/upgrade-report.ts
+++ b/apps/outfitter/src/commands/upgrade-report.ts
@@ -12,6 +12,7 @@ import type {
   UpgradeResult,
 } from "./upgrade.js";
 
+/** Terminal disposition of an upgrade run (written into the report). */
 export type UpgradeReportStatus =
   | "dry_run"
   | "no_updates"
@@ -61,6 +62,7 @@ export interface UpgradeReport {
   readonly workspaceRoot: string | null;
 }
 
+/** Contextual metadata passed alongside the result when writing a report. */
 export interface WriteUpgradeReportMeta {
   readonly error?: OutfitterError;
   readonly options: UpgradeOptions;

--- a/apps/outfitter/src/commands/upgrade.ts
+++ b/apps/outfitter/src/commands/upgrade.ts
@@ -46,6 +46,7 @@ import {
 // Types
 // =============================================================================
 
+/** Input options for `runUpgrade`. */
 export interface UpgradeOptions {
   /** Include breaking changes in the upgrade */
   readonly all?: boolean;
@@ -67,6 +68,7 @@ export interface UpgradeOptions {
   readonly yes?: boolean;
 }
 
+/** Version metadata for a single installed @outfitter/* package. */
 export interface PackageVersionInfo {
   /** Whether the update contains breaking changes (major bump) */
   readonly breaking: boolean;
@@ -112,6 +114,7 @@ export interface CodemodSummary {
   readonly errors: readonly string[];
 }
 
+/** Complete output of a single upgrade run. */
 export interface UpgradeResult {
   /** Whether mutations were made (--apply was used and changes were written) */
   readonly applied: boolean;


### PR DESCRIPTION
## Summary

The OS-425 through OS-439 stack introduced 13 new extraction modules and modified 17 existing files — almost all with zero TSDoc on public exports. This PR adds documentation to every exported function, interface, type, class, and constant across those files.

- **27 files touched**, +256 lines of pure TSDoc (no logic changes)
- **87 exports documented**: action constants, shared utilities, check commands, init/scaffold/upgrade extraction modules
- Style matches existing well-documented files (`upgrade-migration-docs.ts`, `docs-api.ts`)

### What's covered

| Area | Files | Exports |
|------|-------|---------|
| Shared action utilities | `actions/shared.ts` | 12 functions (flag resolution, error adapters) |
| Action constants | `actions/*.ts` (10 files) | 40 `defineAction()` exports with user-facing descriptions |
| Check commands | `check-action-ceremony.ts`, `check-orchestrator.ts` | 15 interfaces, classes, and functions |
| Init extraction modules | `init-execution.ts`, `init-option-resolution.ts`, `init-output.ts`, `init.ts` | 17 exports |
| Scaffold extraction modules | `scaffold-output.ts`, `scaffold-planning.ts`, `scaffold.ts` | 13 exports |
| Upgrade partials | 6 upgrade-*.ts files | Filled gaps in interfaces and added @param/@returns |

## Test plan

- [x] `bun run typecheck` passes (no logic changes, TSDoc only)
- [x] Pre-commit hooks pass (Ultracite, typecheck, exports)
- [x] Pre-push hooks pass (verify, schema drift)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)