### PR TITLE
fix(tooling): harden workspace bunup outputs for hook reliability

### DIFF
--- a/apps/cli-demo/package.json
+++ b/apps/cli-demo/package.json
@@ -66,7 +66,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "bunup --filter outfitter-cli-demo",
+    "build": "cd ../.. && bunup --filter outfitter-cli-demo",
     "dev": "bun run src/cli.ts",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/apps/outfitter/package.json
+++ b/apps/outfitter/package.json
@@ -408,7 +408,7 @@
     }
   },
   "scripts": {
-    "build": "bunup --filter outfitter",
+    "build": "cd ../.. && bunup --filter outfitter",
     "postbuild": "bun link",
     "dev": "bun run src/cli.ts",
     "test": "bun test",

--- a/apps/outfitter/src/__tests__/check-docs-sentinel.test.ts
+++ b/apps/outfitter/src/__tests__/check-docs-sentinel.test.ts
@@ -15,6 +15,19 @@ function wrapSentinel(content: string): string {
   ].join("\n");
 }
 
+function wrapMultipleSentinels(contents: readonly string[]): string {
+  const blocks = contents.flatMap((content) => [
+    "<!-- BEGIN:GENERATED:PACKAGE_LIST -->",
+    "",
+    content,
+    "",
+    "<!-- END:GENERATED:PACKAGE_LIST -->",
+    "",
+  ]);
+
+  return ["# Docs", "", ...blocks].join("\n");
+}
+
 describe("checkDocsReadmeSentinelContent", () => {
   test("reports missing markers", () => {
     const readme = "# Docs\n\nNo sentinel here.\n";
@@ -36,5 +49,12 @@ describe("checkDocsReadmeSentinelContent", () => {
     const result = checkDocsReadmeSentinelContent(readme, "- same");
 
     expect(result.reason).toBe("up-to-date");
+  });
+
+  test("reports stale when any matching sentinel block is out of date", () => {
+    const readme = wrapMultipleSentinels(["- same", "- stale"]);
+    const result = checkDocsReadmeSentinelContent(readme, "- same");
+
+    expect(result.reason).toBe("out-of-date");
   });
 });

--- a/apps/outfitter/src/__tests__/repo.test.ts
+++ b/apps/outfitter/src/__tests__/repo.test.ts
@@ -4,9 +4,6 @@ import { resolve } from "node:path";
 import {
   DOCS_COMMON_OPTION_FLAGS,
   DOCS_EXPORT_OPTION_FLAGS,
-} from "@outfitter/docs";
-
-import {
   createRepoCommand,
   type RepoToolingInvocation,
 } from "../commands/repo.js";

--- a/apps/outfitter/src/commands/docs-list.ts
+++ b/apps/outfitter/src/commands/docs-list.ts
@@ -11,11 +11,11 @@ import { resolve } from "node:path";
 
 import { output } from "@outfitter/cli";
 import { InternalError, Result } from "@outfitter/contracts";
-import { generateDocsMap } from "@outfitter/docs";
 import { createTheme } from "@outfitter/tui/render";
 
 import type { CliOutputMode } from "../output-mode.js";
 import { resolveStructuredOutputMode } from "../output-mode.js";
+import { loadDocsModule } from "./docs-module-loader.js";
 import type { DocsMapEntryShape } from "./docs-types.js";
 import { applyJq } from "./jq-utils.js";
 
@@ -66,7 +66,8 @@ export async function runDocsList(
 ): Promise<Result<DocsListOutput, InternalError>> {
   try {
     const cwd = resolve(input.cwd);
-    const mapResult = await generateDocsMap({ workspaceRoot: cwd });
+    const docsModule = await loadDocsModule();
+    const mapResult = await docsModule.generateDocsMap({ workspaceRoot: cwd });
 
     if (mapResult.isErr()) {
       return Result.err(

--- a/apps/outfitter/src/commands/docs-module-loader.ts
+++ b/apps/outfitter/src/commands/docs-module-loader.ts
@@ -43,7 +43,17 @@ export interface CreateDocsCommandOptions {
   };
 }
 
-interface DocsModule {
+interface DocsResultLike<TValue> {
+  readonly error: { readonly message: string };
+  readonly isErr: () => boolean;
+  readonly value: TValue;
+}
+
+interface DocsMapLike {
+  readonly entries: readonly unknown[];
+}
+
+export interface DocsModule {
   createDocsCommand: (options?: CreateDocsCommandOptions) => Command;
   executeCheckCommand: (
     options: ExecuteCheckCommandOptions,
@@ -57,6 +67,15 @@ interface DocsModule {
     options: ExecuteSyncCommandOptions,
     io: DocsCommandIo
   ) => Promise<number>;
+  generateDocsMap: (options: {
+    readonly workspaceRoot: string;
+  }) => Promise<DocsResultLike<DocsMapLike>>;
+  generatePackageListSection: (workspaceRoot: string) => Promise<string>;
+  replaceSentinelSection: (
+    input: string,
+    sentinelId: string,
+    replacement: string
+  ) => string;
 }
 
 function resolveDocsEntrypoint(): string {
@@ -95,7 +114,10 @@ export async function loadDocsModule(): Promise<DocsModule> {
         typeof module.createDocsCommand !== "function" ||
         typeof module.executeCheckCommand !== "function" ||
         typeof module.executeSyncCommand !== "function" ||
-        typeof module.executeExportCommand !== "function"
+        typeof module.executeExportCommand !== "function" ||
+        typeof module.generateDocsMap !== "function" ||
+        typeof module.generatePackageListSection !== "function" ||
+        typeof module.replaceSentinelSection !== "function"
       ) {
         throw new Error(
           "Resolved @outfitter/docs entrypoint does not export required docs functions."

--- a/apps/outfitter/src/commands/docs-search.ts
+++ b/apps/outfitter/src/commands/docs-search.ts
@@ -12,11 +12,11 @@ import { resolve } from "node:path";
 
 import { output } from "@outfitter/cli";
 import { InternalError, Result } from "@outfitter/contracts";
-import { generateDocsMap } from "@outfitter/docs";
 import { createTheme } from "@outfitter/tui/render";
 
 import type { CliOutputMode } from "../output-mode.js";
 import { resolveStructuredOutputMode } from "../output-mode.js";
+import { loadDocsModule } from "./docs-module-loader.js";
 import type { DocsMapEntryShape } from "./docs-types.js";
 import { applyJq } from "./jq-utils.js";
 
@@ -70,7 +70,8 @@ export async function runDocsSearch(
 ): Promise<Result<DocsSearchOutput, InternalError>> {
   try {
     const cwd = resolve(input.cwd);
-    const mapResult = await generateDocsMap({ workspaceRoot: cwd });
+    const docsModule = await loadDocsModule();
+    const mapResult = await docsModule.generateDocsMap({ workspaceRoot: cwd });
 
     if (mapResult.isErr()) {
       return Result.err(

--- a/apps/outfitter/src/commands/docs-show.ts
+++ b/apps/outfitter/src/commands/docs-show.ts
@@ -12,10 +12,10 @@ import { resolve } from "node:path";
 
 import { output } from "@outfitter/cli";
 import { InternalError, NotFoundError, Result } from "@outfitter/contracts";
-import { generateDocsMap } from "@outfitter/docs";
 
 import type { CliOutputMode } from "../output-mode.js";
 import { resolveStructuredOutputMode } from "../output-mode.js";
+import { loadDocsModule } from "./docs-module-loader.js";
 import type { DocsMapEntryShape } from "./docs-types.js";
 import { applyJq } from "./jq-utils.js";
 
@@ -63,7 +63,8 @@ export async function runDocsShow(
 ): Promise<Result<DocsShowOutput, InternalError | NotFoundError>> {
   try {
     const cwd = resolve(input.cwd);
-    const mapResult = await generateDocsMap({ workspaceRoot: cwd });
+    const docsModule = await loadDocsModule();
+    const mapResult = await docsModule.generateDocsMap({ workspaceRoot: cwd });
 
     if (mapResult.isErr()) {
       return Result.err(

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/config",
+    "build": "cd ../.. && bunup --filter @outfitter/config",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -78,7 +78,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/daemon",
+    "build": "cd ../.. && bunup --filter @outfitter/daemon",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -73,7 +73,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/docs",
+    "build": "cd ../.. && bunup --filter @outfitter/docs",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/file-ops/package.json
+++ b/packages/file-ops/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/file-ops",
+    "build": "cd ../.. && bunup --filter @outfitter/file-ops",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/logging",
+    "build": "cd ../.. && bunup --filter @outfitter/logging",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -77,7 +77,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/mcp",
+    "build": "cd ../.. && bunup --filter @outfitter/mcp",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "bunup --filter @outfitter/oxlint-plugin",
+    "build": "cd ../.. && bunup --filter @outfitter/oxlint-plugin",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/state",
+    "build": "cd ../.. && bunup --filter @outfitter/state",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bunup --filter @outfitter/testing",
+    "build": "cd ../.. && bunup --filter @outfitter/testing",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",
     "test": "bun test",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -74,7 +74,7 @@
     "build:registry": "bun run src/registry/build.ts",
     "sync:exports": "bun run scripts/sync-exports.ts",
     "sync:exports:check": "bun run scripts/sync-exports.ts --check",
-    "build": "bun run build:registry && bun run sync:exports:check && bunup --filter @outfitter/tooling",
+    "build": "bun run build:registry && bun run sync:exports:check && cd ../.. && bunup --filter @outfitter/tooling",
     "prepack": "bun run sync:exports",
     "lint": "oxlint ./src",
     "lint:fix": "oxlint --fix ./src",

--- a/turbo.json
+++ b/turbo.json
@@ -26,12 +26,12 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@outfitter/oxlint-plugin#build"],
       "inputs": ["src/**", ".oxlintrc.json", ".oxfmtrc.jsonc"],
       "outputs": []
     },
     "lint:fix": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@outfitter/oxlint-plugin#build"],
       "inputs": ["src/**", ".oxlintrc.json", ".oxfmtrc.jsonc"],
       "outputs": []
     },


### PR DESCRIPTION
## Context
Hook/runtime reliability regressed due to brittle workspace `dist/` assumptions and non-deterministic barrel repair behavior.

## Changes
- Hardened Outfitter docs/tooling command loading paths to avoid fragile static `dist` coupling.
- Updated docs sentinel checks to validate all matching sentinel blocks and compare semantic content.
- Updated bunup bare-barrel repair to preserve side-effect-only imports.
- Normalized `bunup --filter` package/app build scripts to run from repo root so root `bunup.config.ts` is consistently applied.
- Updated Turbo graph dependencies so lint-related tasks wait for required plugin build outputs.

## Validation
- `bun run verify:ci` (on this branch)
- `bun run apps/outfitter/src/cli.ts check --pre-push`
- `cd apps/outfitter && bun test src/__tests__/check-docs-sentinel.test.ts`

## Stack Notes
- Base PR: #625
- Child PR: #626
