### PR TITLE
feat(tooling): add agent-setup.sh for cloud agent environments [OS-449]

### DIFF
--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -43,6 +43,13 @@ if [[ "$CURRENT_BUN" != "$PINNED_BUN" ]]; then
   # Re-export after install
   export PATH="${BUN_INSTALL}/bin:${PATH}"
   hash -r
+
+  # Verify installation succeeded
+  INSTALLED_BUN="$(bun --version)"
+  if [[ "$INSTALLED_BUN" != "$PINNED_BUN" ]]; then
+    echo "Error: Expected Bun ${PINNED_BUN} but found ${INSTALLED_BUN} after install" >&2
+    exit 1
+  fi
 fi
 
 echo "Bun: $(bun --version)"
@@ -50,7 +57,7 @@ echo "Bun: $(bun --version)"
 # ── Persist PATH for agent phase ─────────────────────────────────────
 # Cloud agent environments run setup and agent in separate shell sessions.
 # Exports here don't carry over — write to .bashrc so the agent gets them.
-if ! grep -q 'BUN_INSTALL' ~/.bashrc 2>/dev/null; then
+if ! grep -q '# Added by agent-setup.sh' ~/.bashrc 2>/dev/null; then
   {
     echo ''
     echo '# Added by agent-setup.sh'


### PR DESCRIPTION
## Summary

- Add `scripts/agent-setup.sh` — a lightweight environment setup script for AI agent cloud sandboxes (Codex, Devin, Factory, etc.)
- Installs the pinned Bun version from `.bun-version`, project dependencies, and builds all workspace packages
- Does **not** install developer tools (gh, gt, markdownlint) or require `sudo`/`apt` — safe for restricted containers
- Persists `BUN_INSTALL` and `PATH` to `~/.bashrc` so the agent phase picks up the correct Bun

## Context

All three recent Codex-delegated Linear tasks (OS-441, OS-201, OS-368) failed with the same environment cascade:

1. Codex container ships Bun 1.2.14, repo needs 1.3.10
2. `bootstrap.sh` installs correct Bun to `~/.bun/bin`, but PATH doesn't persist to subsequent commands
3. `bun install` runs with old Bun → fails on `catalog:` resolution
4. No `node_modules` → no turbo, no oxlint → everything fails

This script replaces `bootstrap.sh --force` as the entry point for agent environments (per OS-449 constraint: avoid full machine bootstrap in restricted sandboxes).

### Usage

In Codex cloud settings ([chatgpt.com/codex/settings/environments](https://chatgpt.com/codex/settings/environments)), set the setup script to:

```bash
./scripts/agent-setup.sh
```

## Test plan

- [ ] Verify script is executable (`chmod +x`)
- [ ] Test in a fresh Codex environment — confirm `bun --version` matches `.bun-version`
- [ ] Confirm `bun run build` succeeds and `dist/` dirs are populated
- [ ] Confirm agent phase can run `bun run lint`, `bun run test`

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)