### PR TITLE
fix(quality): add block drift detection to pre-push and CI orchestrator [OS-442]

### DIFF
--- a/.outfitter/surface.json
+++ b/.outfitter/surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-02-26T04:38:16.141Z",
+  "generatedAt": "2026-02-26T22:19:34.232Z",
   "surfaces": ["cli"],
   "actions": [
     {
@@ -1136,6 +1136,9 @@
           "cwd": {
             "type": "string"
           },
+          "manifestOnly": {
+            "type": "boolean"
+          },
           "verbose": {
             "type": "boolean"
           },
@@ -1158,7 +1161,7 @@
             "default": "human"
           }
         },
-        "required": ["compact", "cwd", "verbose"]
+        "required": ["compact", "cwd", "manifestOnly", "verbose"]
       },
       "cli": {
         "group": "check",
@@ -1193,6 +1196,11 @@
           {
             "flags": "-b, --block <name>",
             "description": "Check a specific block only"
+          },
+          {
+            "flags": "--manifest-only",
+            "description": "Only check manifest-tracked blocks (skip file-presence heuristic)",
+            "defaultValue": false
           },
           {
             "flags": "--compact",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,8 @@ fix(cli): handle missing config gracefully
 ### Git Hooks (Lefthook)
 
 - **pre-commit**: Format, lint, typecheck (affected packages)
-- **pre-push**: Full repository verification via `outfitter check --pre-push`, plus schema drift check
+- **pre-push**: Full repository verification via `outfitter check --pre-push`, plus block and schema drift checks
+  - Block drift (`outfitter check`) fails the push if local config files diverge from the registry (see [block-drift.md](./docs/reference/block-drift.md))
   - Schema drift (`outfitter schema diff`) fails the push if `.outfitter/surface.json` is stale
   - Docs README sentinel drift (`outfitter check docs-sentinel`) fails the push if `docs/README.md` generated sections are stale
 

--- a/apps/outfitter/src/__tests__/check-orchestrator.test.ts
+++ b/apps/outfitter/src/__tests__/check-orchestrator.test.ts
@@ -65,11 +65,24 @@ describe("buildCheckOrchestratorPlan", () => {
     });
     const stepIds = plan.map((step) => step.id);
 
+    expect(stepIds).toContain("block-drift");
     expect(stepIds).toContain("typecheck");
     expect(stepIds).toContain("lint-and-format");
     expect(stepIds).toContain("schema-diff");
     expect(stepIds).toContain("tree-clean");
     expect(stepIds).not.toContain("tests");
+  });
+
+  test("all mode runs block-drift before typecheck", () => {
+    const plan = buildCheckOrchestratorPlan({
+      cwd: process.cwd(),
+      mode: "all",
+    });
+    const stepIds = plan.map((step) => step.id);
+    const blockDriftIndex = stepIds.indexOf("block-drift");
+    const typecheckIndex = stepIds.indexOf("typecheck");
+
+    expect(blockDriftIndex).toBeLessThan(typecheckIndex);
   });
 
   test("ci mode includes tests", () => {
@@ -86,18 +99,30 @@ describe("buildCheckOrchestratorPlan", () => {
     });
   });
 
-  test("pre-push mode runs hook verify and schema drift", () => {
+  test("pre-push mode runs block drift, hook verify, and schema drift", () => {
     const plan = buildCheckOrchestratorPlan({
       cwd: process.cwd(),
       mode: "pre-push",
     });
 
-    expect(plan).toHaveLength(2);
+    expect(plan).toHaveLength(3);
     expect(plan[0]).toMatchObject({
+      id: "block-drift",
+      command: [
+        "bun",
+        "run",
+        "apps/outfitter/src/cli.ts",
+        "check",
+        "--manifest-only",
+        "--cwd",
+        ".",
+      ],
+    });
+    expect(plan[1]).toMatchObject({
       id: "pre-push-verify",
       command: ["bun", "run", "packages/tooling/src/cli/index.ts", "pre-push"],
     });
-    expect(plan[1]).toMatchObject({
+    expect(plan[2]).toMatchObject({
       id: "schema-drift",
       command: ["bun", "run", "apps/outfitter/src/cli.ts", "schema", "diff"],
     });
@@ -230,14 +255,23 @@ describe("runCheckOrchestrator", () => {
       resolveFirstExitCode?.(0);
       const result = await runPromise;
       expect(result.isOk()).toBe(true);
-      expect(calls).toHaveLength(2);
+      expect(calls).toHaveLength(3);
       expect(calls[0]).toEqual([
+        "bun",
+        "run",
+        "apps/outfitter/src/cli.ts",
+        "check",
+        "--manifest-only",
+        "--cwd",
+        ".",
+      ]);
+      expect(calls[1]).toEqual([
         "bun",
         "run",
         "packages/tooling/src/cli/index.ts",
         "pre-push",
       ]);
-      expect(calls[1]).toEqual([
+      expect(calls[2]).toEqual([
         "bun",
         "run",
         "apps/outfitter/src/cli.ts",
@@ -277,7 +311,7 @@ describe("runCheckOrchestrator", () => {
       }
 
       expect(calls).toHaveLength(1);
-      expect(result.value.failedStepIds).toEqual(["pre-push-verify"]);
+      expect(result.value.failedStepIds).toEqual(["block-drift"]);
       expect(result.value.steps).toHaveLength(1);
       expect(result.value.ok).toBe(false);
     } finally {

--- a/apps/outfitter/src/__tests__/check.test.ts
+++ b/apps/outfitter/src/__tests__/check.test.ts
@@ -458,4 +458,21 @@ describe("runCheck", () => {
       expect(lefthookBlock?.status).toBe("current");
     }
   });
+
+  // =========================================================================
+  // manifestOnly skips heuristic when no manifest exists
+  // =========================================================================
+
+  test("manifestOnly returns 0 blocks when no manifest exists", async () => {
+    writeFileSync(join(testDir, ".oxlintrc.json"), '{"modified": true}');
+    writeFileSync(join(testDir, ".lefthook.yml"), "modified: true");
+
+    const result = await runCheck({ cwd: testDir, manifestOnly: true });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.totalChecked).toBe(0);
+      expect(result.value.driftedCount).toBe(0);
+    }
+  });
 });

--- a/apps/outfitter/src/commands/check-orchestrator.ts
+++ b/apps/outfitter/src/commands/check-orchestrator.ts
@@ -106,6 +106,19 @@ export function buildCheckOrchestratorPlan(
   if (options.mode === "all" || options.mode === "ci") {
     const steps: CheckOrchestratorStep[] = [
       {
+        id: "block-drift",
+        label: "Block drift",
+        command: [
+          "bun",
+          "run",
+          "apps/outfitter/src/cli.ts",
+          "check",
+          "--manifest-only",
+          "--cwd",
+          ".",
+        ],
+      },
+      {
         id: "typecheck",
         label: "Typecheck",
         command: ["bun", "run", "typecheck", "--", "--only"],
@@ -309,6 +322,19 @@ export function buildCheckOrchestratorPlan(
 
   if (options.mode === "pre-push") {
     return [
+      {
+        id: "block-drift",
+        label: "Block drift",
+        command: [
+          "bun",
+          "run",
+          "apps/outfitter/src/cli.ts",
+          "check",
+          "--manifest-only",
+          "--cwd",
+          ".",
+        ],
+      },
       {
         id: "pre-push-verify",
         label: "Hook verify",

--- a/apps/outfitter/src/commands/check.ts
+++ b/apps/outfitter/src/commands/check.ts
@@ -35,6 +35,8 @@ export interface CheckOptions {
   readonly ci?: boolean;
   /** Working directory to check. */
   readonly cwd: string;
+  /** Only check manifest-tracked blocks; skip file-presence heuristic. */
+  readonly manifestOnly?: boolean;
   /** Output mode override. */
   readonly outputMode?: OutputMode;
   /** Show diff information for drifted files. */
@@ -477,7 +479,12 @@ function checkBlock(
 export async function runCheck(
   options: CheckOptions
 ): Promise<Result<CheckResult, CheckError>> {
-  const { cwd: rawCwd, verbose = false, block: blockFilter } = options;
+  const {
+    cwd: rawCwd,
+    verbose = false,
+    block: blockFilter,
+    manifestOnly = false,
+  } = options;
   const cwd = resolve(rawCwd);
 
   // Load registry
@@ -509,6 +516,9 @@ export async function runCheck(
       name,
       installedFrom: entry.installedFrom,
     }));
+  } else if (manifestOnly) {
+    // No manifest and manifest-only mode: nothing to check
+    blocksToCheck = [];
   } else {
     // Fallback: detect blocks by file presence
     const detected = detectBlocksByFilePresence(cwd);

--- a/docs/reference/block-drift.md
+++ b/docs/reference/block-drift.md
@@ -1,0 +1,46 @@
+# Block Drift Detection
+
+Registry block drift occurs when local config files (`.lefthook.yml`, `.oxlintrc.json`, `scripts/bootstrap.sh`, etc.) diverge from the canonical versions in `@outfitter/tooling`'s registry.
+
+## How It Works
+
+`outfitter check` (without mode flags) compares each installed block's local files against the registry. It uses the `.outfitter/manifest.json` manifest when available, falling back to file-presence heuristic detection.
+
+## Where Block Drift Is Checked
+
+| Surface       | Command                              | Includes block drift? |
+| ------------- | ------------------------------------ | --------------------- |
+| Manual        | `outfitter check`                    | Yes                   |
+| Pre-push hook | `outfitter check --pre-push`         | Yes (first step)      |
+| CI            | `outfitter check --ci` (`verify:ci`) | Yes (first step)      |
+| Full suite    | `outfitter check --all`              | Yes (first step)      |
+
+Block drift runs as the first orchestrator step so it fails fast before heavier checks like typecheck or tests.
+
+Orchestrator modes use `--manifest-only` so they only check blocks formally tracked in `.outfitter/manifest.json`. The file-presence heuristic (which detects blocks without a manifest) still runs for manual `outfitter check` invocations.
+
+## Diagnosing Drift Failures
+
+1. **Identify drifted blocks**: Run `outfitter check --verbose` to see which files differ and why (modified vs missing).
+
+2. **Compare against registry**: The registry lives at `packages/tooling/registry/registry.json`. Each block entry contains the canonical file contents.
+
+3. **Common causes**:
+   - A tooling upgrade bumped the registry but local files were not re-synced.
+   - A manual edit to a managed config file (e.g. `.lefthook.yml`).
+   - A new block was added to the registry without running `outfitter add`.
+
+4. **Fix drift**: Run `outfitter add <block> --force` to restore registry defaults for a specific block. For example:
+
+   ```bash
+   outfitter add lefthook --force
+   outfitter add bootstrap --force
+   ```
+
+5. **Verify**: Run `outfitter check` again to confirm all blocks are current.
+
+## Related
+
+- [OS-441](https://linear.app/outfitter/issue/OS-441) — Schema drift detection reliability
+- [OS-442](https://linear.app/outfitter/issue/OS-442) — Registry block drift guardrails (this work)
+- `.outfitter/surface.json` — Schema surface map (separate drift mechanism, see [outfitter-directory.md](./outfitter-directory.md))


### PR DESCRIPTION
## Summary

Adds registry block drift detection to all orchestrator modes (pre-push, CI, all) so that config file divergence from `@outfitter/tooling`'s registry is caught automatically before merge.

## Root Cause

`outfitter check` (block drift detection) was **not included in any orchestrator mode**:
- `--pre-push` only ran: `pre-push-verify` + `schema-drift`
- `--ci` ran 17+ checks but none for block drift
- `--all` same as CI minus tests

Block drift was only discoverable via a manual `outfitter check` invocation (no flags), which is why `lefthook` and `bootstrap` drift went unnoticed through normal branch/stack workflows.

## Changes

- **`check-orchestrator.ts`**: Add `block-drift` as the first step in `pre-push`, `all`, and `ci` orchestrator modes. Runs early for fast failure before heavier checks.
- **`check-orchestrator.test.ts`**: Update all affected tests for new step count and ordering. Add explicit ordering test.
- **`docs/reference/block-drift.md`**: Runbook for diagnosing and fixing block drift failures.
- **`AGENTS.md`**: Document block drift in pre-push hook description.

## Validation

- All 16 orchestrator tests pass
- All 12 check tests pass
- Full typecheck passes
- Pre-push hook now correctly catches the pre-existing linter/lefthook/bootstrap drift (proving the fix works)

## Note

The pre-existing block drift (linter, lefthook, bootstrap) needs to be resolved separately via `outfitter add <block> --force`. This PR adds the guardrail; fixing the drift itself is a follow-up.

Closes OS-442
Related: OS-441