### PR TITLE
fix(release): build artifacts before release docs export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
       - name: Version packages
         run: bun run version-packages
 
+      - name: Build workspace artifacts
+        # Release docs export commands execute the Outfitter source CLI, which
+        # imports workspace packages via dist-based exports. Build first so
+        # clean runners have the required runtime artifacts.
+        run: bun run build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_API: ${{ secrets.TURBO_API }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
       - name: Refresh release LLM artifacts
         run: bun run sync:docs:release:llms
 


### PR DESCRIPTION
## Summary
This PR fixes the release workflow failure by ensuring workspace build artifacts exist before release docs export runs.

## Problem
The `Release` workflow `prepare` job ran `bun run sync:docs:release:llms` on a clean GitHub runner before any workspace build.

That command path resolves workspace package exports from `dist/*` (for example, `@outfitter/cli/flags`), so module resolution failed when `dist` files were not present.

## Changes
- add `Build workspace artifacts` step to `.github/workflows/release.yml` `prepare` job
- run `bun run build` immediately before `bun run sync:docs:release:llms`
- pass Turbo remote cache env vars to that build step for consistency with existing CI behavior
- keep scope minimal to release workflow ordering only (no command-surface refactor)

## Validation
- reproduced failure from release workflow run `22467852388`
- confirmed failing step was `Refresh release LLM artifacts`
- verified local success path:
  - `bun run build`
  - `bun run sync:docs:release:llms`
- linted workflow syntax with `actionlint` (existing non-blocking shellcheck style warnings outside this change)

## Risk
Low. This only changes step ordering in release `prepare` and adds a build prerequisite that matches package export expectations.
