### PR TITLE
fix(tooling): persist Bun PATH across agent shell sessions

### DIFF
--- a/scripts/agent-maintenance.sh
+++ b/scripts/agent-maintenance.sh
@@ -57,15 +57,17 @@ if [[ "$CURRENT_BUN" != "$PINNED_BUN" ]]; then
     echo "Error: Expected Bun ${PINNED_BUN} but found ${INSTALLED_BUN} after install" >&2
     exit 1
   fi
-
-  # Update the env file so the agent phase gets the right version too
-  cat > "$ENV_FILE" <<'ENVEOF'
-export BUN_INSTALL="${HOME}/.bun"
-export PATH="${BUN_INSTALL}/bin:${PATH}"
-ENVEOF
 else
   echo "Bun: ${CURRENT_BUN} (up to date)"
 fi
+
+# ── Ensure env file exists ───────────────────────────────────────────
+# Always recreate the env file. In cached containers it may have been
+# removed or never created, even though ~/.bun has the right version.
+cat > "$ENV_FILE" <<'ENVEOF'
+export BUN_INSTALL="${HOME}/.bun"
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+ENVEOF
 
 # ── Dependencies ─────────────────────────────────────────────────────
 echo "Installing dependencies..."

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -76,8 +76,9 @@ for rc in "$HOME/.profile" "$HOME/.bashrc"; do
 done
 
 # BASH_ENV is sourced by non-interactive bash (the common agent case)
-if ! grep -q "BASH_ENV" "$HOME/.profile" 2>/dev/null; then
-  printf '\nexport BASH_ENV="%s"\n' "$ENV_FILE" >> "$HOME/.profile"
+BASH_ENV_SENTINEL="# agent-setup.sh BASH_ENV"
+if ! grep -q "$BASH_ENV_SENTINEL" "$HOME/.profile" 2>/dev/null; then
+  printf '\n%s\nexport BASH_ENV="%s"\n' "$BASH_ENV_SENTINEL" "$ENV_FILE" >> "$HOME/.profile"
 fi
 
 # ── Dependencies ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`agent-setup.sh` installs the pinned Bun version during the Codex setup phase, but the agent phase runs in a separate shell session where `~/.bun/bin` was never on PATH. The agent fell back to the container's pre-installed Bun (1.2.14 vs pinned 1.3.10).

**Root cause**: The script only wrote to `~/.bashrc`, which is skipped by non-interactive shells — the exact shell type Codex uses for the agent phase.

**Fix**: Write a dedicated `~/.agent-env.sh` and source it from three init paths:

| Shell type | Init file | Covers |
|---|---|---|
| Login | `~/.profile` | SSH sessions, container entrypoints |
| Interactive | `~/.bashrc` | Terminal sessions |
| Non-interactive | `BASH_ENV` | Scripts, subshells — the agent case |

Also adds `agent-maintenance.sh` for Codex's "maintenance script" slot — refreshes cached containers after branch checkout (checks Bun version, reinstalls deps, rebuilds).

## Test plan

- [ ] Run Codex task and verify `bun --version` returns 1.3.10 in the agent phase
- [ ] Verify `agent-maintenance.sh` upgrades Bun when `.bun-version` changes between branches

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)