### PR TITLE
test(mocking): adopt `using` keyword with Symbol.dispose for mock cleanup [OS-368]

### DIFF
--- a/apps/outfitter/src/__tests__/check-tsdoc-runner.test.ts
+++ b/apps/outfitter/src/__tests__/check-tsdoc-runner.test.ts
@@ -256,7 +256,7 @@ describe("runCheckTsdoc", () => {
     const workspace = createWorkspace(
       "/** Doc. */\nexport function alpha() {}"
     );
-    const spawnSpy = spyOn(Bun, "spawn").mockImplementation(() => {
+    using _spawnSpy = spyOn(Bun, "spawn").mockImplementation(() => {
       throw new Error("ENOENT: spawn jq");
     });
 
@@ -269,7 +269,6 @@ describe("runCheckTsdoc", () => {
       expect(result.isOk()).toBe(true);
       expect(stderr).toContain("jq is not installed");
     } finally {
-      spawnSpy.mockRestore();
       rmSync(workspace.cwd, { recursive: true, force: true });
     }
   });

--- a/apps/outfitter/src/__tests__/doctor.test.ts
+++ b/apps/outfitter/src/__tests__/doctor.test.ts
@@ -415,20 +415,16 @@ describe("doctor command result structure", () => {
       JSON.stringify({ name: "my-app", version: "1.0.0" }, null, 2)
     );
 
-    const readSpy = spyOn(fs, "readFileSync");
-    try {
-      runDoctor({ cwd: tempDir });
+    using readSpy = spyOn(fs, "readFileSync");
+    runDoctor({ cwd: tempDir });
 
-      const targetPath = join(tempDir, "package.json");
-      const packageReads = readSpy.mock.calls.filter((call) => {
-        const pathArg = call[0];
-        return typeof pathArg === "string" && pathArg === targetPath;
-      });
+    const targetPath = join(tempDir, "package.json");
+    const packageReads = readSpy.mock.calls.filter((call) => {
+      const pathArg = call[0];
+      return typeof pathArg === "string" && pathArg === targetPath;
+    });
 
-      expect(packageReads).toHaveLength(1);
-    } finally {
-      readSpy.mockRestore();
-    }
+    expect(packageReads).toHaveLength(1);
   });
 });
 

--- a/packages/agents/src/__tests__/bootstrap.test.ts
+++ b/packages/agents/src/__tests__/bootstrap.test.ts
@@ -21,22 +21,17 @@ describe("bootstrap", () => {
   });
 
   describe("force (mocked subprocesses)", () => {
-    let spawnSpy: ReturnType<typeof spyOn>;
-
-    beforeEach(() => {
-      spawnSpy = spyOn(Bun, "spawnSync").mockReturnValue({
+    function mockSpawnSync() {
+      return spyOn(Bun, "spawnSync").mockReturnValue({
         exitCode: 0,
         stdout: Buffer.from(""),
         stderr: Buffer.from(""),
         success: true,
       } as ReturnType<typeof Bun.spawnSync>);
-    });
-
-    afterEach(() => {
-      spawnSpy.mockRestore();
-    });
+    }
 
     test("calls extend callback when provided", async () => {
+      using _spawnSpy = mockSpawnSync();
       let extendCalled = false;
 
       await Bun.write(join(tempDir, "node_modules/.keep"), "");
@@ -54,6 +49,7 @@ describe("bootstrap", () => {
     });
 
     test("bypasses fast-path", async () => {
+      using _spawnSpy = mockSpawnSync();
       let extendCalled = false;
 
       await Bun.write(join(tempDir, "node_modules/.keep"), "");
@@ -71,6 +67,8 @@ describe("bootstrap", () => {
     });
 
     test("completes without error in quiet mode", async () => {
+      using _spawnSpy = mockSpawnSync();
+
       await Bun.write(join(tempDir, "node_modules/.keep"), "");
       await Bun.write(join(tempDir, "package.json"), "{}");
 


### PR DESCRIPTION
## Summary

Adopts the `using` keyword with `Symbol.dispose` (available since Bun 1.3.9) to replace manual mock cleanup patterns in test files.

### Changes

**`apps/outfitter/src/__tests__/doctor.test.ts`**
- Replaced `try/finally` + `readSpy.mockRestore()` with `using readSpy = spyOn(...)`

**`apps/outfitter/src/__tests__/check-tsdoc-runner.test.ts`**
- Replaced manual `spawnSpy.mockRestore()` in `finally` block with `using _spawnSpy = spyOn(...)`

**`packages/agents/src/__tests__/bootstrap.test.ts`**
- Removed `beforeEach/afterEach` spy lifecycle management
- Extracted `mockSpawnSync()` helper, each test now uses `using _spawnSpy = mockSpawnSync()` for per-test scoped cleanup

**`packages/daemon/src/__tests__/lifecycle.test.ts`**
- Replaced manual `onSpy.mockRestore()` and `offSpy.mockRestore()` with `using _onSpy` / `using _offSpy`

### Testing

All 66 tests across the 4 modified files pass. Lint, format, and typecheck pass on the changed files.

Closes OS-368