### PR TITLE
fix(reference): connect MCP server to stdio transport in main()

### DIFF
--- a/examples/reference/src/mcp.ts
+++ b/examples/reference/src/mcp.ts
@@ -13,7 +13,12 @@
  */
 
 import { Result } from "@outfitter/contracts";
-import { createMcpServer, defineResource, defineTool } from "@outfitter/mcp";
+import {
+  connectStdio,
+  createMcpServer,
+  defineResource,
+  defineTool,
+} from "@outfitter/mcp";
 
 import {
   analyzeTasks,
@@ -198,6 +203,6 @@ export function buildMcpServer() {
  */
 export async function main(): Promise<void> {
   seedStore();
-  buildMcpServer();
-  // In a real project: capture the return value and call connectStdio(server)
+  const server = buildMcpServer();
+  await connectStdio(server);
 }


### PR DESCRIPTION
## Summary

- Import `connectStdio` from `@outfitter/mcp` and wire it into `main()`
- The reference example MCP server was building the server but never connecting it to stdio, so it couldn't actually serve requests

## Test plan

- [x] Verified `examples/reference/src/mcp.ts` compiles cleanly
- [x] Confirmed `connectStdio` is exported from `@outfitter/mcp`

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)