### PR TITLE
fix(outfitter): fix action-must-register regex false positives

### DIFF
--- a/packages/oxlint-plugin/src/rules/action-must-register.ts
+++ b/packages/oxlint-plugin/src/rules/action-must-register.ts
@@ -92,7 +92,7 @@ function extractImportedNamesForModule({
   const moduleSpecifier = `./actions/${moduleName}.js`;
   const escapedModuleSpecifier = escapeForRegExp(moduleSpecifier);
   const importPattern = new RegExp(
-    `import\\s*\\{([\\s\\S]*?)\\}\\s*from\\s*["']${escapedModuleSpecifier}["'];`,
+    `import\\s*\\{([^}]*)\\}\\s*from\\s*["']${escapedModuleSpecifier}["'];`,
     "gu"
   );
 


### PR DESCRIPTION
## Summary

- Fix `action-must-register` regex false positives that were matching `defineAction()` re-exports in barrel files

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=outfitter` — zero actionable warnings
- [x] `bun run test --filter=outfitter` — all tests pass

Closes: OS-473