### PR TITLE
fix(state,file-ops): suppress no-throw-in-handler for catch-rethrow patterns

### DIFF
--- a/packages/file-ops/src/index.ts
+++ b/packages/file-ops/src/index.ts
@@ -707,7 +707,7 @@ export async function acquireLock(
           })
         );
       }
-      // Re-throw unexpected errors
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected error after handling known conflict case
       throw error;
     }
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -831,6 +831,7 @@ export async function createPersistentStore(
       } catch {
         // Ignore cleanup errors
       }
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
       throw error;
     }
   };


### PR DESCRIPTION
## Summary

- Suppress `no-throw-in-handler` for catch-rethrow patterns in `state/index.ts` and `file-ops/index.ts`
- Both are legitimate rethrows where the outer caller handles the error

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/state --filter=@outfitter/file-ops` — zero actionable warnings
- [x] `bun run test` — all tests pass

Closes: OS-478