### PR TITLE
fix(mcp): suppress no-throw and no-process-env lint warnings

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -115,6 +115,7 @@ function createDefaultMcpSink(): Sink {
  */
 function resolveDefaultLogLevel(options: McpServerOptions): McpLogLevel | null {
   // 1. OUTFITTER_LOG_LEVEL env var (highest precedence)
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based log level override
   const envLogLevel = process.env["OUTFITTER_LOG_LEVEL"];
   if (envLogLevel !== undefined && VALID_MCP_LOG_LEVELS.has(envLogLevel)) {
     return envLogLevel as McpLogLevel;
@@ -221,6 +222,7 @@ export function createMcpServer(options: McpServerOptions): McpServer {
       requestId,
       logger: logger.child(loggerMeta ?? { tool: label, requestId }),
       cwd: process.cwd(),
+      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: pass full env to handler context
       env: process.env as Record<string, string | undefined>,
     };
 

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -197,6 +197,7 @@ export function createSdkServer(server: McpServer): Server {
     const result = await server.readResource(uri);
 
     if (result.isErr()) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 
@@ -235,6 +236,7 @@ export function createSdkServer(server: McpServer): Server {
     );
 
     if (result.isErr()) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 
@@ -256,6 +258,7 @@ export function createSdkServer(server: McpServer): Server {
     );
 
     if (result.isErr()) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 


### PR DESCRIPTION
## Summary

- Suppress 3 `no-throw-in-handler` in `transport.ts` — MCP SDK protocol requires throwing to signal errors
- Suppress 2 `no-process-env-in-packages` in `server.ts` — boundary env reads for log level and handler context

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/mcp` — zero actionable warnings
- [x] `bun run test --filter=@outfitter/mcp` — all tests pass

Closes: OS-480