### PR TITLE
fix(docs): suppress no-throw and use-error-taxonomy lint warnings

### DIFF
--- a/packages/docs/src/core/docs-map-render.ts
+++ b/packages/docs/src/core/docs-map-render.ts
@@ -118,6 +118,7 @@ export async function renderLlmsFullFromMap(
   for (const entry of sortedEntries) {
     const absolutePath = resolve(resolvedWorkspaceRoot, entry.outputPath);
     if (!isPathInsideWorkspace(resolvedWorkspaceRoot, absolutePath)) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- security assertion: reject path traversal
       throw new Error(
         `docs-map entry outputPath resolves outside workspace root: ${entry.outputPath}`
       );
@@ -135,6 +136,7 @@ export async function renderLlmsFullFromMap(
         continue; // Skip if file doesn't exist yet
       }
 
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected (non-ENOENT) fs error
       throw error;
     }
 

--- a/packages/docs/src/core/errors.ts
+++ b/packages/docs/src/core/errors.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+// eslint-disable-next-line outfitter/use-error-taxonomy -- domain error within docs package; not a handler error
 export class DocsCoreError extends Error {
   readonly _tag = "DocsCoreError" as const;
   readonly category: "validation" | "internal";

--- a/packages/docs/src/core/expected-output.ts
+++ b/packages/docs/src/core/expected-output.ts
@@ -33,6 +33,7 @@ export async function buildExpectedOutput(
   if (collectedDocsResult.isErr()) {
     const error = collectedDocsResult.error;
     if (error.kind === "outputPathOutsideWorkspace") {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
       throw DocsCoreError.validation(
         "outputPath must resolve inside workspace",
         {
@@ -42,6 +43,7 @@ export async function buildExpectedOutput(
       );
     }
 
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
     throw DocsCoreError.validation(
       "Multiple source docs files resolve to the same output path",
       {
@@ -87,6 +89,7 @@ export async function buildExpectedOutput(
       mdxMode: options.mdxMode,
     });
     if (processedContentResult.isErr()) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- propagate Result error to throwing caller
       throw processedContentResult.error;
     }
 


### PR DESCRIPTION
## Summary

- Suppress 5 `no-throw-in-handler` across `docs-map-render.ts` and `expected-output.ts` (security assertions, Result→throw conversions)
- Suppress 1 `use-error-taxonomy` for `DocsCoreError` — domain error within docs package, not a handler error

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/docs` — zero actionable warnings
- [x] `bun run test --filter=@outfitter/docs` — all tests pass

Closes: OS-481