### PR TITLE
fix(testing): suppress no-throw, no-process-env, and use-error-taxonomy warnings

### DIFF
--- a/packages/testing/src/cli-helpers.ts
+++ b/packages/testing/src/cli-helpers.ts
@@ -23,6 +23,7 @@ export interface CliTestResult {
 // Output Capture
 // ============================================================================
 
+// eslint-disable-next-line outfitter/use-error-taxonomy -- test harness error, not a handler error
 class ExitError extends Error {
   readonly code: number;
 
@@ -82,6 +83,7 @@ export async function captureCLI(
   };
 
   process.exit = ((code?: number): never => {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- test harness: simulates process.exit via throw
     throw new ExitError(code ?? 0);
   }) as typeof process.exit;
 

--- a/packages/testing/src/fixtures.ts
+++ b/packages/testing/src/fixtures.ts
@@ -14,6 +14,7 @@ let cachedRequire: NodeRequire | null | undefined;
 function getNodeRequire(): NodeRequire {
   if (cachedRequire !== undefined) {
     if (cachedRequire === null) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: cached negative result
       throw new Error("Node.js built-ins are unavailable in this runtime.");
     }
     return cachedRequire;
@@ -33,6 +34,7 @@ function getNodeRequire(): NodeRequire {
   }
 
   cachedRequire = null;
+  // eslint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: Node.js builtins unavailable
   throw new Error("Node.js built-ins are unavailable in this runtime.");
 }
 
@@ -251,6 +253,7 @@ export async function withTempDir<T>(
  * // Original environment is restored
  * ```
  */
+/* eslint-disable outfitter/no-process-env-in-packages -- test harness: env isolation fixture */
 export async function withEnv<T>(
   vars: Record<string, string>,
   fn: () => Promise<T>
@@ -280,6 +283,7 @@ export async function withEnv<T>(
     }
   }
 }
+/* eslint-enable outfitter/no-process-env-in-packages */
 
 // ============================================================================
 // Fixture Loading

--- a/packages/testing/src/mock-factories.ts
+++ b/packages/testing/src/mock-factories.ts
@@ -109,12 +109,14 @@ export function createTestConfig<T>(
       schema as unknown as { partial?: () => z.ZodType<Partial<T>> }
     ).partial;
     if (typeof maybePartial !== "function") {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
       throw parsed.error;
     }
 
     const partialSchema = maybePartial.call(schema);
     const partialParsed = partialSchema.safeParse(values);
     if (!partialParsed.success) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
       throw partialParsed.error;
     }
 
@@ -128,6 +130,7 @@ export function createTestConfig<T>(
     getRequired<TValue>(key: string): TValue {
       const value = getPath<TValue>(data as Record<string, unknown>, key);
       if (value === undefined) {
+        // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: assertion for missing config
         throw new Error(`Missing required config value: ${key}`);
       }
       return value;
@@ -149,6 +152,7 @@ export function createTestContext(
     requestId,
     logger,
     cwd: overrides.cwd ?? process.cwd(),
+    // eslint-disable-next-line outfitter/no-process-env-in-packages -- test factory: default env for test context
     env: overrides.env ?? { ...process.env },
   };
 

--- a/packages/testing/src/test-command.ts
+++ b/packages/testing/src/test-command.ts
@@ -282,6 +282,7 @@ export async function testCommand(
   args: string[],
   options?: TestCommandOptions
 ): Promise<TestCommandResult> {
+  /* eslint-disable outfitter/no-process-env-in-packages -- test harness: env snapshot/restore for test isolation */
   return withProcessLock(async () => {
     // Snapshot the full env so command-side mutations do not leak across tests.
     const originalEnv = { ...process.env };
@@ -351,4 +352,5 @@ export async function testCommand(
       injectedTestContext = undefined;
     }
   });
+  /* eslint-enable outfitter/no-process-env-in-packages */
 }


### PR DESCRIPTION
## Summary

- Suppress 12 `no-process-env-in-packages` with block-level disables in `test-command.ts` and `fixtures.ts` — test harness env snapshot/restore for test isolation
- Suppress 6 `no-throw-in-handler` in mock factories — Zod parse errors, runtime assertions, missing config
- Suppress 1 `use-error-taxonomy` for `ExitError` in `cli-helpers.ts` — test harness error simulating process.exit

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/testing` — zero actionable warnings
- [x] `bun run test --filter=@outfitter/testing` — all tests pass

Closes: OS-482