### PR TITLE
fix(tooling): suppress no-throw and no-process-env lint warnings

### DIFF
--- a/packages/tooling/src/cli/check-boundary-invocations.ts
+++ b/packages/tooling/src/cli/check-boundary-invocations.ts
@@ -130,6 +130,7 @@ export async function readScriptEntries(
       if (isRootManifest) {
         const message =
           error instanceof Error ? error.message : "unknown parse error";
+        // eslint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
         throw new Error(
           `Failed to read root package manifest (${filePath}): ${message}`
         );

--- a/packages/tooling/src/cli/check-changeset.ts
+++ b/packages/tooling/src/cli/check-changeset.ts
@@ -236,6 +236,7 @@ export async function runCheckChangeset(
   options: CheckChangesetOptions = {}
 ): Promise<void> {
   // Skip via flag or env var
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
   if (options.skip || process.env["NO_CHANGESET"] === "1") {
     process.stdout.write(
       `${COLORS.dim}check-changeset skipped (NO_CHANGESET=1)${COLORS.reset}\n`
@@ -245,6 +246,7 @@ export async function runCheckChangeset(
   }
 
   // Skip on post-merge pushes to main
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
   if (process.env["GITHUB_EVENT_NAME"] === "push") {
     process.stdout.write(
       `${COLORS.dim}check-changeset skipped (push event)${COLORS.reset}\n`

--- a/packages/tooling/src/cli/check-exports.ts
+++ b/packages/tooling/src/cli/check-exports.ts
@@ -329,6 +329,7 @@ export interface CheckExportsOptions {
 }
 
 export function resolveJsonMode(options: CheckExportsOptions = {}): boolean {
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/check-readme-imports.ts
+++ b/packages/tooling/src/cli/check-readme-imports.ts
@@ -183,6 +183,7 @@ export interface CheckReadmeImportsOptions {
 export function resolveJsonMode(
   options: CheckReadmeImportsOptions = {}
 ): boolean {
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/check-tsdoc.ts
+++ b/packages/tooling/src/cli/check-tsdoc.ts
@@ -356,6 +356,7 @@ const COLORS = {
 
 /** Resolve whether JSON output mode is active. */
 export function resolveJsonMode(options: CheckTsDocOptions = {}): boolean {
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/upgrade-bun.ts
+++ b/packages/tooling/src/cli/upgrade-bun.ts
@@ -55,6 +55,7 @@ async function fetchLatestVersion(): Promise<string> {
   // tag_name is like "bun-v1.4.0", extract version
   const match = data.tag_name.match(/bun-v(.+)/);
   if (!match?.[1]) {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
     throw new Error(`Could not parse version from tag: ${data.tag_name}`);
   }
   return match[1];
@@ -69,6 +70,7 @@ async function fetchLatestVersion(): Promise<string> {
 async function resolveTypesBunVersion(targetVersion: string): Promise<string> {
   const response = await fetch("https://registry.npmjs.org/@types%2fbun");
   if (!response.ok) {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
     throw new Error(`Failed to fetch @types/bun metadata: ${response.status}`);
   }
 
@@ -312,6 +314,7 @@ export async function runUpgradeBun(
 
       log("");
       info("Updating lockfile...");
+      /* eslint-disable outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup */
       const bunInstall = Bun.spawnSync(["bun", "install"], {
         cwd,
         env: {
@@ -320,6 +323,7 @@ export async function runUpgradeBun(
           PATH: `${process.env["HOME"]}/.bun/bin:${process.env["PATH"]}`,
         },
       });
+      /* eslint-enable outfitter/no-process-env-in-packages */
 
       if (bunInstall.exitCode === 0) {
         success("Lockfile updated");

--- a/packages/tooling/src/registry/build.ts
+++ b/packages/tooling/src/registry/build.ts
@@ -46,6 +46,7 @@ function findRepoRoot(startDir: string): string {
     }
     dir = dirname(dir);
   }
+  // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
   throw new Error("Could not find repository root");
 }
 
@@ -73,6 +74,7 @@ function readFileEntry(
   const fullPath = join(repoRoot, sourcePath);
 
   if (!existsSync(fullPath)) {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Source file not found: ${fullPath}`);
   }
 
@@ -152,6 +154,7 @@ function resolveVersion(
 ): string {
   const version = versions[name];
   if (!version) {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(
       `Missing resolved version for "${name}" in @outfitter/presets`
     );
@@ -169,6 +172,7 @@ function getWorkspacePackageVersion(relativePackageJsonPath: string): string {
   };
 
   if (typeof pkg.version !== "string") {
+    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Expected version in package.json at ${pkgPath}`);
   }
 


### PR DESCRIPTION
## Summary

- Suppress 7 `no-throw-in-handler` across tooling CLI scripts — build registry errors, boundary assertions
- Suppress 9 `no-process-env-in-packages` with block-level disables for env reads in CLI tooling scripts (`upgrade-bun`, `check-changeset`, `check-readme-imports`, `check-exports`, `check-tsdoc`)

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/tooling` — zero actionable warnings
- [x] `bun run test --filter=@outfitter/tooling` — all tests pass

Closes: OS-483