### PR TITLE
fix(tui): resolve lint warnings for no-process-env and no-throw rules

### DIFF
--- a/packages/tui/src/confirm.ts
+++ b/packages/tui/src/confirm.ts
@@ -54,6 +54,7 @@ export async function confirmDestructive(
 
   // Check if we're in a TTY environment
   const isTTY = process.stdout.isTTY;
+  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: terminal capability detection
   const isDumbTerminal = process.env["TERM"] === "dumb";
 
   if (!isTTY || isDumbTerminal) {

--- a/packages/tui/src/render/date.ts
+++ b/packages/tui/src/render/date.ts
@@ -111,6 +111,7 @@ function parseNamedRange(name: NamedRange): DateRange {
     default: {
       // Exhaustive check: all NamedRange cases are handled above
       const _exhaustive: never = name;
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- exhaustive check: unreachable code guard
       throw new Error(`Unhandled named range: ${_exhaustive}`);
     }
   }

--- a/packages/tui/src/render/indicators.ts
+++ b/packages/tui/src/render/indicators.ts
@@ -164,6 +164,7 @@ export const INDICATORS: Record<
  *
  * @returns true if unicode is likely supported
  */
+/* eslint-disable outfitter/no-process-env-in-packages -- boundary: terminal capability detection from env */
 export function isUnicodeSupported(): boolean {
   // CI environments generally support unicode
   if (process.env["CI"]) {
@@ -207,6 +208,7 @@ export function isUnicodeSupported(): boolean {
 
   return false;
 }
+/* eslint-enable outfitter/no-process-env-in-packages */
 
 /**
  * Gets an indicator character with automatic unicode/fallback selection.

--- a/packages/tui/src/render/layout.ts
+++ b/packages/tui/src/render/layout.ts
@@ -144,6 +144,7 @@ export function resolveWidth(mode: WidthMode, ctx?: LayoutContext): number {
   // Container width (requires context)
   if (mode === "container") {
     if (!ctx) {
+      // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: caller must provide ctx for container mode
       throw new Error("container width mode requires LayoutContext");
     }
     return ctx.width;


### PR DESCRIPTION
## Summary

- Suppress 7 `no-process-env-in-packages` with block-level disable in `indicators.ts` (`isUnicodeSupported()`) and inline in `confirm.ts` — terminal capability detection from env
- Suppress 2 `no-throw-in-handler` in `layout.ts` (assertion) and `date.ts` (exhaustive check guard)

Part of lint cleanup stack.

## Test plan

- [x] `bun run lint --filter=@outfitter/tui` — zero actionable warnings
- [x] `bun run test --filter=@outfitter/tui` — all tests pass

Closes: OS-484