### PR TITLE
feat(oxlint-plugin): add extensions filtering to max-file-lines rule

### DIFF
--- a/packages/oxlint-plugin/src/__tests__/rules/max-file-lines.test.ts
+++ b/packages/oxlint-plugin/src/__tests__/rules/max-file-lines.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { maxFileLinesRule } from "../../rules/max-file-lines.js";
+import {
+  DEFAULT_EXTENSIONS,
+  maxFileLinesRule,
+} from "../../rules/max-file-lines.js";
 import { readFixture, runRuleForEvent } from "../rule-test-helpers.js";
 
 describe("max-file-lines", () => {
@@ -229,6 +232,91 @@ describe("max-file-lines", () => {
     });
 
     expect(reports).toHaveLength(0);
+  });
+
+  test("skips files whose extension does not match defaults", () => {
+    const reports = runRuleForEvent({
+      event: "Program",
+      filename: "packages/types/src/styles.css",
+      nodes: [{ type: "Program" }],
+      options: [{ warn: 3, error: 5 }],
+      rule: maxFileLinesRule,
+      sourceText: "a\nb\nc\nd\ne\nf\ng",
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  test("skips non-matching extensions with custom list", () => {
+    const reports = runRuleForEvent({
+      event: "Program",
+      filename: "packages/types/src/index.ts",
+      nodes: [{ type: "Program" }],
+      options: [{ warn: 3, error: 5, extensions: [".vue"] }],
+      rule: maxFileLinesRule,
+      sourceText: "a\nb\nc\nd\ne\nf\ng",
+    });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  test("checks files matching custom extensions", () => {
+    const reports = runRuleForEvent({
+      event: "Program",
+      filename: "packages/types/src/component.vue",
+      nodes: [{ type: "Program" }],
+      options: [{ warn: 3, error: 5, extensions: [".vue", ".ts"] }],
+      rule: maxFileLinesRule,
+      sourceText: "a\nb\nc\nd\ne\nf\ng",
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.messageId).toBe("fileTooLongError");
+  });
+
+  test("falls back to default extensions when extensions array is empty", () => {
+    const reports = runRuleForEvent({
+      event: "Program",
+      filename: "packages/types/src/index.ts",
+      nodes: [{ type: "Program" }],
+      options: [{ warn: 3, error: 5, extensions: [] }],
+      rule: maxFileLinesRule,
+      sourceText: "a\nb\nc\nd\ne",
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.messageId).toBe("fileTooLongWarn");
+  });
+
+  // Defense-in-depth: runtime fallback when schema validation is bypassed
+  test("falls back to default extensions when extensions contains invalid values", () => {
+    const reports = runRuleForEvent({
+      event: "Program",
+      filename: "packages/types/src/index.ts",
+      nodes: [{ type: "Program" }],
+      options: [{ warn: 3, error: 5, extensions: ["noperiod", 42] }],
+      rule: maxFileLinesRule,
+      sourceText: "a\nb\nc\nd\ne",
+    });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]?.messageId).toBe("fileTooLongWarn");
+  });
+
+  test("checks all default source extensions", () => {
+    for (const ext of DEFAULT_EXTENSIONS) {
+      const reports = runRuleForEvent({
+        event: "Program",
+        filename: `packages/types/src/file${ext}`,
+        nodes: [{ type: "Program" }],
+        options: [{ warn: 3, error: 5 }],
+        rule: maxFileLinesRule,
+        sourceText: "a\nb\nc\nd\ne",
+      });
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0]?.messageId).toBe("fileTooLongWarn");
+    }
   });
 
   test("keeps valid fixture clean", () => {

--- a/packages/oxlint-plugin/src/rules/max-file-lines.ts
+++ b/packages/oxlint-plugin/src/rules/max-file-lines.ts
@@ -1,3 +1,5 @@
+import { extname } from "node:path";
+
 import {
   isPackageSourceFile,
   type RuleContext,
@@ -6,8 +8,21 @@ import {
 
 interface MaxFileLinesOptions {
   readonly error: number;
+  readonly extensions: readonly string[];
   readonly warn: number;
 }
+
+/** @internal Exported for test use only. */
+export const DEFAULT_EXTENSIONS: readonly string[] = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".cts",
+  ".mjs",
+  ".cjs",
+];
 
 const DEFAULT_WARN_LIMIT = 200;
 const DEFAULT_ERROR_LIMIT = 400;
@@ -18,11 +33,27 @@ function toPositiveInteger(value: unknown): number | undefined {
     : undefined;
 }
 
+function resolveExtensions(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return DEFAULT_EXTENSIONS;
+  }
+
+  const filtered = value.filter(
+    (item): item is string => typeof item === "string" && item.startsWith(".")
+  );
+
+  return filtered.length > 0 ? filtered : DEFAULT_EXTENSIONS;
+}
+
 function resolveOptions(options: readonly unknown[]): MaxFileLinesOptions {
   const firstOption = options[0];
 
   if (!firstOption || typeof firstOption !== "object") {
-    return { warn: DEFAULT_WARN_LIMIT, error: DEFAULT_ERROR_LIMIT };
+    return {
+      warn: DEFAULT_WARN_LIMIT,
+      error: DEFAULT_ERROR_LIMIT,
+      extensions: DEFAULT_EXTENSIONS,
+    };
   }
 
   const warnCandidate = toPositiveInteger(
@@ -35,11 +66,15 @@ function resolveOptions(options: readonly unknown[]): MaxFileLinesOptions {
   const warnLimit = warnCandidate ?? DEFAULT_WARN_LIMIT;
   const errorLimit = errorCandidate ?? DEFAULT_ERROR_LIMIT;
 
+  const extensions = resolveExtensions(
+    (firstOption as { extensions?: unknown }).extensions
+  );
+
   if (errorLimit <= warnLimit) {
-    return { warn: warnLimit, error: warnLimit + 1 };
+    return { warn: warnLimit, error: warnLimit + 1, extensions };
   }
 
-  return { warn: warnLimit, error: errorLimit };
+  return { warn: warnLimit, error: errorLimit, extensions };
 }
 
 function countLines(sourceText: string): number {
@@ -68,6 +103,11 @@ export const maxFileLinesRule: RuleModule = {
         properties: {
           warn: { type: "integer", minimum: 1 },
           error: { type: "integer", minimum: 1 },
+          extensions: {
+            type: "array",
+            items: { type: "string", pattern: "^\\." },
+            minItems: 1,
+          },
         },
         additionalProperties: false,
       },
@@ -84,7 +124,12 @@ export const maxFileLinesRule: RuleModule = {
       return {};
     }
 
-    const { warn, error } = resolveOptions(context.options);
+    const { warn, error, extensions } = resolveOptions(context.options);
+    const filename = context.filename ?? "";
+
+    if (!extensions.includes(extname(filename))) {
+      return {};
+    }
 
     return {
       Program(node) {


### PR DESCRIPTION
## Summary

Adds configurable file extension filtering to the `max-file-lines` oxlint rule. Previously the rule checked all files; now it defaults to common JS/TS extensions and supports a custom `extensions` array in options.

## Test plan

- [x] Tests for default extensions, custom extensions, empty/invalid extensions
- [x] `bun run test` passes

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)