### PR TITLE
refactor: migrate `eslint-disable` directives to `oxlint-disable`

### DIFF
--- a/apps/outfitter/src/__tests__/add.test.ts
+++ b/apps/outfitter/src/__tests__/add.test.ts
@@ -192,7 +192,7 @@ describe("runAdd", () => {
 
     // Verify executable permission
     const stats = statSync(join(testDir, "scripts/bootstrap.sh"));
-    // eslint-disable-next-line no-bitwise -- checking file mode bits
+    // oxlint-disable-next-line no-bitwise -- checking file mode bits
     const isExecutable = (stats.mode & 0o100) !== 0;
     expect(isExecutable).toBe(true);
   });

--- a/apps/outfitter/src/create/index.ts
+++ b/apps/outfitter/src/create/index.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for create module API surface.
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for create module API surface.
 export { planCreateProject } from "./planner.js";
 export {
   CREATE_PRESET_IDS,

--- a/apps/outfitter/src/engine/index.ts
+++ b/apps/outfitter/src/engine/index.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for engine module API surface.
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for engine module API surface.
 export { addBlocks } from "./blocks.js";
 export { injectSharedConfig, rewriteLocalDependencies } from "./config.js";
 export { executePlan } from "./executor.js";

--- a/apps/outfitter/src/targets/index.ts
+++ b/apps/outfitter/src/targets/index.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for targets module API surface.
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for targets module API surface.
 export {
   getInitTarget,
   getReadyTarget,

--- a/packages/cli/src/actions.ts
+++ b/packages/cli/src/actions.ts
@@ -178,7 +178,7 @@ async function runAction(
   const validation = validateInput(action.input, input);
 
   if (validation.isErr()) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
     throw validation.error;
   }
 
@@ -186,7 +186,7 @@ async function runAction(
 
   const result = await action.handler(validation.value, ctx);
   if (result.isErr()) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
     throw result.error;
   }
 }
@@ -204,7 +204,7 @@ function createCommand(
   const { name, args } = splitCommandSpec(commandSpec);
 
   if (!name) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Missing CLI command name for action ${action.id}`);
   }
 
@@ -239,7 +239,7 @@ export function buildCliCommands(
     ((_input) =>
       createHandlerContext({
         cwd: process.cwd(),
-        // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: pass env to handler context
+        // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: pass env to handler context
         env: process.env as Record<string, string | undefined>,
       }));
 
@@ -278,7 +278,7 @@ export function buildCliCommands(
 
       if (!name || isArgumentToken(name)) {
         if (baseAction) {
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: duplicate base action in group
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: duplicate base action in group
           throw new Error(
             `Group '${groupName}' defines multiple base actions: '${baseAction.id}' and '${action.id}'.`
           );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -60,10 +60,10 @@ export function createCLI(config: CLIConfig): CLI {
     }
 
     if (bridgedJsonEnvPrevious === undefined) {
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var restoration after flag bridging
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var restoration after flag bridging
       delete process.env["OUTFITTER_JSON"];
     } else {
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var restoration after flag bridging
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var restoration after flag bridging
       process.env["OUTFITTER_JSON"] = bridgedJsonEnvPrevious;
     }
 
@@ -83,9 +83,9 @@ export function createCLI(config: CLIConfig): CLI {
   program.hook("preAction", (thisCommand) => {
     const allOpts = thisCommand.optsWithGlobals();
     if (allOpts["json"] === true && !bridgedJsonEnvActive) {
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var state capture before flag bridging
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var state capture before flag bridging
       bridgedJsonEnvPrevious = process.env["OUTFITTER_JSON"];
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var bridging: propagates --json flag
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-var bridging: propagates --json flag
       process.env["OUTFITTER_JSON"] = "1";
       bridgedJsonEnvActive = true;
     }
@@ -95,7 +95,7 @@ export function createCLI(config: CLIConfig): CLI {
   });
 
   const exit =
-    // eslint-disable-next-line outfitter/no-process-exit-in-packages -- CLI adapter default exit hook owns process termination
+    // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- CLI adapter default exit hook owns process termination
     config.onExit ?? ((code: number): void => void process.exit(code));
 
   // Force Commander to throw instead of exiting so parse() can route all exits
@@ -109,9 +109,9 @@ export function createCLI(config: CLIConfig): CLI {
   program.action(async () => {
     const isJsonMode =
       program.opts()["json"] === true ||
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
       process.env["OUTFITTER_JSON"] === "1" ||
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
       process.env["OUTFITTER_JSONL"] === "1" ||
       !process.stdout.isTTY;
 

--- a/packages/cli/src/colors/index.ts
+++ b/packages/cli/src/colors/index.ts
@@ -15,7 +15,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   ANSI,
   applyColor,

--- a/packages/cli/src/completion.ts
+++ b/packages/cli/src/completion.ts
@@ -25,7 +25,7 @@ const SHELL_SAFE_PROGRAM_NAME = /^[A-Za-z0-9._-]+$/;
 function assertSafeProgramName(programName: string): void {
   if (SHELL_SAFE_PROGRAM_NAME.test(programName)) return;
 
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
   throw new Error(
     `Invalid program name for shell completion: "${programName}".` +
       " Must match /^[A-Za-z0-9._-]+$/."

--- a/packages/cli/src/envelope.ts
+++ b/packages/cli/src/envelope.ts
@@ -183,7 +183,7 @@ export async function runHandler<
         // In stream mode, write error envelope to stdout as NDJSON and exit
         writeStreamEnvelope(envelope);
         const exitCode = getExitCode(category);
-        // eslint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
+        // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
         process.exit(exitCode);
       }
 
@@ -223,7 +223,7 @@ export async function runHandler<
     if (isStreaming) {
       writeStreamEnvelope(envelope);
       const exitCode = getExitCode(category);
-      // eslint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
+      // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
       process.exit(exitCode);
     }
 
@@ -291,7 +291,7 @@ export async function runHandler<
     if (isStreaming) {
       writeStreamEnvelope(envelope);
       const exitCode = getExitCode(category);
-      // eslint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
+      // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
       process.exit(exitCode);
     }
 
@@ -321,6 +321,6 @@ function outputErrorEnvelope(
     }
   }
 
-  // eslint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
+  // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
   process.exit(exitCode);
 }

--- a/packages/cli/src/internal/input-normalization.ts
+++ b/packages/cli/src/internal/input-normalization.ts
@@ -58,7 +58,7 @@ export async function collectIds(
       // @- means stdin
       if (filePath === "-") {
         if (!allowStdin) {
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: stdin not allowed per options
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: stdin not allowed per options
           throw new Error("Reading from stdin is not allowed");
         }
         const stdinContent = await readStdin();
@@ -70,13 +70,13 @@ export async function collectIds(
       } else {
         // @file reference
         if (!allowFile) {
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: file references not allowed per options
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: file references not allowed per options
           throw new Error("File references are not allowed");
         }
 
         // Security: validate path doesn't contain traversal patterns
         if (!isSecurePath(filePath, true)) {
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: path traversal security check
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: path traversal security check
           throw new Error(
             `Security error: path traversal not allowed: ${filePath}`
           );
@@ -85,7 +85,7 @@ export async function collectIds(
         const file = Bun.file(filePath);
         const exists = await file.exists();
         if (!exists) {
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: file must exist
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: file must exist
           throw new Error(`File not found: ${filePath}`);
         }
         const content = await file.text();

--- a/packages/cli/src/internal/output-formatting.ts
+++ b/packages/cli/src/internal/output-formatting.ts
@@ -44,9 +44,9 @@ export function detectMode(format?: OutputMode): OutputMode {
   }
 
   // Check environment variables (JSONL takes priority over JSON)
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
   const envJsonl = process.env["OUTFITTER_JSONL"];
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
   const envJson = process.env["OUTFITTER_JSON"];
   if (envJsonl === "1") return "jsonl";
   if (envJson === "1") return "json";

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -149,7 +149,7 @@ export function exitWithError(error: Error, format?: OutputMode): never {
     process.stderr.write(`${formatErrorHuman(error)}\n`);
   }
 
-  // eslint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
+  // oxlint-disable-next-line outfitter/no-process-exit-in-packages -- terminal adapter intentionally exits after serializing errors
   process.exit(exitCode);
 }
 
@@ -186,7 +186,7 @@ export function exitWithError(error: Error, format?: OutputMode): never {
  */
 export function resolveVerbose(verbose?: boolean): boolean {
   // 1. OUTFITTER_VERBOSE env var (highest precedence)
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
   const envVerbose = process.env["OUTFITTER_VERBOSE"];
   if (envVerbose === "1") return true;
   if (envVerbose === "0") return false;

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -30,7 +30,7 @@ const UNSAFE_PATH_PATTERN = /(?:^|[\\/])\.\.(?:[\\/]|$)|^[\\/]|^[a-zA-Z]:/;
  */
 function validatePathComponent(component: string, name: string): void {
   if (UNSAFE_PATH_PATTERN.test(component)) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: path traversal security check
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: path traversal security check
     throw new Error(`Security: path traversal detected in ${name}`);
   }
 }
@@ -47,7 +47,7 @@ function getDefaultStateHome(): string {
     case "darwin":
       return path.join(home, "Library", "Application Support");
     case "win32":
-      // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: platform-specific path lookup
+      // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: platform-specific path lookup
       return process.env["LOCALAPPDATA"] ?? path.join(home, "AppData", "Local");
     default:
       return path.join(home, ".local", "state");
@@ -69,7 +69,7 @@ function getStatePath(options: CursorOptions): string {
     validatePathComponent(options.context, "context");
   }
 
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: runtime env read
   const xdgState = process.env["XDG_STATE_HOME"] ?? getDefaultStateHome();
   const parts = [xdgState, options.toolName, "cursors", options.command];
   if (options.context) {

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -132,11 +132,11 @@ export function resolveOutputMode(
   }
 
   // 4. Environment variable fallback (JSONL takes priority)
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   if (process.env["OUTFITTER_JSONL"] === "1") {
     return { mode: "jsonl", source: "env" };
   }
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   if (process.env["OUTFITTER_JSON"] === "1") {
     return { mode: "json", source: "env" };
   }
@@ -165,7 +165,7 @@ export interface OutputModePresetConfig {
 /**
  * Resolved output mode from CLI input.
  */
-// eslint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+// oxlint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
 export type OutputModeFlags = {
   /** The resolved output mode */
   readonly outputMode: OutputMode;
@@ -219,7 +219,7 @@ export function outputModePreset(
 /**
  * Resolved jq expression from CLI input.
  */
-// eslint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+// oxlint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
 export type JqFlags = {
   /** The jq expression, or undefined if not provided */
   readonly jq: string | undefined;
@@ -232,7 +232,7 @@ export type JqFlags = {
 /**
  * Resolved stream flags from CLI input.
  */
-// eslint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
+// oxlint-disable-next-line typescript/consistent-type-definitions -- must be `type` to satisfy Record<string, unknown> constraint in FlagPreset<T>
 export type StreamFlags = {
   /** Whether NDJSON streaming mode is enabled */
   readonly stream: boolean;

--- a/packages/cli/src/schema-input.ts
+++ b/packages/cli/src/schema-input.ts
@@ -77,7 +77,7 @@ export function unwrapZodField(field: unknown): ZodFieldInfo {
   let isOptional = false;
 
   // Walk through wrapper types (default, optional, nullable)
-  // eslint-disable-next-line no-constant-condition
+  // oxlint-disable-next-line no-constant-condition
   while (true) {
     if (description === undefined) {
       description = (current as { description?: string }).description;
@@ -286,6 +286,6 @@ export function validateInput(
 
   const message = detail ? `${summary}\n${detail}` : summary;
 
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- throw: validation failure; Commander action handler catches and formats as error envelope
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- throw: validation failure; Commander action handler catches and formats as error envelope
   throw ValidationError.fromMessage(message, { issues });
 }

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -29,7 +29,7 @@ export type {
   GenerateManifestOptions,
 } from "@outfitter/schema";
 
-// eslint-disable-next-line oxc/no-barrel-file -- not a barrel — re-exports for backward compat alongside local exports
+// oxlint-disable-next-line oxc/no-barrel-file -- not a barrel — re-exports for backward compat alongside local exports
 export { generateManifest } from "@outfitter/schema";
 
 // =============================================================================

--- a/packages/cli/src/terminal/detection.ts
+++ b/packages/cli/src/terminal/detection.ts
@@ -40,7 +40,7 @@ export interface TerminalOptions {
 export function getEnvValue(
   key: "NO_COLOR" | "FORCE_COLOR"
 ): string | undefined {
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return process.env[key];
 }
 

--- a/packages/cli/src/terminal/index.ts
+++ b/packages/cli/src/terminal/index.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   getEnvValue,
   getTerminalWidth,

--- a/packages/cli/src/text.ts
+++ b/packages/cli/src/text.ts
@@ -16,7 +16,7 @@ import { ANSI } from "./colors/colors.js";
 /**
  * Regular expression pattern to match ANSI escape codes.
  */
-// eslint-disable-next-line no-control-regex -- ANSI escape codes require control characters
+// oxlint-disable-next-line no-control-regex -- ANSI escape codes require control characters
 export const ANSI_REGEX: RegExp = /\x1b\[[0-9;]*m/g;
 
 // ============================================================================
@@ -142,7 +142,7 @@ export function truncateText(text: string, maxWidth: number): string {
     // Check if we're at an ANSI escape sequence in the original text
     while (fullIndex < text.length && text[fullIndex] === "\x1b") {
       // Find end of ANSI sequence
-      // eslint-disable-next-line no-control-regex -- ANSI escape codes require control characters
+      // oxlint-disable-next-line no-control-regex -- ANSI escape codes require control characters
       const match = text.slice(fullIndex).match(/^\x1b\[[0-9;]*m/);
       if (match) {
         result += match[0];

--- a/packages/cli/src/verbs.ts
+++ b/packages/cli/src/verbs.ts
@@ -64,7 +64,7 @@ export function resolveVerb(
 ): { name: string; aliases: string[] } {
   const def = VERB_FAMILIES[family as keyof typeof VERB_FAMILIES];
   if (!Object.hasOwn(VERB_FAMILIES, family) || def === undefined) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Unknown verb family: "${family}"`);
   }
 

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -2,7 +2,7 @@
  * Centralized environment variable access with Zod validation.
  *
  * This module provides a single point of access for process.env,
- * eliminating the need for eslint-disable-next-line comments throughout the codebase
+ * eliminating the need for oxlint-disable-next-line comments throughout the codebase
  * (TypeScript's `noPropertyAccessFromIndexSignature` conflicts with
  * Biome's `useLiteralKeys` rule).
  *
@@ -135,7 +135,7 @@ export function parseEnv<T extends z.ZodRawShape>(
 // App-Level Environment
 // ============================================================================
 
-// eslint-disable-next-line typescript/consistent-type-definitions -- type required for Zod schema constraint
+// oxlint-disable-next-line typescript/consistent-type-definitions -- type required for Zod schema constraint
 type AppEnvShape = {
   NODE_ENV: z.ZodDefault<
     z.ZodEnum<{

--- a/packages/config/src/internal/parsing.ts
+++ b/packages/config/src/internal/parsing.ts
@@ -7,7 +7,7 @@ import { parse as parseYaml } from "yaml";
 // Error Types
 // ============================================================================
 
-// eslint-disable-next-line typescript/consistent-type-definitions -- type required for TaggedError constraint
+// oxlint-disable-next-line typescript/consistent-type-definitions -- type required for TaggedError constraint
 type ParseErrorFields = {
   /** Human-readable error message describing the parse failure */
   message: string;
@@ -40,7 +40,7 @@ export class ParseError extends ParseErrorBase {
   readonly category = "validation" as const;
 }
 
-// eslint-disable-next-line typescript/consistent-type-definitions -- type required for TaggedError constraint
+// oxlint-disable-next-line typescript/consistent-type-definitions -- type required for TaggedError constraint
 type CircularExtendsErrorFields = {
   /** Human-readable error message */
   message: string;

--- a/packages/contracts/src/__tests__/wrap-error.test.ts
+++ b/packages/contracts/src/__tests__/wrap-error.test.ts
@@ -139,7 +139,7 @@ describe("wrapError", () => {
 
     it("wraps as InternalError when mapper returns undefined", () => {
       const plain = new Error("unmatched");
-      // eslint-disable-next-line unicorn/consistent-function-scoping -- test clarity
+      // oxlint-disable-next-line unicorn/consistent-function-scoping -- test clarity
       const mapper: ErrorMapper = () => undefined;
       const wrapped = wrapError(plain, mapper);
       expect(wrapped).toBeInstanceOf(InternalError);
@@ -246,9 +246,9 @@ describe("composeMappers", () => {
   });
 
   it("returns undefined when no mapper matches", () => {
-    // eslint-disable-next-line unicorn/consistent-function-scoping -- test clarity
+    // oxlint-disable-next-line unicorn/consistent-function-scoping -- test clarity
     const m1: ErrorMapper = () => undefined;
-    // eslint-disable-next-line unicorn/consistent-function-scoping -- test clarity
+    // oxlint-disable-next-line unicorn/consistent-function-scoping -- test clarity
     const m2: ErrorMapper = () => undefined;
 
     const composed = composeMappers(m1, m2);

--- a/packages/contracts/src/assert/index.ts
+++ b/packages/contracts/src/assert/index.ts
@@ -133,7 +133,7 @@ export const expectOk = <T, E>(result: Result<T, E>, message?: string): T => {
   }
   const errorDetail = formatValue(result.error);
   const prefix = message ? `${message}: ` : "";
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- intentional: expectOk() is a test assertion that throws by design
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- intentional: expectOk() is a test assertion that throws by design
   throw new Error(`${prefix}Expected Ok, got Err: ${errorDetail}`);
 };
 
@@ -163,6 +163,6 @@ export const expectErr = <T, E>(result: Result<T, E>, message?: string): E => {
   }
   const valueDetail = formatValue(result.value);
   const prefix = message ? `${message}: ` : "";
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- intentional: expectErr() is a test assertion that throws by design
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- intentional: expectErr() is a test assertion that throws by design
   throw new Error(`${prefix}Expected Err, got Ok: ${valueDetail}`);
 };

--- a/packages/contracts/src/internal/error-serialization.ts
+++ b/packages/contracts/src/internal/error-serialization.ts
@@ -172,7 +172,7 @@ export function serializeError(
   options?: SerializeErrorOptions,
   isProduction?: boolean
 ): SerializedError {
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: safe default when isProduction not injected
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: safe default when isProduction not injected
   const production = isProduction ?? process.env["NODE_ENV"] === "production";
   const includeStack = options?.includeStack ?? !production;
 

--- a/packages/contracts/src/internal/schema-converters.ts
+++ b/packages/contracts/src/internal/schema-converters.ts
@@ -24,7 +24,7 @@ export type ZodTypeConverter = (schema: z.ZodType<unknown>) => JsonSchema;
  * Convert Zod array schema.
  */
 export function convertArray(
-  // eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+  // oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
   def: any,
   convertZodType: ZodTypeConverter
 ): JsonSchema {
@@ -44,7 +44,7 @@ export function convertArray(
  * (refinements, transforms) or ZodPipeline, which would otherwise
  * incorrectly appear as required.
  */
-// eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+// oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
 export function isFieldOptional(fieldDef: any): boolean {
   if (!(fieldDef?.typeName || fieldDef?.type)) {
     return false;
@@ -94,7 +94,7 @@ export function isFieldOptional(fieldDef: any): boolean {
  * Convert Zod object schema.
  */
 export function convertObject(
-  // eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+  // oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
   def: any,
   convertZodType: ZodTypeConverter
 ): JsonSchema {

--- a/packages/contracts/src/internal/schema-primitives.ts
+++ b/packages/contracts/src/internal/schema-primitives.ts
@@ -11,7 +11,7 @@ import type { JsonSchema } from "./schema-types.js";
 /**
  * Convert Zod string schema with checks.
  */
-// eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+// oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
 export function convertString(def: any): JsonSchema {
   const schema: JsonSchema = { type: "string" };
 
@@ -90,7 +90,7 @@ export function convertString(def: any): JsonSchema {
 /**
  * Convert Zod number schema with checks.
  */
-// eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+// oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
 export function convertNumber(def: any): JsonSchema {
   const schema: JsonSchema = { type: "number" };
 

--- a/packages/contracts/src/internal/schema-types.ts
+++ b/packages/contracts/src/internal/schema-types.ts
@@ -38,7 +38,7 @@ export interface JsonSchema {
 /**
  * Extract the internal _def object from a Zod schema or def.
  */
-// eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+// oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
 export function getDef(schemaOrDef: any): any {
   if (!schemaOrDef) {
     return undefined;
@@ -58,7 +58,7 @@ export function getDef(schemaOrDef: any): any {
 /**
  * Extract description from a Zod schema or its def.
  */
-// eslint-disable-next-line typescript/no-explicit-any -- Zod internals
+// oxlint-disable-next-line typescript/no-explicit-any -- Zod internals
 export function getDescription(schema: any, def: any): string | undefined {
   if (typeof schema?.description === "string") {
     return schema.description;

--- a/packages/contracts/src/result/index.ts
+++ b/packages/contracts/src/result/index.ts
@@ -6,7 +6,7 @@
  * @module result
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
 export {
   combine2,
   combine3,

--- a/packages/contracts/src/result/utilities.ts
+++ b/packages/contracts/src/result/utilities.ts
@@ -145,6 +145,6 @@ export const combine3 = <T1, T2, T3, E>(
  */
 export const expect = <T, E>(result: Result<T, E>, message: string): T => {
   if (result.isOk()) return result.value;
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- intentional: expect() is an assertion utility that throws by design
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- intentional: expect() is an assertion utility that throws by design
   throw new Error(`${message}: ${String(result.error)}`);
 };

--- a/packages/daemon/src/platform.ts
+++ b/packages/daemon/src/platform.ts
@@ -44,13 +44,13 @@ interface RuntimeEnv {
   readonly TEMP?: string | undefined;
 }
 
-/* eslint-disable outfitter/no-process-env-in-packages -- boundary: snapshot env once, pass to pure functions */
+/* oxlint-disable outfitter/no-process-env-in-packages -- boundary: snapshot env once, pass to pure functions */
 const RUNTIME_ENV: RuntimeEnv = {
   XDG_RUNTIME_DIR: process.env["XDG_RUNTIME_DIR"],
   TMPDIR: process.env["TMPDIR"],
   TEMP: process.env["TEMP"],
 };
-/* eslint-enable outfitter/no-process-env-in-packages */
+/* oxlint-enable outfitter/no-process-env-in-packages */
 
 /**
  * Get the runtime directory for daemon files.

--- a/packages/docs/src/core/docs-map-render.ts
+++ b/packages/docs/src/core/docs-map-render.ts
@@ -118,7 +118,7 @@ export async function renderLlmsFullFromMap(
   for (const entry of sortedEntries) {
     const absolutePath = resolve(resolvedWorkspaceRoot, entry.outputPath);
     if (!isPathInsideWorkspace(resolvedWorkspaceRoot, absolutePath)) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- security assertion: reject path traversal
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- security assertion: reject path traversal
       throw new Error(
         `docs-map entry outputPath resolves outside workspace root: ${entry.outputPath}`
       );
@@ -136,7 +136,7 @@ export async function renderLlmsFullFromMap(
         continue; // Skip if file doesn't exist yet
       }
 
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected (non-ENOENT) fs error
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected (non-ENOENT) fs error
       throw error;
     }
 

--- a/packages/docs/src/core/errors.ts
+++ b/packages/docs/src/core/errors.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line outfitter/use-error-taxonomy -- domain error within docs package; not a handler error
+// oxlint-disable-next-line outfitter/use-error-taxonomy -- domain error within docs package; not a handler error
 export class DocsCoreError extends Error {
   readonly _tag = "DocsCoreError" as const;
   readonly category: "validation" | "internal";

--- a/packages/docs/src/core/expected-output.ts
+++ b/packages/docs/src/core/expected-output.ts
@@ -33,7 +33,7 @@ export async function buildExpectedOutput(
   if (collectedDocsResult.isErr()) {
     const error = collectedDocsResult.error;
     if (error.kind === "outputPathOutsideWorkspace") {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
       throw DocsCoreError.validation(
         "outputPath must resolve inside workspace",
         {
@@ -43,7 +43,7 @@ export async function buildExpectedOutput(
       );
     }
 
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- convert typed Result error to thrown DocsCoreError for caller
     throw DocsCoreError.validation(
       "Multiple source docs files resolve to the same output path",
       {
@@ -89,7 +89,7 @@ export async function buildExpectedOutput(
       mdxMode: options.mdxMode,
     });
     if (processedContentResult.isErr()) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- propagate Result error to throwing caller
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- propagate Result error to throwing caller
       throw processedContentResult.error;
     }
 

--- a/packages/docs/src/core/index.ts
+++ b/packages/docs/src/core/index.ts
@@ -43,7 +43,7 @@ import type {
 } from "./types.js";
 
 export type { PackageDocsError } from "./errors.js";
-// eslint-disable-next-line oxc/no-barrel-file -- preserve existing core/index export shape.
+// oxlint-disable-next-line oxc/no-barrel-file -- preserve existing core/index export shape.
 export { DocsCoreError } from "./errors.js";
 export type {
   CheckLlmsDocsResult,

--- a/packages/file-ops/src/internal/locking.ts
+++ b/packages/file-ops/src/internal/locking.ts
@@ -107,7 +107,7 @@ export async function acquireLock(
           })
         );
       }
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected error after handling known conflict case
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- rethrow unexpected error after handling known conflict case
       throw error;
     }
 

--- a/packages/index/src/fts5.ts
+++ b/packages/index/src/fts5.ts
@@ -116,7 +116,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
     writeIndexMetadata(db, metadata);
   } else if (currentVersion !== INDEX_VERSION) {
     if (!options.migrations) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion in sync factory; propagates to caller
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion in sync factory; propagates to caller
       throw new Error(
         `Index version ${currentVersion} does not match ${INDEX_VERSION}. Provide migrations or rebuild the index.`
       );
@@ -129,7 +129,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
       INDEX_VERSION
     );
     if (result.isErr()) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion in sync factory; propagates to caller
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion in sync factory; propagates to caller
       throw new Error(`Failed to migrate index: ${result.error.message}`);
     }
 
@@ -180,7 +180,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
   }
 
   return {
-    // eslint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
+    // oxlint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
     async add(doc: IndexDocument): Promise<Result<void, StorageError>> {
       const closedCheck = checkClosed();
       if (closedCheck.isErr()) {
@@ -208,7 +208,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
       }
     },
 
-    // eslint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
+    // oxlint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
     async addMany(docs: IndexDocument[]): Promise<Result<void, StorageError>> {
       const closedCheck = checkClosed();
       if (closedCheck.isErr()) {
@@ -243,7 +243,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
           return Result.ok(undefined);
         } catch (error) {
           db.run("ROLLBACK");
-          // eslint-disable-next-line outfitter/no-throw-in-handler -- rethrow after rollback; outer catch converts to Result.err
+          // oxlint-disable-next-line outfitter/no-throw-in-handler -- rethrow after rollback; outer catch converts to Result.err
           throw error;
         }
       } catch (error) {
@@ -256,7 +256,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
       }
     },
 
-    // eslint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
+    // oxlint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
     async search(
       query: SearchQuery
     ): Promise<Result<SearchResult<T>[], StorageError>> {
@@ -325,7 +325,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
       }
     },
 
-    // eslint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
+    // oxlint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
     async remove(id: string): Promise<Result<void, StorageError>> {
       const closedCheck = checkClosed();
       if (closedCheck.isErr()) {
@@ -347,7 +347,7 @@ export function createIndex<T = unknown>(options: IndexOptions): Index<T> {
       }
     },
 
-    // eslint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
+    // oxlint-disable-next-line require-await, typescript/require-await -- interface requires Promise return type
     async clear(): Promise<Result<void, StorageError>> {
       const closedCheck = checkClosed();
       if (closedCheck.isErr()) {

--- a/packages/index/src/internal/fts5-helpers.ts
+++ b/packages/index/src/internal/fts5-helpers.ts
@@ -52,14 +52,14 @@ export const DEFAULT_TOOL_VERSION = "0.0.0";
 
 export function assertValidTableName(tableName: string): void {
   if (!TABLE_NAME_PATTERN.test(tableName)) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Invalid table name: ${tableName}`);
   }
 }
 
 export function assertValidTokenizer(tokenizer: string): TokenizerType {
   if (!Object.hasOwn(VALID_TOKENIZERS, tokenizer)) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Invalid tokenizer: ${tokenizer}`);
   }
   return tokenizer as TokenizerType;
@@ -96,7 +96,7 @@ export function getUserVersion(db: Database): number {
 
 export function setUserVersion(db: Database, version: number): void {
   if (!Number.isInteger(version) || version < 0) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Invalid user_version: ${version}`);
   }
   db.run(`PRAGMA user_version = ${version}`);

--- a/packages/logging/src/internal/env.ts
+++ b/packages/logging/src/internal/env.ts
@@ -15,7 +15,7 @@ import type { LogLevel } from "./types.js";
  */
 function safeGetEnv(key: string): string | undefined {
   if (typeof process !== "undefined") {
-    // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-aware log level resolution
+    // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-aware log level resolution
     return process.env?.[key];
   }
   return undefined;
@@ -77,13 +77,13 @@ export function resolveLogLevel(level?: LogLevel | string): LogLevel {
   // 1. OUTFITTER_LOG_LEVEL env var (highest precedence)
   const envLogLevel = safeGetEnv("OUTFITTER_LOG_LEVEL");
   if (envLogLevel !== undefined && Object.hasOwn(ENV_LEVEL_MAP, envLogLevel)) {
-    // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
     return ENV_LEVEL_MAP[envLogLevel]!;
   }
 
   // 2. Explicit level parameter (validate strings via ENV_LEVEL_MAP)
   if (level !== undefined && Object.hasOwn(ENV_LEVEL_MAP, level)) {
-    // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
     return ENV_LEVEL_MAP[level]!;
   }
 
@@ -95,7 +95,7 @@ export function resolveLogLevel(level?: LogLevel | string): LogLevel {
       defaults.logLevel !== null &&
       Object.hasOwn(ENV_LEVEL_MAP, defaults.logLevel)
     ) {
-      // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+      // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
       return ENV_LEVEL_MAP[defaults.logLevel]!;
     }
   } catch {
@@ -119,13 +119,13 @@ export function resolveOutfitterLogLevel(level?: LogLevel | string): LogLevel {
   // 1. OUTFITTER_LOG_LEVEL env var (highest precedence)
   const envLogLevel = safeGetEnv("OUTFITTER_LOG_LEVEL");
   if (envLogLevel !== undefined && Object.hasOwn(ENV_LEVEL_MAP, envLogLevel)) {
-    // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
     return ENV_LEVEL_MAP[envLogLevel]!;
   }
 
   // 2. Explicit level parameter (validate strings via ENV_LEVEL_MAP)
   if (level !== undefined && Object.hasOwn(ENV_LEVEL_MAP, level)) {
-    // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+    // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
     return ENV_LEVEL_MAP[level]!;
   }
 
@@ -137,7 +137,7 @@ export function resolveOutfitterLogLevel(level?: LogLevel | string): LogLevel {
       defaults.logLevel !== null &&
       Object.hasOwn(ENV_LEVEL_MAP, defaults.logLevel)
     ) {
-      // eslint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
+      // oxlint-disable-next-line typescript/no-non-null-assertion -- hasOwn guarantees key exists
       return ENV_LEVEL_MAP[defaults.logLevel]!;
     }
   } catch {

--- a/packages/mcp/src/internal/log-config.ts
+++ b/packages/mcp/src/internal/log-config.ts
@@ -62,7 +62,7 @@ export function resolveDefaultLogLevel(
   options: McpServerOptions
 ): McpLogLevel | null {
   // 1. OUTFITTER_LOG_LEVEL env var (highest precedence)
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based log level override
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based log level override
   const envLogLevel = process.env["OUTFITTER_LOG_LEVEL"];
   if (envLogLevel !== undefined && VALID_MCP_LOG_LEVELS.has(envLogLevel)) {
     return envLogLevel as McpLogLevel;

--- a/packages/mcp/src/internal/server-types.ts
+++ b/packages/mcp/src/internal/server-types.ts
@@ -31,7 +31,7 @@ import type { SerializedTool, ToolDefinition } from "./tool-types.js";
 
 // Re-export types for convenience
 export type { Result } from "@outfitter/contracts";
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
 export { TaggedError } from "@outfitter/contracts";
 
 // Internal alias for use in this file
@@ -179,7 +179,7 @@ export interface McpServer {
    * Called internally by the transport layer.
    * @param sdkServer - The MCP SDK Server instance
    */
-  // eslint-disable-next-line typescript/no-explicit-any -- SDK Server type
+  // oxlint-disable-next-line typescript/no-explicit-any -- SDK Server type
   bindSdkServer?(sdkServer: any): void;
 
   /**

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -6,5 +6,5 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for backward compatibility
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for backward compatibility
 export { type JsonSchema, zodToJsonSchema } from "@outfitter/contracts/schema";

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -197,7 +197,7 @@ export function createSdkServer(server: McpServer): Server {
     const result = await server.readResource(uri);
 
     if (result.isErr()) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 
@@ -207,7 +207,7 @@ export function createSdkServer(server: McpServer): Server {
   // Subscription handlers (resource feature)
   sdkServer.setRequestHandler(
     SubscribeRequestSchema,
-    // eslint-disable-next-line require-await, typescript/require-await -- protocol requires async
+    // oxlint-disable-next-line require-await, typescript/require-await -- protocol requires async
     async (request) => {
       server.subscribe(request.params.uri);
       return {};
@@ -216,7 +216,7 @@ export function createSdkServer(server: McpServer): Server {
 
   sdkServer.setRequestHandler(
     UnsubscribeRequestSchema,
-    // eslint-disable-next-line require-await, typescript/require-await -- protocol requires async
+    // oxlint-disable-next-line require-await, typescript/require-await -- protocol requires async
     async (request) => {
       server.unsubscribe(request.params.uri);
       return {};
@@ -236,7 +236,7 @@ export function createSdkServer(server: McpServer): Server {
     );
 
     if (result.isErr()) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 
@@ -258,7 +258,7 @@ export function createSdkServer(server: McpServer): Server {
     );
 
     if (result.isErr()) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- MCP SDK protocol requires throwing to signal errors
       throw toSdkError(result.error);
     }
 
@@ -268,7 +268,7 @@ export function createSdkServer(server: McpServer): Server {
   // Logging handler
   sdkServer.setRequestHandler(
     SetLevelRequestSchema,
-    // eslint-disable-next-line require-await, typescript/require-await -- protocol requires async
+    // oxlint-disable-next-line require-await, typescript/require-await -- protocol requires async
     async (request) => {
       const level = request.params.level as McpLogLevel;
       server.setLogLevel?.(level);

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional barrel for public API surface
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional barrel for public API surface
 
 // === Prompt types ===
 export type {

--- a/packages/schema/src/diff/index.ts
+++ b/packages/schema/src/diff/index.ts
@@ -12,7 +12,7 @@ import { diffActions } from "./actions.js";
 import { diffMetadata } from "./metadata.js";
 import type { DiffSurfaceMapsOptions, SurfaceMapDiff } from "./types.js";
 
-// eslint-disable-next-line oxc/no-barrel-file -- re-export entrypoint preserves public import path
+// oxlint-disable-next-line oxc/no-barrel-file -- re-export entrypoint preserves public import path
 export { stableJson } from "./shared.js";
 export type {
   DiffEntry,

--- a/packages/testing/src/cli-helpers.ts
+++ b/packages/testing/src/cli-helpers.ts
@@ -23,7 +23,7 @@ export interface CliTestResult {
 // Output Capture
 // ============================================================================
 
-// eslint-disable-next-line outfitter/use-error-taxonomy -- test harness error, not a handler error
+// oxlint-disable-next-line outfitter/use-error-taxonomy -- test harness error, not a handler error
 class ExitError extends Error {
   readonly code: number;
 
@@ -83,7 +83,7 @@ export async function captureCLI(
   };
 
   process.exit = ((code?: number): never => {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- test harness: simulates process.exit via throw
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- test harness: simulates process.exit via throw
     throw new ExitError(code ?? 0);
   }) as typeof process.exit;
 
@@ -127,7 +127,7 @@ export function mockStdin(input: string): { restore: () => void } {
   const encoded = new TextEncoder().encode(input);
 
   const mockStream = {
-    // eslint-disable-next-line require-await, typescript/require-await -- async generator needs async keyword even without await
+    // oxlint-disable-next-line require-await, typescript/require-await -- async generator needs async keyword even without await
     async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array, void, unknown> {
       yield encoded;
     },

--- a/packages/testing/src/fixtures.ts
+++ b/packages/testing/src/fixtures.ts
@@ -14,7 +14,7 @@ let cachedRequire: NodeRequire | null | undefined;
 function getNodeRequire(): NodeRequire {
   if (cachedRequire !== undefined) {
     if (cachedRequire === null) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: cached negative result
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: cached negative result
       throw new Error("Node.js built-ins are unavailable in this runtime.");
     }
     return cachedRequire;
@@ -34,7 +34,7 @@ function getNodeRequire(): NodeRequire {
   }
 
   cachedRequire = null;
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: Node.js builtins unavailable
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- runtime assertion: Node.js builtins unavailable
   throw new Error("Node.js built-ins are unavailable in this runtime.");
 }
 
@@ -253,7 +253,7 @@ export async function withTempDir<T>(
  * // Original environment is restored
  * ```
  */
-/* eslint-disable outfitter/no-process-env-in-packages -- test harness: env isolation fixture */
+/* oxlint-disable outfitter/no-process-env-in-packages -- test harness: env isolation fixture */
 export async function withEnv<T>(
   vars: Record<string, string>,
   fn: () => Promise<T>
@@ -283,7 +283,7 @@ export async function withEnv<T>(
     }
   }
 }
-/* eslint-enable outfitter/no-process-env-in-packages */
+/* oxlint-enable outfitter/no-process-env-in-packages */
 
 // ============================================================================
 // Fixture Loading

--- a/packages/testing/src/mock-factories.ts
+++ b/packages/testing/src/mock-factories.ts
@@ -109,14 +109,14 @@ export function createTestConfig<T>(
       schema as unknown as { partial?: () => z.ZodType<Partial<T>> }
     ).partial;
     if (typeof maybePartial !== "function") {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
       throw parsed.error;
     }
 
     const partialSchema = maybePartial.call(schema);
     const partialParsed = partialSchema.safeParse(values);
     if (!partialParsed.success) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- test factory: propagate Zod parse error
       throw partialParsed.error;
     }
 
@@ -130,7 +130,7 @@ export function createTestConfig<T>(
     getRequired<TValue>(key: string): TValue {
       const value = getPath<TValue>(data as Record<string, unknown>, key);
       if (value === undefined) {
-        // eslint-disable-next-line outfitter/no-throw-in-handler -- test factory: assertion for missing config
+        // oxlint-disable-next-line outfitter/no-throw-in-handler -- test factory: assertion for missing config
         throw new Error(`Missing required config value: ${key}`);
       }
       return value;
@@ -152,7 +152,7 @@ export function createTestContext(
     requestId,
     logger,
     cwd: overrides.cwd ?? process.cwd(),
-    // eslint-disable-next-line outfitter/no-process-env-in-packages -- test factory: default env for test context
+    // oxlint-disable-next-line outfitter/no-process-env-in-packages -- test factory: default env for test context
     env: overrides.env ?? { ...process.env },
   };
 

--- a/packages/testing/src/test-command.ts
+++ b/packages/testing/src/test-command.ts
@@ -282,7 +282,7 @@ export async function testCommand(
   args: string[],
   options?: TestCommandOptions
 ): Promise<TestCommandResult> {
-  /* eslint-disable outfitter/no-process-env-in-packages -- test harness: env snapshot/restore for test isolation */
+  /* oxlint-disable outfitter/no-process-env-in-packages -- test harness: env snapshot/restore for test isolation */
   return withProcessLock(async () => {
     // Snapshot the full env so command-side mutations do not leak across tests.
     const originalEnv = { ...process.env };
@@ -352,5 +352,5 @@ export async function testCommand(
       injectedTestContext = undefined;
     }
   });
-  /* eslint-enable outfitter/no-process-env-in-packages */
+  /* oxlint-enable outfitter/no-process-env-in-packages */
 }

--- a/packages/tooling/src/cli/check-boundary-invocations.ts
+++ b/packages/tooling/src/cli/check-boundary-invocations.ts
@@ -130,7 +130,7 @@ export async function readScriptEntries(
       if (isRootManifest) {
         const message =
           error instanceof Error ? error.message : "unknown parse error";
-        // eslint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
+        // oxlint-disable-next-line outfitter/no-throw-in-handler -- catch-rethrow: outer caller handles error
         throw new Error(
           `Failed to read root package manifest (${filePath}): ${message}`
         );

--- a/packages/tooling/src/cli/check-changeset.ts
+++ b/packages/tooling/src/cli/check-changeset.ts
@@ -236,7 +236,7 @@ export async function runCheckChangeset(
   options: CheckChangesetOptions = {}
 ): Promise<void> {
   // Skip via flag or env var
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
   if (options.skip || process.env["NO_CHANGESET"] === "1") {
     process.stdout.write(
       `${COLORS.dim}check-changeset skipped (NO_CHANGESET=1)${COLORS.reset}\n`
@@ -246,7 +246,7 @@ export async function runCheckChangeset(
   }
 
   // Skip on post-merge pushes to main
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup
   if (process.env["GITHUB_EVENT_NAME"] === "push") {
     process.stdout.write(
       `${COLORS.dim}check-changeset skipped (push event)${COLORS.reset}\n`

--- a/packages/tooling/src/cli/check-exports.ts
+++ b/packages/tooling/src/cli/check-exports.ts
@@ -55,7 +55,7 @@ export interface CheckExportsOptions {
 
 /** Resolve whether to output JSON based on options and env */
 export function resolveJsonMode(options: CheckExportsOptions = {}): boolean {
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/check-readme-imports.ts
+++ b/packages/tooling/src/cli/check-readme-imports.ts
@@ -183,7 +183,7 @@ export interface CheckReadmeImportsOptions {
 export function resolveJsonMode(
   options: CheckReadmeImportsOptions = {}
 ): boolean {
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/internal/tsdoc-formatting.ts
+++ b/packages/tooling/src/cli/internal/tsdoc-formatting.ts
@@ -26,7 +26,7 @@ const COLORS = {
 
 /** Resolve whether JSON output mode is active. */
 export function resolveJsonMode(options: CheckTsDocOptions = {}): boolean {
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: env-based feature detection
   return options.json ?? process.env["OUTFITTER_JSON"] === "1";
 }
 

--- a/packages/tooling/src/cli/upgrade-bun.ts
+++ b/packages/tooling/src/cli/upgrade-bun.ts
@@ -55,7 +55,7 @@ async function fetchLatestVersion(): Promise<string> {
   // tag_name is like "bun-v1.4.0", extract version
   const match = data.tag_name.match(/bun-v(.+)/);
   if (!match?.[1]) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
     throw new Error(`Could not parse version from tag: ${data.tag_name}`);
   }
   return match[1];
@@ -70,7 +70,7 @@ async function fetchLatestVersion(): Promise<string> {
 async function resolveTypesBunVersion(targetVersion: string): Promise<string> {
   const response = await fetch("https://registry.npmjs.org/@types%2fbun");
   if (!response.ok) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
     throw new Error(`Failed to fetch @types/bun metadata: ${response.status}`);
   }
 
@@ -314,7 +314,7 @@ export async function runUpgradeBun(
 
       log("");
       info("Updating lockfile...");
-      /* eslint-disable outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup */
+      /* oxlint-disable outfitter/no-process-env-in-packages -- boundary: CLI script reads env at startup */
       const bunInstall = Bun.spawnSync(["bun", "install"], {
         cwd,
         env: {
@@ -323,7 +323,7 @@ export async function runUpgradeBun(
           PATH: `${process.env["HOME"]}/.bun/bin:${process.env["PATH"]}`,
         },
       });
-      /* eslint-enable outfitter/no-process-env-in-packages */
+      /* oxlint-enable outfitter/no-process-env-in-packages */
 
       if (bunInstall.exitCode === 0) {
         success("Lockfile updated");

--- a/packages/tooling/src/registry/build.ts
+++ b/packages/tooling/src/registry/build.ts
@@ -46,7 +46,7 @@ function findRepoRoot(startDir: string): string {
     }
     dir = dirname(dir);
   }
-  // eslint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
+  // oxlint-disable-next-line outfitter/no-throw-in-handler -- CLI script: top-level error → exit code
   throw new Error("Could not find repository root");
 }
 
@@ -74,7 +74,7 @@ function readFileEntry(
   const fullPath = join(repoRoot, sourcePath);
 
   if (!existsSync(fullPath)) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Source file not found: ${fullPath}`);
   }
 
@@ -154,7 +154,7 @@ function resolveVersion(
 ): string {
   const version = versions[name];
   if (!version) {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(
       `Missing resolved version for "${name}" in @outfitter/presets`
     );
@@ -172,7 +172,7 @@ function getWorkspacePackageVersion(relativePackageJsonPath: string): string {
   };
 
   if (typeof pkg.version !== "string") {
-    // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
+    // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: invalid input to internal function
     throw new Error(`Expected version in package.json at ${pkgPath}`);
   }
 

--- a/packages/tui/src/borders/index.ts
+++ b/packages/tui/src/borders/index.ts
@@ -25,7 +25,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   BORDERS,
   type BorderCharacters,

--- a/packages/tui/src/box/index.ts
+++ b/packages/tui/src/box/index.ts
@@ -20,5 +20,5 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export { type BoxAlign, type BoxOptions, renderBox } from "../render/box.js";

--- a/packages/tui/src/confirm.ts
+++ b/packages/tui/src/confirm.ts
@@ -54,7 +54,7 @@ export async function confirmDestructive(
 
   // Check if we're in a TTY environment
   const isTTY = process.stdout.isTTY;
-  // eslint-disable-next-line outfitter/no-process-env-in-packages -- boundary: terminal capability detection
+  // oxlint-disable-next-line outfitter/no-process-env-in-packages -- boundary: terminal capability detection
   const isDumbTerminal = process.env["TERM"] === "dumb";
 
   if (!isTTY || isDumbTerminal) {

--- a/packages/tui/src/demo/index.ts
+++ b/packages/tui/src/demo/index.ts
@@ -143,7 +143,7 @@ export function renderAllDemos(config: DemoConfig = {}): string {
  * // ["colors", "borders", "spinner", "list", "box", "table", "progress", "tree", "text", "markdown"]
  * ```
  */
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-export for API surface
 export { getPrimitiveIds } from "./registry.js";
 
 /**

--- a/packages/tui/src/demo/renderers/tree.ts
+++ b/packages/tui/src/demo/renderers/tree.ts
@@ -130,10 +130,10 @@ export function renderTreeDemo(config: DemoConfig, _theme: Theme): string {
     lines.push("renderTree(tree, {");
     lines.push("  renderLabel: (key, value) => {");
     lines.push("    if (value && typeof value === 'object') {");
-    // eslint-disable-next-line no-template-curly-in-string -- code example display
+    // oxlint-disable-next-line no-template-curly-in-string -- code example display
     lines.push("      return `📁 ${key}/`;");
     lines.push("    }");
-    // eslint-disable-next-line no-template-curly-in-string -- code example display
+    // oxlint-disable-next-line no-template-curly-in-string -- code example display
     lines.push("    return `📄 ${key}`;");
     lines.push("  }");
     lines.push("})");

--- a/packages/tui/src/list/index.ts
+++ b/packages/tui/src/list/index.ts
@@ -22,7 +22,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   type ListItem,
   type ListOptions,

--- a/packages/tui/src/preset/full.ts
+++ b/packages/tui/src/preset/full.ts
@@ -23,7 +23,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional preset aggregation
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional preset aggregation
 export {
   BORDERS,
   type BorderStyle,

--- a/packages/tui/src/preset/standard.ts
+++ b/packages/tui/src/preset/standard.ts
@@ -26,7 +26,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional preset aggregation
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional preset aggregation
 export {
   ANSI,
   createTheme,

--- a/packages/tui/src/prompt/index.ts
+++ b/packages/tui/src/prompt/index.ts
@@ -30,7 +30,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export { promptConfirm } from "./confirm.js";
 export { type PromptStep, promptGroup } from "./group.js";
 export { promptMultiSelect, promptSelect } from "./select.js";

--- a/packages/tui/src/render/date.ts
+++ b/packages/tui/src/render/date.ts
@@ -111,7 +111,7 @@ function parseNamedRange(name: NamedRange): DateRange {
     default: {
       // Exhaustive check: all NamedRange cases are handled above
       const _exhaustive: never = name;
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- exhaustive check: unreachable code guard
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- exhaustive check: unreachable code guard
       throw new Error(`Unhandled named range: ${_exhaustive}`);
     }
   }

--- a/packages/tui/src/render/heading.ts
+++ b/packages/tui/src/render/heading.ts
@@ -40,7 +40,7 @@ export interface HeadingOptions {
 }
 
 /** ANSI escape sequence pattern */
-// eslint-disable-next-line no-control-regex -- ANSI escape detection requires matching ESC character
+// oxlint-disable-next-line no-control-regex -- ANSI escape detection requires matching ESC character
 const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
 
 /**

--- a/packages/tui/src/render/index.ts
+++ b/packages/tui/src/render/index.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   ANSI,
   applyColor,

--- a/packages/tui/src/render/indicators.ts
+++ b/packages/tui/src/render/indicators.ts
@@ -164,7 +164,7 @@ export const INDICATORS: Record<
  *
  * @returns true if unicode is likely supported
  */
-/* eslint-disable outfitter/no-process-env-in-packages -- boundary: terminal capability detection from env */
+/* oxlint-disable outfitter/no-process-env-in-packages -- boundary: terminal capability detection from env */
 export function isUnicodeSupported(): boolean {
   // CI environments generally support unicode
   if (process.env["CI"]) {
@@ -208,7 +208,7 @@ export function isUnicodeSupported(): boolean {
 
   return false;
 }
-/* eslint-enable outfitter/no-process-env-in-packages */
+/* oxlint-enable outfitter/no-process-env-in-packages */
 
 /**
  * Gets an indicator character with automatic unicode/fallback selection.

--- a/packages/tui/src/render/layout.ts
+++ b/packages/tui/src/render/layout.ts
@@ -144,7 +144,7 @@ export function resolveWidth(mode: WidthMode, ctx?: LayoutContext): number {
   // Container width (requires context)
   if (mode === "container") {
     if (!ctx) {
-      // eslint-disable-next-line outfitter/no-throw-in-handler -- assertion: caller must provide ctx for container mode
+      // oxlint-disable-next-line outfitter/no-throw-in-handler -- assertion: caller must provide ctx for container mode
       throw new Error("container width mode requires LayoutContext");
     }
     return ctx.width;

--- a/packages/tui/src/streaming/index.ts
+++ b/packages/tui/src/streaming/index.ts
@@ -25,7 +25,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export { ANSI } from "./ansi.js";
 export {
   createSpinner,

--- a/packages/tui/src/table/index.ts
+++ b/packages/tui/src/table/index.ts
@@ -17,5 +17,5 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export { renderTable, type TableOptions } from "../render/table.js";

--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -34,7 +34,7 @@
  */
 
 // Context
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   createThemedContext,
   getContextTheme,

--- a/packages/tui/src/theme/presets/index.ts
+++ b/packages/tui/src/theme/presets/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export { boldTheme } from "./bold.js";
 export { defaultTheme } from "./default.js";
 export { minimalTheme } from "./minimal.js";

--- a/packages/tui/src/tree/index.ts
+++ b/packages/tui/src/tree/index.ts
@@ -21,7 +21,7 @@
  * @packageDocumentation
  */
 
-// eslint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
+// oxlint-disable-next-line oxc/no-barrel-file -- intentional re-exports for subpath API
 export {
   renderTree,
   TREE_GUIDES,


### PR DESCRIPTION
## Summary

Mechanical find-and-replace across 75 files:

- `eslint-disable` → `oxlint-disable`
- `eslint-enable` → `oxlint-enable`

The project uses oxlint, not ESLint. The old `eslint-disable` syntax was silently ignored — these directives now actually suppress their target rules.

## Scope

- **75 files** changed, **153 insertions, 153 deletions** (1:1 replacement)
- No logic changes, no line additions/removals
- Only `.ts` files under `packages/` and `apps/`

## Test plan

- [x] `bun run build` passes (all 20 tasks)
- [x] `bun run test` passes (454 tests, 0 failures)
- [x] `bun run lint` passes (0 errors)
- [x] `grep -r "eslint-disable" packages/ apps/ --include="*.ts"` returns 0 results

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)