### PR TITLE
fix(ci): upgrade actions/checkout to v5 for Node.js 24 compatibility [TRL-181]

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Checkout
         if: steps.filter.outputs.changesets == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect release type from changesets
         if: steps.filter.outputs.changesets == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -145,7 +145,7 @@ jobs:
       OUTFITTER_CI_TURBO_OUTPUT_LOGS: "new-only"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -187,7 +187,7 @@ jobs:
       OUTFITTER_CI_TURBO_OUTPUT_LOGS: "new-only"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -229,7 +229,7 @@ jobs:
       OUTFITTER_CI_TURBO_OUTPUT_LOGS: "new-only"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -272,7 +272,7 @@ jobs:
       OUTFITTER_CI_TURBO_OUTPUT_LOGS: "new-only"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # PAT required so the release PR can trigger CI workflows
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for changesets
         id: check
@@ -252,7 +252,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Motivation
- GitHub Actions is transitioning JavaScript actions to Node.js 24 and the repo used `actions/checkout@v4`, so workflows must be updated to avoid deprecation/breaks when runners switch to Node.js 24. 
- A quick scan showed no `actions/cache@...` usages in `.github/workflows`, so only the `checkout` action needed bumping.

### Description
- Updated all `uses: actions/checkout@v4` occurrences to `uses: actions/checkout@v5` across the following workflows: `.github/workflows/auto-label.yml`, `.github/workflows/ci.yml`, `.github/workflows/droid.yml`, `.github/workflows/label-sync.yml`, and `.github/workflows/release.yml`.
- Commit created on branch `trl-181-upgrade-github-actions-node24-actions` with message `fix(ci): upgrade checkout action to v5 for node24 [TRL-181]`.

### Testing
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest` to validate workflow syntax, which completed with no actionlint errors. 
- Ran `bun run lint` (monorepo lint) which completed successfully with lint tasks passing. 
- Ran `bun run test --filter=outfitter` which executed the outfitter test shard and reported `909 pass, 0 fail`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9019549083209eb39b83b5e8d920)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/outfitter-dev/outfitter/pull/814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
